### PR TITLE
fix(review): Mise-VCF追詰の三の代替防御を分岐収集する (#18)

### DIFF
--- a/src/logic/cpu/review/forcedWinDetection.ts
+++ b/src/logic/cpu/review/forcedWinDetection.ts
@@ -7,7 +7,11 @@
 import type { BoardState, Position } from "@/types/game";
 import type { ForcedWinType } from "@/types/review";
 
-import type { VCTSearchOptions, VCTSequenceResult } from "../search/types";
+import type {
+  VCTBranch,
+  VCTSearchOptions,
+  VCTSequenceResult,
+} from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { findDoubleMiseMoves } from "../evaluation/tactics";
@@ -31,7 +35,7 @@ export interface ForcedWinInfo {
   firstMove: Position;
   sequence: Position[];
   isForbiddenTrap: boolean;
-  branches?: unknown;
+  branches?: VCTBranch[];
 }
 
 export interface ForcedWinDetectionResult {
@@ -150,7 +154,8 @@ export function detectForcedWin(
       wasmSearchEngine,
       board,
       color,
-      REVIEW_MISE_VCF_OPTIONS,
+      // 振り返り表示で三の代替防御を分岐タブに出すため分岐収集を有効化（issue #18）
+      { ...REVIEW_MISE_VCF_OPTIONS, collectBranches: true },
     );
   }
 

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -21,7 +21,6 @@ import type {
   IterativeDeepingResult,
   MoveScoreEntry,
   VCFSequenceResult,
-  VCTBranch,
 } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
@@ -787,11 +786,7 @@ function buildForcedWinResult(
       doubleMiseTargets,
     );
   } else {
-    const rawBranches =
-      "branches" in forcedWin
-        ? (forcedWin.branches as VCTBranch[] | undefined)
-        : undefined;
-    forcedWinBranches = rawBranches?.map((b) => ({
+    forcedWinBranches = forcedWin.branches?.map((b) => ({
       defenseIndex: b.defenseIndex,
       defenseMove: b.defenseMove,
       continuation: b.continuation,

--- a/src/logic/cpu/review/wasmAdapters.ts
+++ b/src/logic/cpu/review/wasmAdapters.ts
@@ -62,12 +62,13 @@ export function wasmFindMiseVCFSequence(
   board: BoardState,
   color: "black" | "white",
   options: MiseVCFSearchOptions,
-): VCFSequenceResult | null {
+): VCTSequenceResult | null {
   return engine.findMiseVCFSequence(
     board,
     color,
     toWasmLimit(options.timeLimit),
     toWasmLimit(options.vcfOptions?.maxNodes),
+    options.collectBranches ?? false,
   );
 }
 

--- a/src/logic/cpu/search/types.ts
+++ b/src/logic/cpu/search/types.ts
@@ -96,6 +96,8 @@ export interface MiseVCFSearchOptions {
   vcfOptions?: VCFSearchOptions;
   /** 全体の時間制限（ミリ秒、デフォルト: 500） */
   timeLimit?: number;
+  /** 三の代替防御の分岐を収集するか（振り返り表示用、デフォルト: false） */
+  collectBranches?: boolean;
 }
 
 // =============================================================================

--- a/src/logic/cpu/wasm/searchEngine.ts
+++ b/src/logic/cpu/wasm/searchEngine.ts
@@ -284,39 +284,17 @@ export class WasmSearchEngine {
     color: "black" | "white",
     timeLimitMs: number,
     maxNodes: number,
-  ): VCFSequenceResult | null {
+    collectBranches: boolean,
+  ): VCTSequenceResult | null {
     boardStateToWasm(this.wasm, board);
     this.wasm.findMiseVCFSequenceWasm(
       colorToWasm(color),
       timeLimitMs,
       maxNodes,
+      collectBranches ? 1 : 0,
     );
-    return this.readMiseVCFSequenceResult();
-  }
-
-  private readMiseVCFSequenceResult(): VCFSequenceResult | null {
-    const ptr = this.wasm.getMiseVCFSequenceBuffer();
-    const { memory } = this.wasm;
-    const view = new DataView(memory.buffer);
-
-    const found = view.getUint8(ptr) === 1;
-    if (!found) {
-      return null;
-    }
-
-    const len = view.getUint8(ptr + 1);
-    const isForbiddenTrap = view.getUint8(ptr + 2) === 1;
-
-    const sequence: Position[] = [];
-    for (let i = 0; i < len; i++) {
-      sequence.push({
-        row: view.getUint8(ptr + 3 + i * 2),
-        col: view.getUint8(ptr + 3 + i * 2 + 1),
-      });
-    }
-
-    const firstMove = sequence[0] ?? { row: 0, col: 0 };
-    return { firstMove, sequence, isForbiddenTrap };
+    // Mise-VCF バッファは VCT と同一フォーマット（分岐情報を含む）
+    return this.readSequenceWithBranches(this.wasm.getMiseVCFSequenceBuffer());
   }
 
   private readVCFSequenceResult(): VCFSequenceResult | null {
@@ -416,7 +394,19 @@ export class WasmSearchEngine {
   }
 
   private readVCTSequenceResult(): VCTSequenceResult | null {
-    const ptr = this.wasm.getVCTSequenceBuffer();
+    return this.readSequenceWithBranches(this.wasm.getVCTSequenceBuffer());
+  }
+
+  /**
+   * 分岐情報付きの手順バッファをデシリアライズする（VCT / Mise-VCF 共通）。
+   *
+   * バッファフォーマット（Zig writeVCTResult / findMiseVCFSequenceWasm と一致）:
+   * [0] found, [1] seq_len, [2] isForbiddenTrap,
+   * [3..] row,col ペア（メインPV）,
+   * offset = 3 + seq_len*2: branch_count,
+   * 以降の各 branch: defenseIndex, defRow, defCol, cont_len, cont の row,col ペア
+   */
+  private readSequenceWithBranches(ptr: number): VCTSequenceResult | null {
     const { memory } = this.wasm;
     const view = new DataView(memory.buffer);
 

--- a/src/logic/cpu/wasm/types.ts
+++ b/src/logic/cpu/wasm/types.ts
@@ -75,6 +75,7 @@ export interface WasmModuleContext {
     color: number,
     timeLimitMs: number,
     maxNodes: number,
+    collectBranches: number,
   ) => void;
   getMiseVCFSequenceBuffer: () => number;
 

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -340,14 +340,16 @@ const mise_vcf = @import("mise_vcf.zig");
 /// [1]: sequence length
 /// [2]: isForbiddenTrap (0 or 1)
 /// [3..N*2+2]: row, col pairs
-var mise_vcf_seq_buffer: [256]u8 = .{0} ** 256;
+/// Mise-VCF手順バッファ（VCT同様、分岐情報を含むため大きめ）
+/// フォーマットは vct_seq_buffer と同一（writeVCTResult 参照）
+var mise_vcf_seq_buffer: [2048]u8 = .{0} ** 2048;
 
 export fn getMiseVCFSequenceBuffer() [*]u8 {
     return &mise_vcf_seq_buffer;
 }
 
 /// Mise-VCF手順を探索し結果を mise_vcf_seq_buffer に書き込む
-export fn findMiseVCFSequenceWasm(color: u8, time_limit_ms: u32, max_nodes: u32) void {
+export fn findMiseVCFSequenceWasm(color: u8, time_limit_ms: u32, max_nodes: u32, collect_branches: u8) void {
     const cell_color: board.Cell = switch (color) {
         1 => .black,
         2 => .white,
@@ -358,7 +360,7 @@ export fn findMiseVCFSequenceWasm(color: u8, time_limit_ms: u32, max_nodes: u32)
     };
 
     const cells = &board.board_cells;
-    const result = mise_vcf.findMiseVCFSequence(cells, cell_color, time_limit_ms, max_nodes);
+    const result = mise_vcf.findMiseVCFSequence(cells, cell_color, time_limit_ms, max_nodes, collect_branches != 0);
 
     mise_vcf_seq_buffer[0] = if (result.found) 1 else 0;
     mise_vcf_seq_buffer[1] = result.len;
@@ -368,6 +370,25 @@ export fn findMiseVCFSequenceWasm(color: u8, time_limit_ms: u32, max_nodes: u32)
         for (0..result.len) |i| {
             mise_vcf_seq_buffer[3 + i * 2] = result.sequence[i].row;
             mise_vcf_seq_buffer[3 + i * 2 + 1] = result.sequence[i].col;
+        }
+
+        // 分岐情報（VCT と同一フォーマット）
+        const offset = 3 + @as(usize, result.len) * 2;
+        mise_vcf_seq_buffer[offset] = result.branch_count;
+
+        var pos: usize = offset + 1;
+        for (0..result.branch_count) |bi| {
+            const branch = result.branches[bi];
+            mise_vcf_seq_buffer[pos] = branch.defense_index;
+            mise_vcf_seq_buffer[pos + 1] = branch.defense_move.row;
+            mise_vcf_seq_buffer[pos + 2] = branch.defense_move.col;
+            mise_vcf_seq_buffer[pos + 3] = branch.continuation_len;
+            pos += 4;
+            for (0..branch.continuation_len) |ci| {
+                mise_vcf_seq_buffer[pos] = branch.continuation[ci].row;
+                mise_vcf_seq_buffer[pos + 1] = branch.continuation[ci].col;
+                pos += 2;
+            }
         }
     }
 }

--- a/zig/src/mise_vcf.zig
+++ b/zig/src/mise_vcf.zig
@@ -353,6 +353,24 @@ pub fn findMiseVCFMove(cells: []Cell, color: Cell) ?Position {
 // findMiseVCFSequence（TS版 miseVcf.ts の findMiseVCFSequence に対応）
 // =============================================================================
 
+/// 分岐の最大数（1ミセ手が作る三の防御点の数。活三2点×複数方向＋飛三）
+pub const MAX_MISE_BRANCHES = 16;
+/// 分岐continuationの最大手数（VCF手順。表示用途のため固定長で切り捨て）
+pub const MISE_BRANCH_CONT = 32;
+
+/// Mise-VCF分岐: 主筋以外の三防御手と、その後のVCF継続手順
+///
+/// VCTのVCTBranchと同じ役割だが、continuationがVCF手順で長くなり得るため
+/// 専用に [MISE_BRANCH_CONT] を持つ（VCTBranchの [16] では不足）。
+pub const MiseVCFBranch = struct {
+    /// 主筋sequenceのどのindexで分岐するか（ミセ手の次=常に1）
+    defense_index: u8,
+    /// 代替の三防御手
+    defense_move: Position,
+    continuation: [MISE_BRANCH_CONT]Position,
+    continuation_len: u8,
+};
+
 /// Mise-VCF手順の結果
 pub const MiseVCFSequenceResult = struct {
     /// [ミセ手, 防御手, VCF手順...]
@@ -360,6 +378,9 @@ pub const MiseVCFSequenceResult = struct {
     len: u8,
     is_forbidden_trap: bool,
     found: bool,
+    /// 三の代替防御の分岐（collect_branches有効時のみ）
+    branches: [MAX_MISE_BRANCHES]MiseVCFBranch = undefined,
+    branch_count: u8 = 0,
 };
 
 /// Mise-VCF手順を探索
@@ -371,6 +392,7 @@ pub fn findMiseVCFSequence(
     color: Cell,
     time_limit_ms: u32,
     max_nodes: u32,
+    collect_branches: bool,
 ) MiseVCFSequenceResult {
     // トップレベルエントリ: bitboard を cells と同期
     bitboard.initFromCells(cells);
@@ -478,6 +500,41 @@ pub fn findMiseVCFSequence(
                     result.len = 2 + vcf_result.len;
                     result.is_forbidden_trap = vcf_result.is_forbidden_trap;
                     result.found = true;
+
+                    // 三の代替防御を分岐収集（ミセ手 M は盤上のまま）。
+                    // 主筋防御 target 以外の各三防御点で VCF 手順を取得する。
+                    // ノリ手チェック (isInvalidatedByNoriTe) が全 three_defense で
+                    // VCF 成立を既に保証しているため found 前提だが、手順取得のため再探索する。
+                    if (collect_branches) {
+                        for (0..three_defenses.len) |di| {
+                            const d = three_defenses.items[di];
+                            // 主筋に採用済みの防御は除外
+                            if (d.row == target.row and d.col == target.col) continue;
+                            if (result.branch_count >= MAX_MISE_BRANCHES) break;
+
+                            const d_idx = @as(u16, d.row) * BOARD_SIZE + d.col;
+                            cells[d_idx] = opponent;
+                            bitboard.placeStone(d.row, d.col, opponent);
+                            const br = vcf.findVCFSequence(cells, color, MISE_VCF_DEPTH, time_limit_ms, max_nodes);
+                            cells[d_idx] = .empty;
+                            bitboard.removeStone(d.row, d.col);
+
+                            if (br.found) {
+                                var branch = MiseVCFBranch{
+                                    .defense_index = 1,
+                                    .defense_move = d,
+                                    .continuation = undefined,
+                                    .continuation_len = @min(br.len, MISE_BRANCH_CONT),
+                                };
+                                var ci: u8 = 0;
+                                while (ci < branch.continuation_len) : (ci += 1) {
+                                    branch.continuation[ci] = br.sequence[ci];
+                                }
+                                result.branches[result.branch_count] = branch;
+                                result.branch_count += 1;
+                            }
+                        }
+                    }
 
                     cells[idx] = .empty;
                     bitboard.removeStone(r, c);
@@ -612,7 +669,7 @@ test "findMiseVCFSequence: 12手目局面でG7がMise-VCF手順として検出�
     cells[6 * BOARD_SIZE + 9] = .black; // J9
     cells[5 * BOARD_SIZE + 8] = .white; // I10
 
-    const result = findMiseVCFSequence(&cells, .black, 0, 5000);
+    const result = findMiseVCFSequence(&cells, .black, 0, 5000, false);
     try testing.expect(result.found);
     // 最初の手はG7: row=8, col=6
     try testing.expectEqual(result.sequence[0].row, 8);
@@ -626,14 +683,114 @@ test "findMiseVCFSequence: 初期局面では不成立" {
     cells[7 * BOARD_SIZE + 7] = .black;
     cells[6 * BOARD_SIZE + 8] = .white;
 
-    const result = findMiseVCFSequence(&cells, .black, 0, 5000);
+    const result = findMiseVCFSequence(&cells, .black, 0, 5000, false);
     try testing.expect(!result.found);
 }
 
 test "findMiseVCFSequence: 空盤面では不成立" {
     var cells = [_]Cell{.empty} ** CELL_COUNT;
-    const result = findMiseVCFSequence(&cells, .black, 0, 5000);
+    const result = findMiseVCFSequence(&cells, .black, 0, 5000, false);
     try testing.expect(!result.found);
+}
+
+test "findMiseVCFSequence: collect_branches で三の代替防御を分岐収集 (issue #18)" {
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    const P = struct {
+        fn place(c: []Cell, col_letter: u8, disp_row: u8, color: Cell) void {
+            const col: u16 = col_letter - 'A';
+            const irow: u16 = 15 - @as(u16, disp_row);
+            c[irow * BOARD_SIZE + col] = color;
+        }
+    };
+    const B = Cell.black;
+    const W = Cell.white;
+    // issue #18 の棋譜 43手目まで（黒=奇数, 白=偶数）。44手目は白番、最善 G6（ミセ手）。
+    P.place(&cells, 'H', 8, B);
+    P.place(&cells, 'H', 9, W);
+    P.place(&cells, 'I', 9, B);
+    P.place(&cells, 'I', 8, W);
+    P.place(&cells, 'G', 7, B);
+    P.place(&cells, 'F', 6, W);
+    P.place(&cells, 'G', 10, B);
+    P.place(&cells, 'G', 9, W);
+    P.place(&cells, 'F', 9, B);
+    P.place(&cells, 'H', 11, W);
+    P.place(&cells, 'H', 7, B);
+    P.place(&cells, 'F', 7, W);
+    P.place(&cells, 'F', 10, B);
+    P.place(&cells, 'G', 8, W);
+    P.place(&cells, 'I', 10, B);
+    P.place(&cells, 'H', 10, W);
+    P.place(&cells, 'K', 11, B);
+    P.place(&cells, 'J', 10, W);
+    P.place(&cells, 'F', 8, B);
+    P.place(&cells, 'K', 9, W);
+    P.place(&cells, 'I', 11, B);
+    P.place(&cells, 'I', 13, W);
+    P.place(&cells, 'H', 6, B);
+    P.place(&cells, 'E', 9, W);
+    P.place(&cells, 'F', 11, B);
+    P.place(&cells, 'F', 12, W);
+    P.place(&cells, 'I', 5, B);
+    P.place(&cells, 'J', 4, W);
+    P.place(&cells, 'G', 5, B);
+    P.place(&cells, 'H', 5, W);
+    P.place(&cells, 'I', 7, B);
+    P.place(&cells, 'J', 8, W);
+    P.place(&cells, 'J', 6, B);
+    P.place(&cells, 'J', 7, W);
+    P.place(&cells, 'K', 7, B);
+    P.place(&cells, 'L', 8, W);
+    P.place(&cells, 'F', 4, B);
+    P.place(&cells, 'E', 3, W);
+    P.place(&cells, 'G', 3, B);
+    P.place(&cells, 'H', 4, W);
+    P.place(&cells, 'I', 6, B);
+    P.place(&cells, 'K', 6, W);
+    P.place(&cells, 'L', 5, B);
+    bitboard.initFromCells(&cells);
+
+    const result = findMiseVCFSequence(&cells, W, 0, 5000, true);
+    try testing.expect(result.found);
+    // 主筋防御は I4 (col='I'-'A'=8, row=15-4=11)
+    try testing.expectEqual(@as(u8, 8), result.sequence[1].col);
+    try testing.expectEqual(@as(u8, 11), result.sequence[1].row);
+    // 三の代替防御 E8 (col='E'-'A'=4, row=15-8=7) が分岐に含まれること
+    try testing.expect(result.branch_count >= 1);
+    var found_e8 = false;
+    for (0..result.branch_count) |i| {
+        const d = result.branches[i].defense_move;
+        if (d.row == 7 and d.col == 4) {
+            found_e8 = true;
+            // 分岐は M の次手なので defense_index は 1、continuation が存在する
+            try testing.expectEqual(@as(u8, 1), result.branches[i].defense_index);
+            try testing.expect(result.branches[i].continuation_len >= 1);
+        }
+    }
+    try testing.expect(found_e8);
+}
+
+test "findMiseVCFSequence: collect_branches=false では分岐を収集しない" {
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    // H8 I9 I7 G9 J8 H10 H6 K9 H7 H9 J9 I10（既存テストと同じ局面）
+    cells[7 * BOARD_SIZE + 7] = .black; // H8
+    cells[6 * BOARD_SIZE + 8] = .white; // I9
+    cells[8 * BOARD_SIZE + 8] = .black; // I7
+    cells[6 * BOARD_SIZE + 6] = .white; // G9
+    cells[7 * BOARD_SIZE + 9] = .black; // J8
+    cells[5 * BOARD_SIZE + 7] = .white; // H10
+    cells[9 * BOARD_SIZE + 7] = .black; // H6
+    cells[6 * BOARD_SIZE + 10] = .white; // K9
+    cells[8 * BOARD_SIZE + 7] = .black; // H7
+    cells[6 * BOARD_SIZE + 7] = .white; // H9
+    cells[6 * BOARD_SIZE + 9] = .black; // J9
+    cells[5 * BOARD_SIZE + 8] = .white; // I10
+
+    const result = findMiseVCFSequence(&cells, .black, 0, 5000, false);
+    try testing.expect(result.found);
+    try testing.expectEqual(@as(u8, 0), result.branch_count);
 }
 
 test "findMiseVCFMove: ノリ手で無効なH7をMise-VCF手として返さない" {


### PR DESCRIPTION
## 概要

Closes #18

Mise-VCF（ミセ四追い）追詰で、ミセ手が作る活三/飛三の防御が複数あるのに**1通りしか表示されない**問題を修正。振り返り進行ツリーに、欠落していた代替の三防御を分岐タブとして表示する。

## 原因

`findMiseVCFSequence` は最初に VCF が成立した手順1本のみを返し、`collectBranches` 相当の機能を持たなかった（VCT 探索にはあった）。一方ノリ手チェック (`isInvalidatedByNoriTe`) は全 three_defense で VCF 成立を既に保証している。

## 修正方針（実測で確定）

issue 局面の44手目（白番・ミセ手 G6）を計測し、`getCreatedOpenThreeDefenses(G6) = [I4, E8]`（両方 VCF 成立）で欠落分岐が **E8** だと確認。分岐集合は `three_defenses`（mise_targets ではない）。各三防御点に `findVCFSequence` を回して continuation を収集する。

## 変更内容

### Zig
- `mise_vcf.zig`: `MiseVCFBranch` 型と `findMiseVCFSequence` の `collect_branches` 引数を追加。勝ちミセ手 M 確定時（M を盤上に置いたまま）に three_defenses を走査し、主筋防御 `sequence[1]` 以外の各防御で VCF 手順を収集（`defense_index=1`、continuation は最大32手でクランプ、最大16分岐）
- `main.zig`: `findMiseVCFSequenceWasm` に `collect_branches`、バッファに branches を VCT と同一フォーマットでシリアライズ、`mise_vcf_seq_buffer` 256→2048
- 回帰テスト追加（issue 局面で E8 が分岐に入る／`collect_branches=false` では分岐ゼロ）

### TS
- `searchEngine.ts`: VCT / Mise-VCF の branch 読取を `readSequenceWithBranches` に共通化、`findMiseVCFSequence` に `collectBranches` 引数
- `search/types.ts`: `MiseVCFSearchOptions.collectBranches?`
- `wasm/types.ts` / `wasmAdapters.ts`: 配管
- `forcedWinDetection.ts`: forcedWin 経路のみ `collectBranches: true`（forcedLoss 経路 `forcedLossCheck.ts:203` は不変＝無駄な計算なし）、`ForcedWinInfo.branches` を `VCTBranch[]` に型付け
- `fullEval.ts`: 既存の `forcedWin.branches` マッピングがそのまま機能（VCT 配管を再利用、`defense_index=1` で progressionModel と整合）

## レビュー（/review 3観点反映）
continuation `[32]`・バッファ 2048・reader 共通化・防御カテゴリ整合・型締め・二重 VCF 計算の割り切り（レビュー専用パス）・#22/#26 とのスコープ分離。

## スコープ
- forcedWin（プレイヤーの勝ちミセ）のみ。#26（forcedLoss 側・別データフロー）は別 issue で巻き込まない。
- continuation はフラット構造のまま。内部分岐の再帰化は #22 に委譲。

## テスト・確認
- Zig テスト全通過、全 TS テスト 86ファイル/1665件 通過、`pnpm check-fix` クリーン
- 実機確認: 44手目 G6 で「45手目 I4（推奨手）/ E8（代替手）」が表示。コンソールエラーなし
- `collect_branches=false`（CPU対局・forcedLoss 経路）は挙動不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)
