### PR TITLE
fix(renju): 同方向の異なる4石セットの飛び四を四四禁手として正しく検出 (#19)

### DIFF
--- a/src/logic/renjuRules.test.ts
+++ b/src/logic/renjuRules.test.ts
@@ -756,6 +756,48 @@ describe("飛び四の検出", () => {
     expect(result.isForbidden).toBe(true);
     expect(result.type).toBe("double-four");
   });
+
+  // 連続四(XXXX)と同方向の飛び四(XXX_X)の片方のみが「真の四」(他方は overline)
+  it("XXXX_X 配置（連続四＋飛び四同方向）は真の四1つ＋ウソの四1つ → 四四ではない", () => {
+    const board = createEmptyBoard();
+    // row=7, cols 4,5,6 に黒、col 7 に置く、col 9 に黒（col 8 は空き）
+    // 配置後: 0(空き) 4(B) 5(B) 6(B) 7(B*placed) 8(空き) 9(B)
+    //   - 連続四 {4,5,6,7}: gap=3 で完成 → 5石(3..7) 真の四
+    //                       gap=8 で完成 → 5石(4..8) だが col 9 が同色 → 長連
+    //                       少なくとも1つ真の完成があるので真の四
+    //   - 飛び四 {5,6,7,9}: gap=8 で完成 → 5石(5..9) だが col 4 が同色 → 長連
+    //                       他に completion なし → ウソの四
+    // 結果: 真の四は1つだけ → 四四ではない
+    board[7][4] = "black";
+    board[7][5] = "black";
+    board[7][6] = "black";
+    board[7][9] = "black";
+
+    const result = checkForbiddenMove(board, 7, 7);
+    expect(result.isForbidden).toBe(false);
+  });
+
+  // Issue #19 リグレッション: 同一方向に2つの異なる飛び四ができる
+  it("同方向の2つの飛び四（D_FGH と FGH_J）で四四禁になる", () => {
+    const board = createEmptyBoard();
+    // 横方向 row=5 に D, F, H, J を黒、E, I は空き、G に置く
+    // 配置後: ●・●*●・● → 4石セット {D,F,G,H} と {F,G,H,J} の2つの飛び四
+    // (※座標は内部表現: G11=(row=4,col=6), F10=(row=5,col=5), G10=(row=5,col=6) ...
+    //   ここでは簡略化のため row=5 で再現)
+    board[5][3] = "black"; // D
+    board[5][5] = "black"; // F
+    // col=6 (G) が置く位置
+    board[5][7] = "black"; // H
+    board[5][9] = "black"; // J
+
+    // (5,6) に置くと、行 row=5 だけで:
+    //   - 飛び四 D・FGH (gap=E10 相当)
+    //   - 飛び四 FGH・J (gap=I10 相当)
+    // 2つの異なる4石セットが同時にできる → 四四禁
+    const result = checkForbiddenMove(board, 5, 6);
+    expect(result.isForbidden).toBe(true);
+    expect(result.type).toBe("double-four");
+  });
 });
 
 describe("recognizePattern（パターン認識）", () => {

--- a/src/logic/renjuRules/forbiddenMoves.ts
+++ b/src/logic/renjuRules/forbiddenMoves.ts
@@ -18,6 +18,17 @@ import {
 } from "./patterns";
 
 /**
+ * 四四判定用の4方向ベクトル（縦, 横, 斜め↘, 斜め↙）
+ * DIRECTION_PAIRS の各ペアの先頭方向に対応
+ */
+const FOUR_DIRECTION_VECTORS: readonly (readonly [number, number])[] = [
+  [1, 0], // 縦
+  [0, 1], // 横
+  [1, 1], // 斜め↘
+  [1, -1], // 斜め↙
+];
+
+/**
  * 禁手判定の再帰的コンテキスト
  * - inProgress: 現在判定中の点のSet（循環参照検出用）
  * - cache: 計算済みの禁手判定結果のキャッシュ（ローカル）
@@ -51,12 +62,6 @@ interface ThreeInfo {
   directionIndex: number;
   type: "consecutive" | "jump";
   straightFourPoints: Position[];
-}
-
-/** 四の情報 */
-interface FourInfo {
-  directionIndex: number;
-  type: "consecutive" | "jump";
 }
 
 /**
@@ -328,33 +333,130 @@ function checkForbiddenMoveInternal(
 }
 
 /**
- * 四四をチェック（2つ以上の四ができるか）
- * 連続四と飛び四の両方をカウント
- * @returns 四四の禁じ手に該当する場合true
+ * 指定方向の「異なる4石セットの真の四」を数える
+ *
+ * 配置点 (row, col) を含む 5-cell ウィンドウを 5個（start offset = -4..0）列挙し、
+ * 各ウィンドウが「自色4石 + 空き1マス、相手石・盤外なし」を満たすかチェック。
+ * 該当ウィンドウについて:
+ * - 4石の位置を bitmask 化して、同じ4石セットの重複を排除
+ * - 完成形が 5石ちょうど（長連=overline にならない）かチェック
+ *   完成後の連を [windowStart, windowStart+4] とし、windowStart-1 / windowStart+5 が
+ *   自色でないことを要請
+ *
+ * 既存の `checkOpenPattern.four` / `checkJumpFour` は方向ごとに boolean しか返さず、
+ * 同方向に4石セットが異なる複数の四（飛び四×2 や 連続四＋飛び四）を区別できないため
+ * ここでは独自に 5-cell ウィンドウ列挙する（Issue #19）。
+ *
+ * 仕様 SSoT: zig/src/forbidden.zig の countDistinctFoursInDirection と同期させること。
+ *
+ * @returns 真の四として成立する異なる4石セットの数
  */
-function checkDoubleFour(board: BoardState, row: number, col: number): boolean {
-  const fours: FourInfo[] = [];
+/* eslint-disable no-bitwise -- 4石セットの bitmask 表現に必要 */
+function countDistinctFoursInDirection(
+  board: BoardState,
+  row: number,
+  col: number,
+  dr: number,
+  dc: number,
+): number {
+  // 配置点を含む 5-cell window は最大5個 (start offset = -4..0)。
+  // 線形探索で dedupe（最大5 entries なので Map のアロケーション不要）。
+  // 同じ stone set 由来の複数 window がある場合、いずれかが real なら真の四扱い。
+  const masks: number[] = [];
+  const isReals: boolean[] = [];
 
-  for (let i = 0; i < 4; i++) {
-    const pair = DIRECTION_PAIRS[i];
-    const dir1Index = pair?.[0];
-    if (dir1Index === undefined) {
+  for (let start = -4; start <= 0; start++) {
+    let stoneMask = 0;
+    let stoneCount = 0;
+    let emptyCount = 0;
+    let windowInBounds = true;
+
+    for (let i = 0; i < 5; i++) {
+      const offset = start + i;
+      const r = row + offset * dr;
+      const c = col + offset * dc;
+      if (r < 0 || r >= 15 || c < 0 || c >= 15) {
+        windowInBounds = false;
+        break;
+      }
+      const cell = offset === 0 ? "black" : (board[r]?.[c] ?? null);
+      if (cell === "black") {
+        // bit (offset+4) で stone 位置を表現（offset ∈ [-4, +4] → bit 0..8 = 9bit）
+        stoneMask |= 1 << (offset + 4);
+        stoneCount++;
+      } else if (cell === null) {
+        emptyCount++;
+      } else {
+        // 相手石は四四を構成しないので即除外
+        windowInBounds = false;
+        break;
+      }
+    }
+
+    if (!windowInBounds || stoneCount !== 4 || emptyCount !== 1) {
       continue;
     }
 
-    // 連続四をチェック
-    const pattern = checkOpenPattern(board, row, col, dir1Index, "black");
-    if (pattern.four) {
-      fours.push({ directionIndex: dir1Index, type: "consecutive" });
-    }
+    // 完成形の長連チェック: 完成後の5石は [start, start+4]、
+    // 隣接マス (start-1, start+5) が黒なら長連 (ウソの四)
+    const beforeR = row + (start - 1) * dr;
+    const beforeC = col + (start - 1) * dc;
+    const afterR = row + (start + 5) * dr;
+    const afterC = col + (start + 5) * dc;
+    const beforeIsBlack =
+      beforeR >= 0 &&
+      beforeR < 15 &&
+      beforeC >= 0 &&
+      beforeC < 15 &&
+      (board[beforeR]?.[beforeC] ?? null) === "black";
+    const afterIsBlack =
+      afterR >= 0 &&
+      afterR < 15 &&
+      afterC >= 0 &&
+      afterC < 15 &&
+      (board[afterR]?.[afterC] ?? null) === "black";
+    const isReal = !beforeIsBlack && !afterIsBlack;
 
-    // 飛び四をチェック（連続四がない場合のみ）
-    if (!pattern.four && checkJumpFour(board, row, col, dir1Index, "black")) {
-      fours.push({ directionIndex: dir1Index, type: "jump" });
+    let foundIdx = -1;
+    for (let k = 0; k < masks.length; k++) {
+      if (masks[k] === stoneMask) {
+        foundIdx = k;
+        break;
+      }
+    }
+    if (foundIdx === -1) {
+      masks.push(stoneMask);
+      isReals.push(isReal);
+    } else if (isReal && !isReals[foundIdx]) {
+      isReals[foundIdx] = true;
     }
   }
 
-  return fours.length >= 2;
+  let realCount = 0;
+  for (const r of isReals) {
+    if (r) {
+      realCount++;
+    }
+  }
+  return realCount;
+}
+/* eslint-enable no-bitwise */
+
+/**
+ * 四四をチェック（2つ以上の真の四ができるか）
+ * 同方向に4石セットが異なる複数の四が成立する場合もそれぞれ別個にカウントする。
+ * 連続四・飛び四を区別せず、5-cell ウィンドウ列挙で統一的に判定する。
+ * @returns 四四の禁じ手に該当する場合true
+ */
+function checkDoubleFour(board: BoardState, row: number, col: number): boolean {
+  let total = 0;
+  for (const [dr, dc] of FOUR_DIRECTION_VECTORS) {
+    total += countDistinctFoursInDirection(board, row, col, dr, dc);
+    if (total >= 2) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/zig/src/forbidden.zig
+++ b/zig/src/forbidden.zig
@@ -9,6 +9,14 @@ const BOARD_SIZE = board_mod.BOARD_SIZE;
 /// [縦(0), 横(2), 斜め右(1), 斜め左(3)] — dirIndex の値
 const DIRECTION_PAIR_INDICES = [4]u8{ 0, 2, 1, 3 };
 
+/// 四四判定用の4方向ベクトル（縦, 横, ↘, ↙）
+const FOUR_DIRECTION_VECTORS = [4]struct { dr: i8, dc: i8 }{
+    .{ .dr = 1, .dc = 0 }, // 縦
+    .{ .dr = 0, .dc = 1 }, // 横
+    .{ .dr = 1, .dc = 1 }, // 斜め↘
+    .{ .dr = 1, .dc = -1 }, // 斜め↙
+};
+
 /// 禁手の種類
 pub const ForbiddenType = enum(u8) {
     none = 0,
@@ -42,20 +50,113 @@ pub fn checkOverline(cells: []const Cell, row: u8, col: u8) bool {
     return false;
 }
 
-/// 四四をチェック（2つ以上の四ができるか）
-fn checkDoubleFour(cells: []const Cell, row: u8, col: u8) bool {
-    var four_count: u8 = 0;
+/// 指定方向の「異なる4石セットの真の四」を数える
+///
+/// 配置点 (row, col) を含む 5-cell ウィンドウを 5個 (start offset = -4..0) 列挙し、
+/// 各ウィンドウが「自色4石 + 空き1マス、相手石・盤外なし」を満たすかチェックする。
+/// 該当ウィンドウについて:
+/// - 4石位置の bitmask で重複排除（同じ4石セットは1つの四として扱う）
+/// - 完成形が長連 (overline) にならないか検証（隣接マス start-1 / start+5 が黒でない）
+///
+/// 既存の `checkOpenPattern.four` / `checkJumpFour` は方向ごとに bool しか返さず、
+/// 同方向に4石セットが異なる複数の四（飛び四×2 や 連続四＋飛び四）を区別できないため
+/// ここでは独自に 5-cell ウィンドウ列挙する（Issue #19）。
+///
+/// 仕様 SSoT: src/logic/renjuRules/forbiddenMoves.ts の countDistinctFoursInDirection と同期させること。
+///
+/// stack 上の固定配列で dedupe するため alloc-free。
+fn countDistinctFoursInDirection(
+    cells: []const Cell,
+    row: u8,
+    col: u8,
+    dr: i8,
+    dc: i8,
+) u8 {
+    // 同一 stone set の bitmask が複数 window から出現する可能性があるため、
+    // dedupe しつつ「いずれかの window が真の四（長連にならない）」かを記録する。
+    var masks: [5]u16 = undefined;
+    var is_real: [5]bool = undefined;
+    var mask_count: u8 = 0;
 
-    for (DIRECTION_PAIR_INDICES) |dir_index| {
-        const pattern = jp.checkOpenPattern(cells, row, col, dir_index, .black);
-        if (pattern.four) {
-            four_count += 1;
-        } else if (jp.checkJumpFour(cells, row, col, dir_index, .black)) {
-            four_count += 1;
+    var start: i32 = -4;
+    while (start <= 0) : (start += 1) {
+        var stone_mask: u16 = 0;
+        var stone_count: u8 = 0;
+        var empty_count: u8 = 0;
+        var window_valid = true;
+
+        var i: u8 = 0;
+        while (i < 5) : (i += 1) {
+            const offset: i32 = start + @as(i32, i);
+            const r: i32 = @as(i32, row) + offset * @as(i32, dr);
+            const c: i32 = @as(i32, col) + offset * @as(i32, dc);
+            if (r < 0 or r >= BOARD_SIZE or c < 0 or c >= BOARD_SIZE) {
+                window_valid = false;
+                break;
+            }
+            const idx: usize = @intCast(r * BOARD_SIZE + c);
+            const cell: Cell = if (offset == 0) .black else cells[idx];
+            if (cell == .black) {
+                stone_mask |= (@as(u16, 1) << @intCast(offset + 4));
+                stone_count += 1;
+            } else if (cell == .empty) {
+                empty_count += 1;
+            } else {
+                window_valid = false;
+                break;
+            }
         }
-        if (four_count >= 2) return true;
+
+        if (!window_valid or stone_count != 4 or empty_count != 1) continue;
+
+        // 完成形の長連チェック: 完成後の 5石は [start, start+4]、
+        // 隣接マス (start-1, start+5) が黒なら長連 (ウソの四)
+        const before_r: i32 = @as(i32, row) + (start - 1) * @as(i32, dr);
+        const before_c: i32 = @as(i32, col) + (start - 1) * @as(i32, dc);
+        const after_r: i32 = @as(i32, row) + (start + 5) * @as(i32, dr);
+        const after_c: i32 = @as(i32, col) + (start + 5) * @as(i32, dc);
+        const before_is_black = before_r >= 0 and before_r < BOARD_SIZE and
+            before_c >= 0 and before_c < BOARD_SIZE and
+            cells[@as(usize, @intCast(before_r * BOARD_SIZE + before_c))] == .black;
+        const after_is_black = after_r >= 0 and after_r < BOARD_SIZE and
+            after_c >= 0 and after_c < BOARD_SIZE and
+            cells[@as(usize, @intCast(after_r * BOARD_SIZE + after_c))] == .black;
+        const window_is_real = !before_is_black and !after_is_black;
+
+        // dedupe: 同じ stone_mask が既にあれば、real 判定を OR 更新
+        var found = false;
+        var k: u8 = 0;
+        while (k < mask_count) : (k += 1) {
+            if (masks[k] == stone_mask) {
+                if (window_is_real) is_real[k] = true;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            masks[mask_count] = stone_mask;
+            is_real[mask_count] = window_is_real;
+            mask_count += 1;
+        }
     }
 
+    var real_count: u8 = 0;
+    var k: u8 = 0;
+    while (k < mask_count) : (k += 1) {
+        if (is_real[k]) real_count += 1;
+    }
+    return real_count;
+}
+
+/// 四四をチェック（2つ以上の真の四ができるか）
+/// 同方向に 4石セットが異なる複数の四が成立する場合もそれぞれカウントする。
+/// 連続四・飛び四を区別せず、5-cell ウィンドウ列挙で統一的に判定する。
+fn checkDoubleFour(cells: []const Cell, row: u8, col: u8) bool {
+    var total: u8 = 0;
+    for (FOUR_DIRECTION_VECTORS) |dir| {
+        total += countDistinctFoursInDirection(cells, row, col, dir.dr, dir.dc);
+        if (total >= 2) return true;
+    }
     return false;
 }
 
@@ -271,6 +372,41 @@ test "checkForbiddenMove: 四四禁" {
     cells[6 * BOARD_SIZE + 7] = .black;
     cells[8 * BOARD_SIZE + 7] = .black;
     try std.testing.expectEqual(checkForbiddenMove(&cells, 7, 7), .double_four);
+}
+
+// Issue #19 リグレッション: 同方向に 2つの異なる飛び四 (D_FGH と FGH_J) が成立
+test "checkForbiddenMove: 同方向の2つの飛び四で四四禁" {
+    const CELL_COUNT = board_mod.CELL_COUNT;
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    // row=5 に col 3(D), 5(F), 7(H), 9(J) を黒、col 6(G) に置く
+    // 配置後 row 5: ・・・●・●・●・●・・・・・
+    // 飛び四 1: {3,5,6,7} (gap=4) → 5石(3..7)
+    // 飛び四 2: {5,6,7,9} (gap=8) → 5石(5..9)
+    // 異なる4石セットの真の四が同方向に2つ → 四四禁
+    cells[5 * BOARD_SIZE + 3] = .black; // D
+    cells[5 * BOARD_SIZE + 5] = .black; // F
+    cells[5 * BOARD_SIZE + 7] = .black; // H
+    cells[5 * BOARD_SIZE + 9] = .black; // J
+    try std.testing.expectEqual(checkForbiddenMove(&cells, 5, 6), .double_four);
+}
+
+// 完成形が長連になる「ウソの四」は四四にカウントしない
+test "checkForbiddenMove: XXXX_X 配置はウソの四を含むため四四ではない" {
+    const CELL_COUNT = board_mod.CELL_COUNT;
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    // row=7 に cols 4,5,6 黒、col 7 placed、col 9 黒（col 8 空き）
+    // 連続四 {4,5,6,7}: gap=3→真の5、gap=8→col 9 が黒で長連 → 真
+    // 飛び四 {5,6,7,9}: gap=8 のみ、col 4 が黒で長連 → ウソ
+    // 真の四は1つだけ → 四四ではない
+    cells[7 * BOARD_SIZE + 4] = .black;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 9] = .black;
+    const result = checkForbiddenMove(&cells, 7, 7);
+    // 長連にはならない (cols 4..7 = 4石 + col 9 で 5石、空 col 8 が間にあるので連続5ではない)
+    // 四四でもない (真の四1つだけ)
+    try std.testing.expect(result != .double_four);
+    try std.testing.expect(result != .overline);
 }
 
 test "checkForbiddenMove: 五連は禁手ではない" {


### PR DESCRIPTION
## Summary
- Issue #19: 追い詰め PV で黒の四四（禁手）が登場する問題の修正
- TS と Zig の `checkDoubleFour` が方向ごとに最大1つの四しかカウントしなかったため、同方向に4石セットが異なる複数の飛び四（共有3石・両端異なる）を見落としていた
- 5-cell ウィンドウを 5個列挙し、4石位置を bitmask 化して dedupe する方式に置換。完成形が長連 (overline) になる「ウソの四」も除外

## 再現
棋譜: \`H8 G8 F10 G9 G7 F9 H7 D9 E9 F7 F8 H6\` (12手)
13手目の最善 PV: \`13.G11 14.D8 15.I9 16.F6 17.H10 18.J8 19.D10 20.C11 21.J10 22.K11 23.G10\`

23手目 G10 配置時、横方向 row 10 に黒石 D, F, G(置く), H, J が並び:
- D _ F G H = 飛び四 (gap=E10, 完成→DEFGH=5)
- F G H _ J = 飛び四 (gap=I10, 完成→FGHIJ=5)

異なる4石セットの真の四が同方向に2つ → 四四禁手のはずだが、修正前は検出漏れていた。

## 修正後
PV: \`13.G11 14.D8 15.I9 16.F6 17.H10 18.F12 19.J10 20.K11 21.I10 22.G10(白) 23.K7 ...\`
G10 は白の22手目に変わり、黒の四四は登場しなくなった。

## 影響範囲
- TS: \`src/logic/renjuRules/forbiddenMoves.ts\`
- Zig: \`zig/src/forbidden.zig\`
- 探索エンジン (CPU 対局・振り返り解析) と UI 側の禁手判定が両方対応

## Test plan
- [x] TS unit tests 1643件全パス
- [x] Zig tests 全パス
- [x] Issue #19 リグレッションテスト追加（同方向 飛び四×2 → 四四検出）
- [x] XXXX_X 配置（連続四＋飛び四同方向で片方ウソの四）→ 四四ではないことを検証
- [x] ブラウザで PV から黒の四四が消えたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #19