### PR TITLE
fix: 跳び四+跳び三の同方向重複による偽陽性両ミセを修正

### DIFF
--- a/src/logic/cpu/evaluation/jumpPatterns.ts
+++ b/src/logic/cpu/evaluation/jumpPatterns.ts
@@ -201,9 +201,11 @@ export function analyzeJumpPatterns(
       // 跳び四は両端開の形がないので、常に止め四扱い
     }
 
-    // 跳び三をチェック（連続三がない場合のみ）
+    // 跳び三をチェック（連続三がなく、跳び四もない場合のみ）
+    // 跳び四と同方向の跳び三は同一スジの四と三であり、四三を構成しない
     if (
       pattern.count !== 3 &&
+      !jumpFourDirections.has(i) &&
       checkJumpThree(board, row, col, dirIndex, color)
     ) {
       result.hasJumpThree = true;

--- a/src/logic/cpu/evaluation/tactics.test.ts
+++ b/src/logic/cpu/evaluation/tactics.test.ts
@@ -1468,3 +1468,31 @@ describe("白の制約ライン偽活三 - 棋譜回帰テスト", () => {
     expect(isDoubleMise(board, 9, 5, "white")).toBe(false);
   });
 });
+
+describe("Issue #13: 跳び四+跳び三の同方向重複", () => {
+  // 棋譜: 44手目（白番）でJ13が不正に両ミセと検出される
+  // J13に白を置いた後、ターゲットJ11の縦方向で
+  // 跳び四(J7-J8-gap-J10-J11)と跳び三(J10-J11-gap-J12-J13)が同時検出され偽陽性
+  const RECORD =
+    "H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 F8 K9 I11 I13 H6 E9 F11 F12 I5 J4 G5 H5 I7 J8 J6 J7 K7 L8 F4 E3 G3 H4 I6 K6 L5 K5 L6 I4 K4 G6 J3 E8";
+
+  it("J11は四三ではない（縦方向の跳び四と跳び三が同一スジ）", () => {
+    const { board } = createBoardFromRecord(RECORD, 43);
+    board[2]![9] = "white"; // J13
+    expect(createsFourThree(board, 4, 9, "white")).toBe(false);
+    board[2]![9] = null;
+  });
+
+  it("J13は白の両ミセではない", () => {
+    const { board } = createBoardFromRecord(RECORD, 43);
+    board[2]![9] = "white";
+    expect(isDoubleMise(board, 2, 9, "white")).toBe(false);
+    board[2]![9] = null;
+  });
+
+  it("findDoubleMiseMovesがJ13を返さない", () => {
+    const { board } = createBoardFromRecord(RECORD, 43);
+    const moves = findDoubleMiseMoves(board, "white");
+    expect(moves.some((m) => m.row === 2 && m.col === 9)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `analyzeJumpPatterns()` で同一方向の跳び四と跳び三が同時にカウントされ、偽の四三→偽の両ミセが検出されるバグを修正
- 既存の連続三ガード (`!jumpFourDirections.has(i)`) と対称のガードを跳び三チェックにも追加

Closes #13

## 再現局面

棋譜: `H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 F8 K9 I11 I13 H6 E9 F11 F12 I5 J4 G5 H5 I7 J8 J6 J7 K7 L8 F4 E3 G3 H4 I6 K6 L5 K5 L6 I4 K4 G6 J3 E8`

44手目（白番）でJ13が両ミセと誤検出。ターゲットJ11の縦方向で跳び四(J7-J8-gap-J10-J11)と跳び三(J10-J11-gap-J12-J13)が同一スジに重複していた。

## Test plan

- [x] 新規テスト3件 PASS（`createsFourThree`, `isDoubleMise`, `findDoubleMiseMoves`）
- [x] 既存テスト1641件 全PASS
- [x] `pnpm check-fix` PASS
- [ ] ブラウザで棋譜を再現し、44手目に不正な両ミセが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)