### PR TITLE
refactor(review): useReviewProgression の純粋ロジックを progressionModel.ts に分離 (#23)

### DIFF
--- a/src/components/cpu/BranchOptions.vue
+++ b/src/components/cpu/BranchOptions.vue
@@ -19,7 +19,7 @@
 
 import { toRef } from "vue";
 
-import type { PVDisplayItem } from "./composables/useReviewProgression";
+import type { PVDisplayItem } from "./composables/progressionModel";
 import { useRovingTabindex } from "./composables/useRovingTabindex";
 
 interface Option {

--- a/src/components/cpu/composables/progressionModel.test.ts
+++ b/src/components/cpu/composables/progressionModel.test.ts
@@ -1,0 +1,337 @@
+/**
+ * progressionModel（振り返り進行ツリーの純粋ロジック）のテスト
+ *
+ * リアクティブ環境を構築せずに PV 構築・分岐正規化・行展開・可視手列を検証する。
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Position } from "@/types/game";
+import type {
+  EvaluatedMove,
+  ForcedWinBranch,
+  ReviewCandidate,
+} from "@/types/review";
+
+import {
+  type ProgressionTab,
+  buildForcedLossPV,
+  buildInlineBranches,
+  buildPV,
+  buildRows,
+  buildTopTabs,
+  buildVisibleItems,
+  findBestCandidate,
+  findPlayedCandidate,
+  forcedLossLabelOf,
+} from "./progressionModel";
+
+const pos = (row: number, col: number): Position => ({ row, col });
+
+function candidate(overrides: Partial<ReviewCandidate>): ReviewCandidate {
+  return {
+    position: pos(7, 7),
+    score: 0,
+    searchScore: 0,
+    ...overrides,
+  };
+}
+
+function evaluatedMove(overrides: Partial<EvaluatedMove>): EvaluatedMove {
+  return {
+    moveIndex: 1,
+    position: pos(7, 7),
+    isPlayerMove: true,
+    quality: "good",
+    playedScore: 0,
+    bestScore: 0,
+    scoreDiff: 0,
+    bestMove: pos(7, 7),
+    candidates: [],
+    ...overrides,
+  };
+}
+
+describe("buildPV", () => {
+  it("principalVariation を手番交互の PVDisplayItem[] に変換する", () => {
+    const c = candidate({
+      principalVariation: [pos(0, 0), pos(1, 1), pos(2, 2)],
+    });
+    const pv = buildPV(c, 5, true);
+    expect(pv.map((i) => i.isSelf)).toEqual([true, false, true]);
+    expect(pv.map((i) => i.moveNum)).toEqual([5, 6, 7]);
+  });
+
+  it("selfFirst=false で先頭が相手手になる", () => {
+    const c = candidate({ principalVariation: [pos(0, 0), pos(1, 1)] });
+    expect(buildPV(c, 0, false).map((i) => i.isSelf)).toEqual([false, true]);
+  });
+
+  it("principalVariation 未設定・空なら空配列", () => {
+    expect(buildPV(candidate({}), 0, true)).toEqual([]);
+    expect(buildPV(candidate({ principalVariation: [] }), 0, true)).toEqual([]);
+  });
+
+  it("null の穴で打ち切る", () => {
+    const c = candidate({
+      principalVariation: [pos(0, 0), null as unknown as Position, pos(2, 2)],
+    });
+    expect(buildPV(c, 0, true)).toHaveLength(1);
+  });
+});
+
+describe("findBestCandidate / findPlayedCandidate", () => {
+  it("bestMove に一致する候補を返す", () => {
+    const eval_ = evaluatedMove({
+      bestMove: pos(3, 3),
+      candidates: [
+        candidate({ position: pos(1, 1) }),
+        candidate({ position: pos(3, 3) }),
+      ],
+    });
+    expect(findBestCandidate(eval_)?.position).toEqual(pos(3, 3));
+  });
+
+  it("一致が無ければ先頭候補にフォールバック", () => {
+    const eval_ = evaluatedMove({
+      bestMove: pos(9, 9),
+      candidates: [candidate({ position: pos(1, 1) })],
+    });
+    expect(findBestCandidate(eval_)?.position).toEqual(pos(1, 1));
+  });
+
+  it("候補が空なら null", () => {
+    expect(findBestCandidate(evaluatedMove({ candidates: [] }))).toBeNull();
+  });
+
+  it("findPlayedCandidate は position 一致を返す", () => {
+    const eval_ = evaluatedMove({
+      position: pos(2, 2),
+      candidates: [
+        candidate({ position: pos(1, 1) }),
+        candidate({ position: pos(2, 2) }),
+      ],
+    });
+    expect(findPlayedCandidate(eval_)?.position).toEqual(pos(2, 2));
+    const miss = evaluatedMove({
+      position: pos(8, 8),
+      candidates: [candidate({ position: pos(1, 1) })],
+    });
+    expect(findPlayedCandidate(miss)).toBeNull();
+  });
+});
+
+describe("buildForcedLossPV", () => {
+  it("先頭にプレイヤー着手を差し込み、以降は相手始まりの交互", () => {
+    const eval_ = evaluatedMove({
+      moveIndex: 10,
+      position: pos(5, 5),
+      forcedLossSequence: [pos(0, 0), pos(1, 1), pos(2, 2)],
+    });
+    const pv = buildForcedLossPV(eval_, 10);
+    // [played(self), seq0(opp), seq1(self), seq2(opp)]
+    expect(pv.map((i) => i.isSelf)).toEqual([true, false, true, false]);
+    expect(pv.map((i) => i.moveNum)).toEqual([10, 11, 12, 13]);
+    expect(pv[0]?.position).toEqual(pos(5, 5));
+  });
+
+  it("forcedLossSequence が無ければ空配列", () => {
+    expect(buildForcedLossPV(evaluatedMove({}), 0)).toEqual([]);
+  });
+});
+
+describe("forcedLossLabelOf", () => {
+  it("forcedLossType から 被ラベルを生成", () => {
+    expect(forcedLossLabelOf(evaluatedMove({ forcedLossType: "vct" }))).toBe(
+      "被追詰",
+    );
+    expect(
+      forcedLossLabelOf(evaluatedMove({ forcedLossType: "double-four" })),
+    ).toBe("被四四");
+  });
+
+  it("forcedLossType が無ければ null", () => {
+    expect(forcedLossLabelOf(evaluatedMove({}))).toBeNull();
+  });
+});
+
+describe("buildInlineBranches", () => {
+  const branch: ForcedWinBranch = {
+    defenseIndex: 2,
+    defenseMove: pos(4, 4),
+    continuation: [pos(0, 0), pos(1, 1)],
+  };
+
+  it("win: pvIdx=defenseIndex、防御手=相手、continuation 先頭=自分", () => {
+    const [b] = buildInlineBranches([branch], 10, "win");
+    expect(b?.id).toBe("win-0");
+    expect(b?.pvIdx).toBe(2);
+    expect(b?.defenseMove.isSelf).toBe(false);
+    expect(b?.defenseMove.moveNum).toBe(12); // moveIndex(10)+defenseIndex(2)
+    expect(b?.continuation.map((i) => i.isSelf)).toEqual([true, false]);
+    expect(b?.continuation.map((i) => i.moveNum)).toEqual([13, 14]);
+  });
+
+  it("loss: pvIdx=defenseIndex+1、防御手=自分、continuation 先頭=相手", () => {
+    const [b] = buildInlineBranches([branch], 10, "loss");
+    expect(b?.id).toBe("loss-0");
+    expect(b?.pvIdx).toBe(3); // defenseIndex(2)+1
+    expect(b?.defenseMove.isSelf).toBe(true);
+    expect(b?.defenseMove.moveNum).toBe(13); // moveIndex(10)+defenseIndex(2)+1
+    expect(b?.continuation.map((i) => i.isSelf)).toEqual([false, true]);
+    expect(b?.continuation.map((i) => i.moveNum)).toEqual([14, 15]);
+  });
+
+  it("continuation の null 穴で打ち切る", () => {
+    const holed: ForcedWinBranch = {
+      defenseIndex: 0,
+      defenseMove: pos(4, 4),
+      continuation: [pos(0, 0), null as unknown as Position, pos(2, 2)],
+    };
+    expect(
+      buildInlineBranches([holed], 0, "win")[0]?.continuation,
+    ).toHaveLength(1);
+  });
+});
+
+describe("buildTopTabs", () => {
+  it("null なら空配列（ガードの集約点）", () => {
+    expect(buildTopTabs(null, 0)).toEqual([]);
+  });
+
+  it("best / played タブを構築する", () => {
+    const eval_ = evaluatedMove({
+      moveIndex: 0,
+      position: pos(2, 2),
+      bestMove: pos(1, 1),
+      candidates: [
+        candidate({
+          position: pos(1, 1),
+          principalVariation: [pos(1, 1), pos(9, 9)],
+        }),
+        candidate({
+          position: pos(2, 2),
+          principalVariation: [pos(2, 2), pos(8, 8)],
+        }),
+      ],
+    });
+    const tabs = buildTopTabs(eval_, 0);
+    expect(tabs.map((t) => t.id)).toEqual(["best", "played"]);
+    expect(tabs[0]?.basePV[0]?.position).toEqual(pos(1, 1));
+  });
+
+  it("forcedLossSequence があれば played を抑制し loss タブを出す", () => {
+    const eval_ = evaluatedMove({
+      moveIndex: 0,
+      position: pos(2, 2),
+      bestMove: pos(1, 1),
+      candidates: [
+        candidate({ position: pos(1, 1), principalVariation: [pos(1, 1)] }),
+        candidate({ position: pos(2, 2), principalVariation: [pos(2, 2)] }),
+      ],
+      forcedLossType: "vct",
+      forcedLossSequence: [pos(3, 3), pos(4, 4)],
+      forcedLossBranches: [
+        { defenseIndex: 0, defenseMove: pos(5, 5), continuation: [pos(6, 6)] },
+      ],
+    });
+    const tabs = buildTopTabs(eval_, 0);
+    expect(tabs.map((t) => t.id)).toEqual(["best", "loss"]);
+    const loss = tabs.find((t) => t.id === "loss");
+    expect(loss?.label).toBe("被追詰");
+    expect(loss?.branches[0]?.pvIdx).toBe(1); // defenseIndex(0)+1
+  });
+});
+
+describe("buildRows", () => {
+  function tabWithBranch(): ProgressionTab {
+    return buildTopTabs(
+      evaluatedMove({
+        moveIndex: 0,
+        bestMove: pos(0, 0),
+        candidates: [
+          candidate({
+            position: pos(0, 0),
+            principalVariation: [pos(0, 0), pos(1, 1), pos(2, 2)],
+          }),
+        ],
+        forcedWinBranches: [
+          {
+            defenseIndex: 1,
+            defenseMove: pos(8, 8),
+            continuation: [pos(9, 9)],
+          },
+        ],
+      }),
+      0,
+    )[0]!;
+  }
+
+  it("分岐点に branch 行を挿入し、既定では basePV を辿る", () => {
+    const rows = buildRows(tabWithBranch(), {});
+    expect(rows.map((r) => r.type)).toEqual(["move", "branch", "move"]);
+    const [, branchRow] = rows;
+    expect(
+      branchRow?.type === "branch" && branchRow.options.map((o) => o.id),
+    ).toEqual(["best", "win-0"]);
+  });
+
+  it("分岐を選択すると continuation に切り替わる", () => {
+    const rows = buildRows(tabWithBranch(), { 1: "win-0" });
+    // move(base0), branch(idx1), then win-0 continuation
+    expect(rows.map((r) => r.type)).toEqual(["move", "branch", "move"]);
+    const [, , last] = rows;
+    expect(last?.type === "move" && last.item.position).toEqual(pos(9, 9));
+  });
+});
+
+describe("buildVisibleItems", () => {
+  it("move 行と branch 行の選択オプションを upToRowIdx まで集める", () => {
+    const tab = buildTopTabs(
+      evaluatedMove({
+        moveIndex: 0,
+        bestMove: pos(0, 0),
+        candidates: [
+          candidate({
+            position: pos(0, 0),
+            principalVariation: [pos(0, 0), pos(1, 1)],
+          }),
+        ],
+        forcedWinBranches: [
+          {
+            defenseIndex: 1,
+            defenseMove: pos(8, 8),
+            continuation: [pos(9, 9)],
+          },
+        ],
+      }),
+      0,
+    )[0]!;
+    const rows = buildRows(tab, { 1: "win-0" });
+    // branch 行で win-0 を選んだ可視手列
+    const items = buildVisibleItems(rows, rows.length, { 1: "win-0" });
+    expect(items.map((i) => i.position)).toEqual([
+      pos(0, 0),
+      pos(8, 8),
+      pos(9, 9),
+    ]);
+  });
+
+  it("upToRowIdx で打ち切る", () => {
+    const tab = buildTopTabs(
+      evaluatedMove({
+        moveIndex: 0,
+        bestMove: pos(0, 0),
+        candidates: [
+          candidate({
+            position: pos(0, 0),
+            principalVariation: [pos(0, 0), pos(1, 1), pos(2, 2)],
+          }),
+        ],
+      }),
+      0,
+    )[0]!;
+    const rows = buildRows(tab, {});
+    expect(buildVisibleItems(rows, 2, {})).toHaveLength(2);
+  });
+});

--- a/src/components/cpu/composables/progressionModel.ts
+++ b/src/components/cpu/composables/progressionModel.ts
@@ -1,0 +1,401 @@
+/**
+ * 振り返り進行ツリーの純粋ロジック（リアクティブ非依存）
+ *
+ * useReviewProgression からリアクティブ状態（ref/computed/watch/emit）を除いた
+ * 「PV 構築・分岐正規化・行展開・可視手列」の純粋関数群。
+ * リアクティブ環境なしで単体テストできることを目的とする。
+ *
+ * - PV ビルダ / 候補探索は `EvaluatedMove`（非null）契約。null ガードは
+ *   入口の buildTopTabs に1箇所だけ集約する。
+ * - buildRows / buildVisibleItems は「アクティブタブ1つ分」の selection
+ *   （`Record<number, string>`）のみ受け取る。タブ解決は呼び出し側の責務。
+ */
+
+import type { Position } from "@/types/game";
+import type {
+  EvaluatedMove,
+  ForcedWinBranch,
+  ReviewCandidate,
+} from "@/types/review";
+
+import { SHORT_LABELS } from "@/logic/forcedTypeLabels";
+import { formatMove } from "@/logic/gameRecordParser";
+
+export interface PVDisplayItem {
+  isSelf: boolean;
+  position: Position;
+  coord: string;
+  /** 対局全体での手番（Verdict の moveIndex を起点とする1始まり） */
+  moveNum: number;
+}
+
+export interface InlineBranch {
+  id: string;
+  /** basePV のどのインデックスで分岐するか */
+  pvIdx: number;
+  defenseMove: PVDisplayItem;
+  continuation: PVDisplayItem[];
+}
+
+export interface ProgressionTab {
+  id: string;
+  label: string;
+  sub?: string;
+  emitType: "best" | "played";
+  basePV: PVDisplayItem[];
+  branches: InlineBranch[];
+}
+
+export type Row =
+  | { type: "move"; key: string; item: PVDisplayItem }
+  | {
+      type: "branch";
+      key: string;
+      pvIdx: number;
+      options: { id: string; item: PVDisplayItem }[];
+    };
+
+/** 候補手の予想手順 (principalVariation) を PVDisplayItem[] に変換する */
+export function buildPV(
+  candidate: ReviewCandidate,
+  startMoveIndex: number,
+  selfFirst: boolean,
+): PVDisplayItem[] {
+  if (
+    !candidate.principalVariation ||
+    candidate.principalVariation.length === 0
+  ) {
+    return [];
+  }
+  const items: PVDisplayItem[] = [];
+  for (let i = 0; i < candidate.principalVariation.length; i++) {
+    const pos = candidate.principalVariation[i];
+    if (!pos) {
+      break;
+    }
+    items.push({
+      isSelf: selfFirst ? i % 2 === 0 : i % 2 !== 0,
+      position: pos,
+      coord: formatMove(pos),
+      moveNum: startMoveIndex + i,
+    });
+  }
+  return items;
+}
+
+/** 最善手に対応する候補を探す（一致なければ先頭候補にフォールバック） */
+export function findBestCandidate(
+  eval_: EvaluatedMove,
+): ReviewCandidate | null {
+  if (eval_.candidates.length === 0) {
+    return null;
+  }
+  return (
+    eval_.candidates.find(
+      (c) =>
+        c.position.row === eval_.bestMove.row &&
+        c.position.col === eval_.bestMove.col,
+    ) ??
+    eval_.candidates[0] ??
+    null
+  );
+}
+
+/** 実際に着手した手に対応する候補を探す */
+export function findPlayedCandidate(
+  eval_: EvaluatedMove,
+): ReviewCandidate | null {
+  return (
+    eval_.candidates.find(
+      (c) =>
+        c.position.row === eval_.position.row &&
+        c.position.col === eval_.position.col,
+    ) ?? null
+  );
+}
+
+export function buildBestPV(
+  eval_: EvaluatedMove,
+  moveIndex: number,
+): PVDisplayItem[] {
+  const best = findBestCandidate(eval_);
+  if (!best) {
+    return [];
+  }
+  return buildPV(best, moveIndex, true);
+}
+
+export function buildPlayedPV(
+  eval_: EvaluatedMove,
+  moveIndex: number,
+): PVDisplayItem[] {
+  if (eval_.forcedLossSequence && eval_.forcedLossSequence.length > 0) {
+    return [];
+  }
+  const played = findPlayedCandidate(eval_);
+  if (!played) {
+    return [];
+  }
+  return buildPV(played, moveIndex, true);
+}
+
+export function buildForcedLossPV(
+  eval_: EvaluatedMove,
+  moveIndex: number,
+): PVDisplayItem[] {
+  if (!eval_.forcedLossSequence || eval_.forcedLossSequence.length === 0) {
+    return [];
+  }
+  const items: PVDisplayItem[] = [
+    {
+      isSelf: true,
+      position: eval_.position,
+      coord: formatMove(eval_.position),
+      moveNum: moveIndex,
+    },
+  ];
+  let n = moveIndex + 1;
+  for (let i = 0; i < eval_.forcedLossSequence.length; i++) {
+    const pos = eval_.forcedLossSequence[i];
+    if (!pos) {
+      break;
+    }
+    items.push({
+      isSelf: i % 2 !== 0,
+      position: pos,
+      coord: formatMove(pos),
+      moveNum: n,
+    });
+    n++;
+  }
+  return items;
+}
+
+/** 被詰タブのラベル（例: 「被追詰」）。SSoT としてここで一元管理する */
+export function forcedLossLabelOf(eval_: EvaluatedMove): string | null {
+  const type = eval_.forcedLossType;
+  return type ? `被${SHORT_LABELS[type]}` : null;
+}
+
+/**
+ * forcedWinBranches / forcedLossBranches を InlineBranch[] に正規化する。
+ *
+ * win / loss で異なるのは以下のみで、kind で吸収する:
+ * - pvIdx: win は defenseIndex そのまま、loss は forcedLossPV[0] にプレイヤー
+ *   着手が入るぶん +1 オフセット
+ * - moveNum 起点: win は moveIndex + defenseIndex、loss はさらに +1
+ * - isSelf パリティ: 防御手は win=相手(false)/loss=自分(true)、
+ *   continuation はそこから交互
+ */
+export function buildInlineBranches(
+  branches: ForcedWinBranch[],
+  moveIndex: number,
+  kind: "win" | "loss",
+): InlineBranch[] {
+  const isWin = kind === "win";
+  const pvIdxOffset = isWin ? 0 : 1;
+  const moveNumOffset = isWin ? 0 : 1;
+  const defenseIsSelf = !isWin;
+
+  const result: InlineBranch[] = [];
+  for (let idx = 0; idx < branches.length; idx++) {
+    const branch = branches[idx];
+    if (!branch) {
+      continue;
+    }
+    const branchMoveNum = moveIndex + branch.defenseIndex + moveNumOffset;
+    const continuation: PVDisplayItem[] = [];
+    for (let j = 0; j < branch.continuation.length; j++) {
+      const pos = branch.continuation[j];
+      if (!pos) {
+        break;
+      }
+      continuation.push({
+        // win: continuation 先頭が自分(j%2===0)、loss: 先頭が相手(j%2!==0)
+        isSelf: isWin ? j % 2 === 0 : j % 2 !== 0,
+        position: pos,
+        coord: formatMove(pos),
+        moveNum: branchMoveNum + 1 + j,
+      });
+    }
+    result.push({
+      id: `${kind}-${idx}`,
+      pvIdx: branch.defenseIndex + pvIdxOffset,
+      defenseMove: {
+        isSelf: defenseIsSelf,
+        position: branch.defenseMove,
+        coord: formatMove(branch.defenseMove),
+        moveNum: branchMoveNum,
+      },
+      continuation,
+    });
+  }
+  return result;
+}
+
+/**
+ * 最善 / 実際 / 被詰のタブ群を構築する。null ガードの集約点。
+ */
+export function buildTopTabs(
+  eval_: EvaluatedMove | null,
+  moveIndex: number,
+): ProgressionTab[] {
+  if (!eval_) {
+    return [];
+  }
+  const result: ProgressionTab[] = [];
+
+  const bestPV = buildBestPV(eval_, moveIndex);
+  if (bestPV.length > 0) {
+    result.push({
+      id: "best",
+      label: "最善",
+      sub: formatMove(eval_.bestMove),
+      emitType: "best",
+      basePV: bestPV,
+      branches: buildInlineBranches(
+        eval_.forcedWinBranches ?? [],
+        moveIndex,
+        "win",
+      ),
+    });
+  }
+
+  const playedPV = buildPlayedPV(eval_, moveIndex);
+  if (playedPV.length > 0) {
+    result.push({
+      id: "played",
+      label: "実際",
+      sub: formatMove(eval_.position),
+      emitType: "played",
+      basePV: playedPV,
+      branches: [],
+    });
+  }
+
+  const forcedLossPV = buildForcedLossPV(eval_, moveIndex);
+  if (forcedLossPV.length > 0) {
+    result.push({
+      id: "loss",
+      label: forcedLossLabelOf(eval_) ?? "被詰",
+      sub: formatMove(eval_.position),
+      emitType: "played",
+      basePV: forcedLossPV,
+      branches: buildInlineBranches(
+        eval_.forcedLossBranches ?? [],
+        moveIndex,
+        "loss",
+      ),
+    });
+  }
+
+  return result;
+}
+
+/**
+ * basePV と選択中の分岐から表示行（Row[]）を展開する。
+ *
+ * @param selection アクティブタブ1つ分の pvIdx → optId マップ。
+ *   （将来 #22 の再帰分岐化で、キーが「親選択を含むパス文字列」へ
+ *   変わる可能性がある）
+ */
+export function buildRows(
+  tab: ProgressionTab,
+  selection: Record<number, string>,
+): Row[] {
+  const branchesByIdx = new Map<number, InlineBranch[]>();
+  for (const b of tab.branches) {
+    const list = branchesByIdx.get(b.pvIdx) ?? [];
+    list.push(b);
+    branchesByIdx.set(b.pvIdx, list);
+  }
+
+  const result: Row[] = [];
+  let i = 0;
+  let inBranch: InlineBranch | null = null;
+  let branchOff = 0;
+
+  while (true) {
+    if (inBranch) {
+      if (branchOff >= inBranch.continuation.length) {
+        break;
+      }
+      const item = inBranch.continuation[branchOff];
+      if (!item) {
+        break;
+      }
+      result.push({
+        type: "move",
+        key: `${tab.id}-${inBranch.id}-${branchOff}`,
+        item,
+      });
+      branchOff++;
+      continue;
+    }
+
+    if (i >= tab.basePV.length) {
+      break;
+    }
+
+    const branchesHere = branchesByIdx.get(i);
+    const baseItem = tab.basePV[i];
+    if (branchesHere && branchesHere.length > 0 && baseItem) {
+      const options = [
+        { id: "best", item: baseItem },
+        ...branchesHere.map((b) => ({ id: b.id, item: b.defenseMove })),
+      ];
+      result.push({
+        type: "branch",
+        key: `${tab.id}-br-${i}`,
+        pvIdx: i,
+        options,
+      });
+
+      const selected = selection[i] ?? "best";
+      if (selected !== "best") {
+        const branch = branchesHere.find((b) => b.id === selected);
+        if (branch) {
+          inBranch = branch;
+          branchOff = 0;
+        }
+      }
+      i++;
+    } else {
+      if (baseItem) {
+        result.push({ type: "move", key: `${tab.id}-${i}`, item: baseItem });
+      }
+      i++;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 行 0..upToRowIdx-1 の可視手列を返す（盤面プレビュー用）。
+ * branch 行は selection で選ばれたオプション（既定 best）を採用する。
+ */
+export function buildVisibleItems(
+  rows: Row[],
+  upToRowIdx: number,
+  selection: Record<number, string>,
+): { position: Position; isSelf: boolean }[] {
+  const items: { position: Position; isSelf: boolean }[] = [];
+  for (let r = 0; r < upToRowIdx && r < rows.length; r++) {
+    const row = rows[r];
+    if (!row) {
+      break;
+    }
+    if (row.type === "move") {
+      items.push({ position: row.item.position, isSelf: row.item.isSelf });
+    } else {
+      const selectedId = selection[row.pvIdx] ?? "best";
+      const opt =
+        row.options.find((o) => o.id === selectedId) ?? row.options[0];
+      if (opt) {
+        items.push({ position: opt.item.position, isSelf: opt.item.isSelf });
+      }
+    }
+  }
+  return items;
+}

--- a/src/components/cpu/composables/useReviewProgression.ts
+++ b/src/components/cpu/composables/useReviewProgression.ts
@@ -1,55 +1,24 @@
 /**
- * 振り返り進行ツリー（最善・実際・被詰）の状態と行構築ロジック
+ * 振り返り進行ツリー（最善・実際・被詰）の状態管理と emit
  *
- * - basePV と分岐（forcedWinBranches / forcedLossBranches）を、
- *   タブごとの InlineBranch[] に正規化する
- * - 行（rows）は単一手 or 分岐タブ群の判別共用体として展開し、
- *   ユーザー選択（selections）に応じて続きをブランチの continuation に切り替える
- * - step / showAll でステップ送り、jumpTo / selectBranchOption で位置やブランチを切替
- * - emit 関数を引数で受け取り、preview の発火を担当
+ * - PV 構築・分岐正規化・行展開・可視手列の純粋ロジックは progressionModel に分離。
+ *   このファイルは ref/computed/watch とプレビュー emit のみを担当する。
+ * - step / showAll でステップ送り、jumpTo / selectBranchOption で位置やブランチを切替。
  */
 
 import { type ComputedRef, type Ref, computed, ref, watch } from "vue";
 
 import type { Position } from "@/types/game";
-import type { EvaluatedMove, ReviewCandidate } from "@/types/review";
+import type { EvaluatedMove } from "@/types/review";
 
-import { SHORT_LABELS } from "@/logic/forcedTypeLabels";
-import { formatMove } from "@/logic/gameRecordParser";
-
-export interface PVDisplayItem {
-  isSelf: boolean;
-  position: Position;
-  coord: string;
-  /** 対局全体での手番（Verdict の moveIndex を起点とする1始まり） */
-  moveNum: number;
-}
-
-export interface InlineBranch {
-  id: string;
-  /** basePV のどのインデックスで分岐するか */
-  pvIdx: number;
-  defenseMove: PVDisplayItem;
-  continuation: PVDisplayItem[];
-}
-
-export interface ProgressionTab {
-  id: string;
-  label: string;
-  sub?: string;
-  emitType: "best" | "played";
-  basePV: PVDisplayItem[];
-  branches: InlineBranch[];
-}
-
-export type Row =
-  | { type: "move"; key: string; item: PVDisplayItem }
-  | {
-      type: "branch";
-      key: string;
-      pvIdx: number;
-      options: { id: string; item: PVDisplayItem }[];
-    };
+import {
+  type ProgressionTab,
+  type Row,
+  buildRows,
+  buildTopTabs,
+  buildVisibleItems,
+  forcedLossLabelOf,
+} from "./progressionModel";
 
 interface UseReviewProgressionParams {
   evaluation: Ref<EvaluatedMove | null>;
@@ -82,236 +51,18 @@ interface UseReviewProgressionReturn {
   previewLeave: () => void;
 }
 
-function buildPV(
-  candidate: ReviewCandidate,
-  startMoveIndex: number,
-  selfFirst: boolean,
-): PVDisplayItem[] {
-  if (
-    !candidate.principalVariation ||
-    candidate.principalVariation.length === 0
-  ) {
-    return [];
-  }
-  const items: PVDisplayItem[] = [];
-  for (let i = 0; i < candidate.principalVariation.length; i++) {
-    const pos = candidate.principalVariation[i];
-    if (!pos) {
-      break;
-    }
-    items.push({
-      isSelf: selfFirst ? i % 2 === 0 : i % 2 !== 0,
-      position: pos,
-      coord: formatMove(pos),
-      moveNum: startMoveIndex + i,
-    });
-  }
-  return items;
-}
-
 export function useReviewProgression(
   params: UseReviewProgressionParams,
 ): UseReviewProgressionReturn {
   const { evaluation, moveIndex, emitHover, emitLeave } = params;
 
-  const forcedLossLabel = computed(() => {
-    const type = evaluation.value?.forcedLossType;
-    return type ? `被${SHORT_LABELS[type]}` : null;
-  });
+  const forcedLossLabel = computed(() =>
+    evaluation.value ? forcedLossLabelOf(evaluation.value) : null,
+  );
 
-  const bestCandidate = computed<ReviewCandidate | null>(() => {
-    const eval_ = evaluation.value;
-    if (!eval_ || eval_.candidates.length === 0) {
-      return null;
-    }
-    return (
-      eval_.candidates.find(
-        (c) =>
-          c.position.row === eval_.bestMove.row &&
-          c.position.col === eval_.bestMove.col,
-      ) ??
-      eval_.candidates[0] ??
-      null
-    );
-  });
-
-  const playedCandidate = computed<ReviewCandidate | null>(() => {
-    const eval_ = evaluation.value;
-    if (!eval_) {
-      return null;
-    }
-    return (
-      eval_.candidates.find(
-        (c) =>
-          c.position.row === eval_.position.row &&
-          c.position.col === eval_.position.col,
-      ) ?? null
-    );
-  });
-
-  const bestPV = computed<PVDisplayItem[]>(() => {
-    const eval_ = evaluation.value;
-    const best = bestCandidate.value;
-    if (!eval_ || !best) {
-      return [];
-    }
-    return buildPV(best, moveIndex.value, true);
-  });
-
-  const playedPV = computed<PVDisplayItem[]>(() => {
-    const eval_ = evaluation.value;
-    if (!eval_) {
-      return [];
-    }
-    if (eval_.forcedLossSequence && eval_.forcedLossSequence.length > 0) {
-      return [];
-    }
-    const played = playedCandidate.value;
-    if (!played) {
-      return [];
-    }
-    return buildPV(played, moveIndex.value, true);
-  });
-
-  const forcedLossPV = computed<PVDisplayItem[]>(() => {
-    const eval_ = evaluation.value;
-    if (!eval_?.forcedLossSequence || eval_.forcedLossSequence.length === 0) {
-      return [];
-    }
-    const items: PVDisplayItem[] = [
-      {
-        isSelf: true,
-        position: eval_.position,
-        coord: formatMove(eval_.position),
-        moveNum: moveIndex.value,
-      },
-    ];
-    let n = moveIndex.value + 1;
-    for (let i = 0; i < eval_.forcedLossSequence.length; i++) {
-      const pos = eval_.forcedLossSequence[i];
-      if (!pos) {
-        break;
-      }
-      items.push({
-        isSelf: i % 2 !== 0,
-        position: pos,
-        coord: formatMove(pos),
-        moveNum: n,
-      });
-      n++;
-    }
-    return items;
-  });
-
-  const topTabs = computed<ProgressionTab[]>(() => {
-    const eval_ = evaluation.value;
-    if (!eval_) {
-      return [];
-    }
-    const result: ProgressionTab[] = [];
-
-    if (bestPV.value.length > 0) {
-      const branches: InlineBranch[] = [];
-      const winBranches = eval_.forcedWinBranches ?? [];
-      for (let idx = 0; idx < winBranches.length; idx++) {
-        const branch = winBranches[idx];
-        if (!branch) {
-          continue;
-        }
-        const branchMoveNum = moveIndex.value + branch.defenseIndex;
-        const continuation: PVDisplayItem[] = [];
-        for (let j = 0; j < branch.continuation.length; j++) {
-          const pos = branch.continuation[j];
-          if (!pos) {
-            break;
-          }
-          continuation.push({
-            isSelf: j % 2 === 0,
-            position: pos,
-            coord: formatMove(pos),
-            moveNum: branchMoveNum + 1 + j,
-          });
-        }
-        branches.push({
-          id: `win-${idx}`,
-          pvIdx: branch.defenseIndex,
-          defenseMove: {
-            isSelf: false,
-            position: branch.defenseMove,
-            coord: formatMove(branch.defenseMove),
-            moveNum: branchMoveNum,
-          },
-          continuation,
-        });
-      }
-      result.push({
-        id: "best",
-        label: "最善",
-        sub: formatMove(eval_.bestMove),
-        emitType: "best",
-        basePV: bestPV.value,
-        branches,
-      });
-    }
-
-    if (playedPV.value.length > 0) {
-      result.push({
-        id: "played",
-        label: "実際",
-        sub: formatMove(eval_.position),
-        emitType: "played",
-        basePV: playedPV.value,
-        branches: [],
-      });
-    }
-
-    if (forcedLossPV.value.length > 0) {
-      const branches: InlineBranch[] = [];
-      const lossBranches = eval_.forcedLossBranches ?? [];
-      for (let idx = 0; idx < lossBranches.length; idx++) {
-        const branch = lossBranches[idx];
-        if (!branch) {
-          continue;
-        }
-        const branchMoveNum = moveIndex.value + branch.defenseIndex + 1;
-        const continuation: PVDisplayItem[] = [];
-        for (let j = 0; j < branch.continuation.length; j++) {
-          const pos = branch.continuation[j];
-          if (!pos) {
-            break;
-          }
-          continuation.push({
-            isSelf: j % 2 !== 0,
-            position: pos,
-            coord: formatMove(pos),
-            moveNum: branchMoveNum + 1 + j,
-          });
-        }
-        branches.push({
-          id: `loss-${idx}`,
-          // forcedLossPV[0] = プレイヤーの着手なので、forcedLossSequence の index は basePV では +1 される
-          pvIdx: branch.defenseIndex + 1,
-          defenseMove: {
-            isSelf: true,
-            position: branch.defenseMove,
-            coord: formatMove(branch.defenseMove),
-            moveNum: branchMoveNum,
-          },
-          continuation,
-        });
-      }
-      result.push({
-        id: "loss",
-        label: forcedLossLabel.value ?? "被詰",
-        sub: formatMove(eval_.position),
-        emitType: "played",
-        basePV: forcedLossPV.value,
-        branches,
-      });
-    }
-
-    return result;
-  });
+  const topTabs = computed<ProgressionTab[]>(() =>
+    buildTopTabs(evaluation.value, moveIndex.value),
+  );
 
   // ── State ──
   const activeTabId = ref<string | null>(null);
@@ -323,78 +74,15 @@ export function useReviewProgression(
     () => topTabs.value.find((t) => t.id === activeTabId.value) ?? null,
   );
 
+  /** アクティブタブ1つ分の selection マップ（タブ解決はここで吸収） */
+  function activeSelection(): Record<number, string> {
+    const tab = activeTab.value;
+    return (tab && selections.value[tab.id]) ?? {};
+  }
+
   const rows = computed<Row[]>(() => {
     const tab = activeTab.value;
-    if (!tab) {
-      return [];
-    }
-    const sel = selections.value[tab.id] ?? {};
-    const branchesByIdx = new Map<number, InlineBranch[]>();
-    for (const b of tab.branches) {
-      const list = branchesByIdx.get(b.pvIdx) ?? [];
-      list.push(b);
-      branchesByIdx.set(b.pvIdx, list);
-    }
-
-    const result: Row[] = [];
-    let i = 0;
-    let inBranch: InlineBranch | null = null;
-    let branchOff = 0;
-
-    while (true) {
-      if (inBranch) {
-        if (branchOff >= inBranch.continuation.length) {
-          break;
-        }
-        const item = inBranch.continuation[branchOff];
-        if (!item) {
-          break;
-        }
-        result.push({
-          type: "move",
-          key: `${tab.id}-${inBranch.id}-${branchOff}`,
-          item,
-        });
-        branchOff++;
-        continue;
-      }
-
-      if (i >= tab.basePV.length) {
-        break;
-      }
-
-      const branchesHere = branchesByIdx.get(i);
-      const baseItem = tab.basePV[i];
-      if (branchesHere && branchesHere.length > 0 && baseItem) {
-        const options = [
-          { id: "best", item: baseItem },
-          ...branchesHere.map((b) => ({ id: b.id, item: b.defenseMove })),
-        ];
-        result.push({
-          type: "branch",
-          key: `${tab.id}-br-${i}`,
-          pvIdx: i,
-          options,
-        });
-
-        const selected = sel[i] ?? "best";
-        if (selected !== "best") {
-          const branch = branchesHere.find((b) => b.id === selected);
-          if (branch) {
-            inBranch = branch;
-            branchOff = 0;
-          }
-        }
-        i++;
-      } else {
-        if (baseItem) {
-          result.push({ type: "move", key: `${tab.id}-${i}`, item: baseItem });
-        }
-        i++;
-      }
-    }
-
-    return result;
+    return tab ? buildRows(tab, activeSelection()) : [];
   });
 
   const hasSelections = computed(() => {
@@ -405,36 +93,7 @@ export function useReviewProgression(
     return Object.keys(selections.value[id] ?? {}).length > 0;
   });
 
-  // ── Helpers ──
-
-  function getVisibleItems(
-    upToRowIdx: number,
-  ): { position: Position; isSelf: boolean }[] {
-    const tab = activeTab.value;
-    if (!tab) {
-      return [];
-    }
-    const sel = selections.value[tab.id] ?? {};
-    const items: { position: Position; isSelf: boolean }[] = [];
-    const allRows = rows.value;
-    for (let r = 0; r < upToRowIdx && r < allRows.length; r++) {
-      const row = allRows[r];
-      if (!row) {
-        break;
-      }
-      if (row.type === "move") {
-        items.push({ position: row.item.position, isSelf: row.item.isSelf });
-      } else {
-        const selectedId = sel[row.pvIdx] ?? "best";
-        const opt =
-          row.options.find((o) => o.id === selectedId) ?? row.options[0];
-        if (opt) {
-          items.push({ position: opt.item.position, isSelf: opt.item.isSelf });
-        }
-      }
-    }
-    return items;
-  }
+  // ── Preview emit ──
 
   function emitPreview(): void {
     const tab = activeTab.value;
@@ -442,7 +101,10 @@ export function useReviewProgression(
       emitLeave();
       return;
     }
-    emitHover(getVisibleItems(step.value), tab.emitType);
+    emitHover(
+      buildVisibleItems(rows.value, step.value, activeSelection()),
+      tab.emitType,
+    );
   }
 
   // ── Actions ──
@@ -519,12 +181,7 @@ export function useReviewProgression(
   }
 
   function getSelectedOptionId(pvIdx: number): string {
-    const tab = activeTab.value;
-    if (!tab) {
-      return "best";
-    }
-    const sel = selections.value[tab.id] ?? {};
-    return sel[pvIdx] ?? "best";
+    return activeSelection()[pvIdx] ?? "best";
   }
 
   function previewHoverMove(rowIdx: number): void {
@@ -532,7 +189,10 @@ export function useReviewProgression(
     if (!tab) {
       return;
     }
-    emitHover(getVisibleItems(rowIdx + 1), tab.emitType);
+    emitHover(
+      buildVisibleItems(rows.value, rowIdx + 1, activeSelection()),
+      tab.emitType,
+    );
   }
 
   function previewHoverOption(rowIdx: number, optId: string): void {
@@ -544,7 +204,8 @@ export function useReviewProgression(
     if (!row || row.type !== "branch") {
       return;
     }
-    const items = getVisibleItems(rowIdx);
+    // rowIdx までの可視手 + ホバー中のオプション1手を末尾に合成（emit 依存のため非純粋）
+    const items = buildVisibleItems(rows.value, rowIdx, activeSelection());
     const opt = row.options.find((o) => o.id === optId);
     if (opt) {
       items.push({ position: opt.item.position, isSelf: opt.item.isSelf });


### PR DESCRIPTION
## 概要

Closes #23

振り返り進行ツリーの `useReviewProgression`（603行）から純粋ロジックを `progressionModel.ts` に分離し、テスタビリティを向上させた。**振る舞い変更なし**のリファクタ。

## 変更内容

### 新規 `progressionModel.ts`（純粋・リアクティブ非依存）
PV 構築・候補探索・分岐正規化・行展開・可視手列を純粋関数として抽出:
- `buildPV` / `findBestCandidate` / `findPlayedCandidate`
- `buildBestPV` / `buildPlayedPV` / `buildForcedLossPV`
- `forcedLossLabelOf`（SSoT ラベル）
- `buildInlineBranches`（win/loss 分岐 continuation 構築の重複を統合）
- `buildTopTabs`（null ガードの集約点）
- `buildRows` / `buildVisibleItems`

### `useReviewProgression.ts`（603 → 264行）
ref/computed/watch とプレビュー emit のみを担当。computed は純粋関数の薄いラッパに。selection のタブ解決と hover 時の末尾+1手合成は composable 側に残置。

### その他
- `BranchOptions.vue`: `PVDisplayItem` の import 元を `progressionModel` へ変更
- `progressionModel.test.ts`: リアクティブ環境なしの単体テスト 22ケースを新規追加

## 設計判断（/review で SOLID・パフォーマンス・イシューの3観点レビュー反映）
- 型は完全移設（re-export しない）。外部 import は `BranchOptions.vue` の1箇所のみ
- null 許容は `buildTopTabs` 入口に限定、下位ビルダは非null契約
- `buildTopTabs` を単一 computed 化し candidate の二重評価を回避
- `buildVisibleItems` の branch 再選択ロジックは既存挙動として温存
- #22（再帰分岐化）への先回り構造変更は入れずスコープを分離のみに限定

## テスト
- `progressionModel.test.ts` 22ケース 全通過
- 全ユニットテスト 86ファイル / 1665件 全通過（振る舞い保存を確認）
- `pnpm check-fix` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
