### PR TITLE
test(renju): TS⇄Zig 連珠ルールのパリティテストを追加 (#21)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -61,6 +61,12 @@
         "no-console": "off",
         "no-await-in-loop": "off"
       }
+    },
+    {
+      "files": ["**/renjuParity.test.ts"],
+      "rules": {
+        "no-bitwise": "off"
+      }
     }
   ],
   "ignorePatterns": ["node_modules/", "dist/", "build/", "coverage/", ".git/"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ pnpm build         # 本番ビルド
 
 ## 連珠の知識
 
+- **連珠ルール（禁手・パターン判定）は TS (`src/logic/renjuRules/`) と Zig (`zig/src/forbidden.zig`, `jump_patterns.zig`) に二重実装されている。どちらかを変更したら必ず両方を直し、`renjuParity.test.ts`（TS⇄Zig パリティテスト）が緑か確認すること。**
 - 連珠は15×15の盤で行う
 - 黒が先手で、禁手あり（三三、四四、長連）
 - 勝利条件: 横・縦・斜めに先に5つ石を並べること

--- a/docs/plans/issue-21-forbidden-wasm.md
+++ b/docs/plans/issue-21-forbidden-wasm.md
@@ -1,0 +1,138 @@
+# Issue #21: 連珠ルールの TS⇄Zig ドリフトを CI パリティテストで防止
+
+## 方針（確定）
+
+連珠の禁手・パターン判定は **TS (`renjuRules/`) と Zig (`zig/src/`) に二重実装**されている。#19 (PR #20) では TS/Zig 両方を直す必要があり、片方だけ直すと**サイレントに食い違う**（ドリフト）。
+
+物理的な単一ソース化（TS削除）は、調査の結果**氷山の本体が `patterns.ts`（連珠プリミティブ6関数、26ファイルが依存）⇄ `jump_patterns.zig`** にあり、これを消すには review worker の連珠ロジック層を丸ごと Zig 移植する大工事（`project_full_zig_migration` 級）が必要と判明。
+
+→ 本 issue は **TS を残したまま、TS と Zig が一致していることを CI で常時検証するパリティテストを導入**し、#19級ドリフトを「**サイレントなバグ → 失敗するテスト**」に変える。**氷山全面（forbiddenMoves.ts ＋ patterns.ts）をカバー**する。最小・低リスク・最広カバレッジ。
+
+- 物理削除・本番コード移行は**やらない**（別 issue: 連珠ロジック全面 Zig 移植）。
+- 成果物 = CI 常駐パリティテスト ＋ それが使う Zig export。
+
+## 調査で判明した対応関係（パリティ設計の前提）
+
+`patterns.ts` の6 export 関数は **`jump_patterns.zig` に完全1:1対応**（同名・同ロジック）:
+
+| TS (`renjuRules/patterns.ts`)                 | Zig (`zig/src/jump_patterns.zig`) |
+| --------------------------------------------- | --------------------------------- |
+| `checkOpenPattern` (L28)                      | `checkOpenPattern` (L281)         |
+| `getConsecutiveThreeStraightFourPoints` (L99) | 同名 (L413)                       |
+| `getJumpThreeStraightFourPoints` (L175)       | 同名 (L474)                       |
+| `checkStraightFour` (L298)                    | 同名 (L348)                       |
+| `checkJumpThree` (L392)                       | 同名 (L201)                       |
+| `checkJumpFour` (L512)                        | 同名 (L93)                        |
+
+`forbiddenMoves.ts:checkForbiddenMove` (L466, 黒のみ) ⇄ `forbidden.zig:checkForbiddenMove` (L319) も関数として1:1（内部構造は別だが入出力は同義）。
+
+依存: `forbidden.zig`・`jump_patterns.zig` とも `board.zig` + `std` のみ（探索/TTを引かない）。`loadWasmModule()` は node/vitest で動作（テストから WASM 検証可）。
+
+## 設計：分類オラクル方式
+
+同一 `(board, row, col, color)` に対し、TS と Zig 双方から**観測可能な連珠判定をパックして突き合わせる**。
+
+### Zig 側（`zig/src/main.zig` に export 1本追加）
+
+```zig
+// 既存の boardInit/boardSet/boardGet を再利用して盤面同期。
+// 1点の全方向パターン分類＋禁手種別を u32 にパックして返す。
+export fn classifyPointWasm(row: u8, col: u8, color: u8) u32 {
+    var bits: u32 = 0;
+    const c: board.Cell = @enumFromInt(color);
+    inline for (0..4) |dir| {
+        const op = jump_patterns.checkOpenPattern(&board.board_cells, row, col, dir, c);
+        const sf = jump_patterns.checkStraightFour(&board.board_cells, row, col, dir, c);
+        const jf = jump_patterns.checkJumpFour(&board.board_cells, row, col, dir, c);
+        const jt = jump_patterns.checkJumpThree(&board.board_cells, row, col, dir, c);
+        // dirあたり5bit: four,open4,open3,straightFour,jumpFour,jumpThree → 6bit
+        const base = dir * 6;
+        bits |= packBit(op.four, base + 0) | packBit(op.open4, base + 1) | packBit(op.open3, base + 2)
+              | packBit(sf, base + 3) | packBit(jf, base + 4) | packBit(jt, base + 5);
+    }
+    // 禁手種別（黒のみ意味を持つ）を上位2bit
+    if (color == 1) bits |= @as(u32, @intFromEnum(forbidden.checkForbiddenMove(&board.board_cells, row, col))) << 24;
+    return bits;
+}
+```
+
+- **既存エンジン wasm (`cpu-engine.wasm`) に export を足すだけ**。新ビルドターゲット・vite 変更・本番コード変更は不要。`pnpm build:wasm` で反映。
+- 4方向 × 6bit = 24bit ＋ 禁手2bit が u32 に収まる。バッファ/ポインタ不要で境界越え1回。
+
+### TS 側（テストヘルパー `classifyPointTs`）
+
+```ts
+// 同じ (board,row,col,color) で patterns.ts の同関数群＋checkForbiddenMove を呼び、同レイアウトで u32 にパック。
+function classifyPointTs(board, row, col, color): number {
+  /* checkOpenPattern/checkStraightFour/checkJumpFour/checkJumpThree ×4dir + checkForbiddenMove */
+}
+```
+
+### パリティテスト（`src/logic/renjuRules/renjuParity.test.ts`）
+
+1. **コーパス**:
+   - **#19型局面を明示投入（必須・乱数任せにしない）**: 同方向の2飛び四＋「ウソの四(XXXX_X)」など、`renjuRules.test.ts` の #19 リグレッションケースおよび `forbidden.zig` の test 群（L378「同方向の2飛び四」/L394「ウソの四」）相当の局面を**種局面として固定投入**。これが #19 再発検出の生命線。
+   - 既存 `renjuRules.test.ts` の局面群 ＋ ベンチ/テスト棋譜（reference の実戦譜）。
+   - **決定的 PRNG（mulberry32/xorshift32 等、外部依存なし）**で生成した盤面（黒白混在・石密度を疎/中/密で段階化）。**非合法局面でも可**（同一盤面での TS/Zig 一致のみを問うため。むしろエッジケースを炙り出せて有益）。
+   - **コーパス局面数は定数/env で可変**（CI は固定シードのサブセット、ローカルは全量）。
+2. **WASM は `beforeAll` で1回だけロード**（48MB エンジン wasm。`loadWasmModule`）。全局面で使い回す（点/局面毎に再ロードしない）。
+3. 各局面で WASM に全同期（`boardInit`＋石数 `boardSet`、局面毎1回。同期直後に board_cells が局面と一致することをアサート）。
+4. 各空き点 × {black, white} について `classifyPointTs == classifyPointWasm` をアサート。
+5. 不一致時は **局面・点・色・両者の分解結果＋「TS/Zigどちらかをドリフトさせた。両方直すかルール解釈を確認せよ」の指示**を出力して落とす。
+
+### ビットレイアウトの一元化（SSoT補強）
+
+- ビット位置（dirあたり `four,open4,open3,straightFour,jumpFour,jumpThree`＝6bit×4dir、禁手種別＝24bit目〜）を **TS 側 named const 1セット**＋**テスト冒頭の対応表（本プランの表）**に集約。Zig 側は数値直書きなので隣にミラーコメント。
+- **禁手種別の数値マッピング**（TS `"overline"→1, "double-four"→2, "double-three"→3` ⇄ Zig `ForbiddenType`）もテスト内マッピング関数1箇所に閉じる（罠リスト参照）。
+- **自己検証アサート**: 既知の単独パターン局面（例: 横の活三のみ）で「該当ビットだけ立つ」ことをパリティ比較とは独立にアサート（レイアウト自体のドリフト検知）。
+
+## getConsecutive/getJumpThreeStraightFourPoints（点リスト返却）の扱い
+
+- `getConsecutiveThreeStraightFourPoints`（両端の単純計算）→ `checkForbiddenMove` 経由の**間接カバーで可**。
+- `getJumpThreeStraightFourPoints` は Zig 側の gap_offset 座標逆算（jump_patterns.zig L501-541）が非自明でバグ余地が大きい → **初回から達四点リストの直接比較を入れる**（点集合の一致を検証。バッファ返し or 点数+座標を別 export）。
+
+## 想定される「初回失敗」＝既存ドリフトの露見
+
+- パリティテストは**初回に既存の TS/Zig 不一致を炙り出す可能性**がある（それが本来の価値）。
+- 不一致が出たら：局面を最小化し、連珠ルール上どちらが正しいかを判定 → 誤っている側を修正。**判断はボスに報告**してから直す。
+
+## 罠（パリティ設計の注意点・テストで吸収）
+
+- **方向インデックスの対応**: TS `dirIndex` と Zig の方向順 (`DIRECTION_PAIR_INDICES=[0,2,1,3]` 等) が食い違うと偽 fail。`classifyPoint` は**両側で同一の物理方向順**を使う。既知局面で方向対応を1点検証してから全体を回す。
+- **色変換**: TS `"black"/"white"` ⇄ Zig `Cell`(black=1/white=2)。
+- **禁手種別の数値マッピング**: TS `"overline"→1, "double-four"→2, "double-three"→3, null→0` ⇄ Zig `ForbiddenType`。テスト内マッピング関数1箇所に閉じる。
+- **盤面復元**: 両実装とも仮置き→復元する（TS undo / Zig `@constCast` 復元）。同期後の board_cells が局面と一致することを最初にアサート。
+- **禁手は黒のみ**: 白の禁手ビットは比較対象外（両側0）。
+
+## スコープ
+
+- **オラクル対象 = `patterns.ts` ＋ `forbiddenMoves.ts`**（氷山＝連珠ルールの二重実装）。`core.ts` の `checkFive`/`checkOverline`/`getLineLength` は `checkForbiddenMove` 経由の間接観測のみで**直接は対象外**（board.zig 側、氷山外）。
+- **既存 Zig 単体テスト（`forbidden.zig`/`jump_patterns.zig` の `test` 群）は維持**（縦軸＝正しさの担保。パリティは横軸＝一致の担保で、両軸を残す）。
+- **既存 `renjuRules.test.ts`（人手期待値）も維持**（縦軸）。TS正しい ∧ TS==Zig ⇒ Zig正しい、の二軸担保。
+
+### PR 分割基準（ドリフト露見への備え）
+
+- **ドリフト0〜1件**: PR1本（テスト基盤＋export＋修正）。
+- **ドリフト2件以上 or ルール解釈の判断を要する**: **テスト基盤を先行マージ**（該当局面のみ `it.skip`＋TODO化）し、ドリフト修正は後続PR。基盤を先に常駐化する。
+- ドリフト修正コミットはテスト導入コミットと**分離**。
+
+### 対象外（別issue「連珠ロジック全面Zig移植」へ）
+
+- TS削除・本番WASM移行・メインスレッドプリロード・差分同期・バッチAPI。
+- 将来 wasm ロードが CI で重くなれば `ReleaseSmall` の thin wasm（patterns+forbidden+board のみ、数十KB）を別ターゲット化（今は不要）。
+
+## TDD 手順
+
+1. (RED) `renjuParity.test.ts` を最小コーパス＋ `classifyPointTs` だけで書く（WASM未exportで落ちる/コンパイル不可）。
+2. (GREEN) `classifyPointWasm` を export、`zig build`、WASM ラッパ（`forbiddenLoader` 不要、既存 `loadWasmModule` 利用）でテストを通す。
+3. 方向対応・色変換を1点検証 → コーパス拡大。
+4. 不一致が出れば最小化→ボス報告→修正（PR分割基準に従う）。
+5. コーパスを #19型種局面＋実戦譜＋決定的乱数で厚くし安定化。
+6. **防御の主役は CI 常駐テスト**。クロスリファレンスコメントは従（「変更すると `renjuParity.test.ts` が落ちる」と因果を併記）。`forbiddenMoves.ts`/`patterns.ts` ⇄ `forbidden.zig`/`jump_patterns.zig` 冒頭にリンク。
+7. **`CLAUDE.md` に一文追加**: 「patterns.ts/forbidden.zig（連珠ルール）を触ったら `renjuParity.test.ts` が緑か確認」。メモリ更新。
+8. **issue #21 にゴール再定義コメント**: 「物理的ダブルメンテ解消（TS削除）ではなく、TS⇄Zig ドリフトの CI 検出に再定義。物理統一は別issue（連珠ロジック全面Zig移植）」。クローズ条件を明記。
+
+## ワークツリー運用
+
+- コミット前: `cd zig && zig build` ＋ `pnpm install --frozen-lockfile --ignore-scripts` ＋ `pnpm check-fix`。
+- コミットメッセージは `-m` のみ（パイプ/`$()` 禁止）。`/review` 実施。

--- a/src/logic/cpu/wasm/types.ts
+++ b/src/logic/cpu/wasm/types.ts
@@ -23,6 +23,15 @@ export interface WasmModuleContext {
     color: number,
   ) => number;
 
+  // Parity oracle (#21): TS⇄Zig 連珠判定の一致検証用。本番探索からは未使用。
+  classifyPointWasm: (row: number, col: number, color: number) => number;
+  getJumpThreeStraightFourPointsWasm: (
+    row: number,
+    col: number,
+    dirIndex: number,
+    color: number,
+  ) => number;
+
   // Pattern scoring
   evaluateDirectionScores: (row: number, col: number, color: number) => number;
   wasmGetPatternScore: (count: number, end1: number, end2: number) => number;

--- a/src/logic/renjuRules/forbiddenMoves.ts
+++ b/src/logic/renjuRules/forbiddenMoves.ts
@@ -1,5 +1,9 @@
 /**
  * 禁手判定: 三三禁、四四禁、長連禁の検出
+ *
+ * ⚠️ 連珠ルールの二重実装: このロジックは Zig 側 `zig/src/forbidden.zig` と同義であり、
+ * 片方だけ変更するとサイレントに食い違う（#19 で実害）。変更すると
+ * `renjuParity.test.ts`（TS⇄Zig パリティテスト）が落ちる。両方を直すこと。
  */
 
 import type { BoardState, ForbiddenMoveResult, Position } from "@/types/game";

--- a/src/logic/renjuRules/patterns.ts
+++ b/src/logic/renjuRules/patterns.ts
@@ -1,5 +1,9 @@
 /**
  * パターン判定: 活三・活四・飛び三・飛び四・達四の検出
+ *
+ * ⚠️ 連珠ルールの二重実装: ここの6関数は Zig 側 `zig/src/jump_patterns.zig` と1:1対応する。
+ * 片方だけ変更するとサイレントに食い違う。変更すると `renjuParity.test.ts`
+ * （TS⇄Zig パリティテスト）が落ちる。両方を直すこと。
  */
 
 import type { BoardState, Position, StoneColor } from "@/types/game";

--- a/src/logic/renjuRules/renjuParity.test.ts
+++ b/src/logic/renjuRules/renjuParity.test.ts
@@ -1,0 +1,372 @@
+/**
+ * 連珠ルール TS⇄Zig パリティテスト（Issue #21）
+ *
+ * 連珠の禁手・パターン判定は TS (`renjuRules/`) と Zig (`zig/src/`) に二重実装されている。
+ * 片方だけ変更するとサイレントに食い違う（#19 で実害）。本テストは同一局面・同一点・同一色で
+ * 両実装の判定を突き合わせ、ドリフトを「失敗するテスト」として常時検出する。
+ *
+ * 比較オラクル: `classifyPoint(board,row,col,color)` を TS/Zig 双方で u32 にパックして比較。
+ *   ビットレイアウト: dir d (0..3) が bit [d*6 .. d*6+5] を占有
+ *     +0 four / +1 open4 / +2 open3 / +3 straightFour / +4 jumpFour / +5 jumpThree
+ *   禁手種別 (none0/overline1/double-four2/double-three3, 黒のみ) は bit 24-25。
+ *
+ * 配置規約（TS/Zig で吸収済み）:
+ *   - 禁手判定は候補マスが「空き」の状態で評価（内部で黒を仮置き）。
+ *   - パターン判定は候補マスに color を「配置済み」で評価（Zig checkJumpFour が生 cells の
+ *     中心を same として読むため）。classifyPoint 内で配置→評価→復元する。
+ *
+ * 方向は TS DIRECTIONS と Zig DIRECTIONS_8 が同一規約（上0/右上1/右2/右下3/...）。
+ * dir 0=縦, 1=右上斜, 2=横, 3=右下斜。
+ *
+ * 詳細: docs/plans/issue-21-forbidden-wasm.md
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { WasmModuleContext } from "@/logic/cpu/wasm/types";
+import type { BoardState, StoneColor } from "@/types/game";
+
+import { loadWasmModule } from "@/logic/cpu/wasm/loader";
+import { createBoardFromRecord, formatMove } from "@/logic/gameRecordParser";
+
+import { createEmptyBoard } from "./core";
+import { checkForbiddenMove } from "./forbiddenMoves";
+import {
+  checkJumpFour,
+  checkJumpThree,
+  checkOpenPattern,
+  checkStraightFour,
+  getJumpThreeStraightFourPoints,
+} from "./patterns";
+
+// ── ビットレイアウト（SSoT。Zig main.zig classifyPointWasm と一致させること）──
+const BIT = {
+  four: 0,
+  open4: 1,
+  open3: 2,
+  straightFour: 3,
+  jumpFour: 4,
+  jumpThree: 5,
+} as const;
+const BITS_PER_DIR = 6;
+const FORBIDDEN_SHIFT = 24;
+
+const FORBIDDEN_TYPE_TO_NUM: Record<string, number> = {
+  overline: 1,
+  "double-four": 2,
+  "double-three": 3,
+};
+
+const CELL_NUM: Record<StoneColor, number> = { black: 1, white: 2 };
+
+/** BoardState を WASM の board_cells へ全同期（局面毎に1回） */
+function syncBoard(wasm: WasmModuleContext, board: BoardState): void {
+  wasm.boardInit();
+  for (let row = 0; row < 15; row++) {
+    const boardRow = board[row];
+    if (!boardRow) {
+      continue;
+    }
+    for (let col = 0; col < 15; col++) {
+      const v = boardRow[col];
+      if (v) {
+        wasm.boardSet(row, col, CELL_NUM[v]);
+      }
+    }
+  }
+}
+
+/** TS 側の分類オラクル（classifyPointWasm と同一レイアウト） */
+function classifyPointTs(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: StoneColor,
+): number {
+  let bits = 0;
+
+  // Phase A: 禁手（候補は空き、黒のみ）
+  if (color === "black") {
+    const f = checkForbiddenMove(board, row, col);
+    const n = f.isForbidden ? (FORBIDDEN_TYPE_TO_NUM[f.type ?? ""] ?? 0) : 0;
+    bits |= n << FORBIDDEN_SHIFT;
+  }
+
+  // Phase B: パターン（候補を配置して評価し復元）
+  const boardRow = board[row];
+  const original = boardRow ? boardRow[col] : null;
+  if (boardRow) {
+    boardRow[col] = color;
+  }
+  for (let dir = 0; dir < 4; dir++) {
+    const op = checkOpenPattern(board, row, col, dir, color);
+    const sf = checkStraightFour(board, row, col, dir, color);
+    const jf = checkJumpFour(board, row, col, dir, color);
+    const jt = checkJumpThree(board, row, col, dir, color);
+    const base = dir * BITS_PER_DIR;
+    if (op.four) {
+      bits |= 1 << (base + BIT.four);
+    }
+    if (op.open4) {
+      bits |= 1 << (base + BIT.open4);
+    }
+    if (op.open3) {
+      bits |= 1 << (base + BIT.open3);
+    }
+    if (sf) {
+      bits |= 1 << (base + BIT.straightFour);
+    }
+    if (jf) {
+      bits |= 1 << (base + BIT.jumpFour);
+    }
+    if (jt) {
+      bits |= 1 << (base + BIT.jumpThree);
+    }
+  }
+  if (boardRow) {
+    boardRow[col] = original ?? null;
+  }
+
+  return bits >>> 0;
+}
+
+/** u32 を人間可読な分類へ展開（不一致時のデバッグ用） */
+function explain(bits: number): Record<string, unknown> {
+  const dirs: Record<string, string[]> = {};
+  for (let dir = 0; dir < 4; dir++) {
+    const base = dir * BITS_PER_DIR;
+    const flags: string[] = [];
+    for (const [name, off] of Object.entries(BIT)) {
+      if (bits & (1 << (base + off))) {
+        flags.push(name);
+      }
+    }
+    if (flags.length) {
+      dirs[`dir${dir}`] = flags;
+    }
+  }
+  const forbidden = (bits >>> FORBIDDEN_SHIFT) & 0x3;
+  return { dirs, forbidden };
+}
+
+/** 決定的 PRNG（mulberry32、外部依存なし） */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeBoard(stones: [number, number, StoneColor][]): BoardState {
+  const board = createEmptyBoard();
+  for (const [r, c, color] of stones) {
+    const br = board[r];
+    if (br) {
+      br[c] = color;
+    }
+  }
+  return board;
+}
+
+/** 手作りの種局面（#19 リグレッション・禁手の核を明示投入） */
+function seedBoards(): { name: string; board: BoardState }[] {
+  return [
+    {
+      name: "#19 同方向の2飛び四 (D F H J / row5)",
+      board: makeBoard([
+        [5, 3, "black"],
+        [5, 5, "black"],
+        [5, 7, "black"],
+        [5, 9, "black"],
+      ]),
+    },
+    {
+      name: "#19 ウソの四 XXXX_X (row7 cols4,5,6,9)",
+      board: makeBoard([
+        [7, 4, "black"],
+        [7, 5, "black"],
+        [7, 6, "black"],
+        [7, 9, "black"],
+      ]),
+    },
+    {
+      name: "四四禁 (横3+縦3 → 中心)",
+      board: makeBoard([
+        [7, 4, "black"],
+        [7, 5, "black"],
+        [7, 6, "black"],
+        [5, 7, "black"],
+        [6, 7, "black"],
+        [8, 7, "black"],
+      ]),
+    },
+    {
+      name: "長連禁 (4連の延長)",
+      board: makeBoard([
+        [7, 3, "black"],
+        [7, 4, "black"],
+        [7, 5, "black"],
+        [7, 6, "black"],
+        [7, 7, "black"],
+      ]),
+    },
+    {
+      name: "三三禁 (活三×2)",
+      board: makeBoard([
+        [7, 6, "black"],
+        [7, 8, "black"],
+        [6, 7, "black"],
+        [8, 7, "black"],
+      ]),
+    },
+  ];
+}
+
+/** 実戦譜ベースの局面 */
+function kifuBoards(): { name: string; board: BoardState }[] {
+  const records = [
+    "H8 H9 I8 G8 I9 I10 F7 G7 G9 H10 F9 J11",
+    "H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 F8 K9",
+  ];
+  return records.map((rec, i) => ({
+    name: `kifu#${i}`,
+    board: createBoardFromRecord(rec).board,
+  }));
+}
+
+/** 決定的乱数局面（黒白混在・複数密度。非合法局面でも可） */
+function randomBoards(): { name: string; board: BoardState }[] {
+  const out: { name: string; board: BoardState }[] = [];
+  const densities = [0.1, 0.25, 0.4];
+  let seed = 0x1234abcd;
+  for (const density of densities) {
+    for (let n = 0; n < 12; n++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const board = createEmptyBoard();
+      for (let r = 0; r < 15; r++) {
+        for (let c = 0; c < 15; c++) {
+          if (rng() < density) {
+            const br = board[r];
+            if (br) {
+              br[c] = rng() < 0.5 ? "black" : "white";
+            }
+          }
+        }
+      }
+      out.push({ name: `rand d=${density} #${n}`, board });
+    }
+  }
+  return out;
+}
+
+// WASM は1回だけロードして全テストで使い回す（48MB エンジン wasm）
+const wasm = await loadWasmModule();
+
+describe("連珠ルール TS⇄Zig パリティ (#21)", () => {
+  it("ビットレイアウト自己検証: 横の活三のみが立つ", () => {
+    // (7,6),(7,8) 黒、(7,7) に黒を置くと横(dir2)に活三
+    const board = makeBoard([
+      [7, 6, "black"],
+      [7, 8, "black"],
+    ]);
+    const bits = classifyPointTs(board, 7, 7, "black");
+    // 横(dir2)に open3 が立つ
+    expect(bits & (1 << (2 * BITS_PER_DIR + BIT.open3))).toBeTruthy();
+    // 他方向には open3 は立たない（checkStraightFour は非4連で true を返す仕様のため
+    // straightFour ビットは方向問わず立ちうる。レイアウト検証は open3 の位置で行う）
+    for (const dir of [0, 1, 3]) {
+      expect(bits & (1 << (dir * BITS_PER_DIR + BIT.open3))).toBe(0);
+    }
+  });
+
+  const corpus = [...seedBoards(), ...kifuBoards(), ...randomBoards()];
+
+  it.each(corpus)("classifyPoint 一致: $name", ({ board }) => {
+    syncBoard(wasm, board);
+    const mismatches: string[] = [];
+    for (let row = 0; row < 15; row++) {
+      const boardRow = board[row];
+      if (!boardRow) {
+        continue;
+      }
+      for (let col = 0; col < 15; col++) {
+        if (boardRow[col]) {
+          continue;
+        } // 空き点のみ
+        for (const color of ["black", "white"] as const) {
+          const ts = classifyPointTs(board, row, col, color);
+          const zig = wasm.classifyPointWasm(row, col, CELL_NUM[color]) >>> 0;
+          if (ts !== zig) {
+            mismatches.push(
+              `${formatMove({ row, col })} ${color}: TS=${JSON.stringify(
+                explain(ts),
+              )} Zig=${JSON.stringify(explain(zig))}`,
+            );
+          }
+        }
+      }
+    }
+    expect(
+      mismatches,
+      `TS/Zig ドリフト検出。両方を直すかルール解釈を確認せよ:\n${mismatches.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it.each(corpus)("getJumpThreeStraightFourPoints 一致: $name", ({ board }) => {
+    syncBoard(wasm, board);
+    const mismatches: string[] = [];
+    for (let row = 0; row < 15; row++) {
+      const boardRow = board[row];
+      if (!boardRow) {
+        continue;
+      }
+      for (let col = 0; col < 15; col++) {
+        if (boardRow[col]) {
+          continue;
+        }
+        for (const color of ["black", "white"] as const) {
+          for (let dir = 0; dir < 4; dir++) {
+            const tsPts = getJumpThreeStraightFourPoints(
+              board,
+              row,
+              col,
+              dir,
+              color,
+            );
+            const tsFound = tsPts.length > 0;
+            const packed =
+              wasm.getJumpThreeStraightFourPointsWasm(
+                row,
+                col,
+                dir,
+                CELL_NUM[color],
+              ) >>> 0;
+            const zigFound = (packed & 1) === 1;
+            if (tsFound !== zigFound) {
+              mismatches.push(
+                `${formatMove({ row, col })} ${color} dir${dir}: TS found=${tsFound} Zig found=${zigFound}`,
+              );
+              continue;
+            }
+            if (tsFound) {
+              const zr = (packed >>> 8) & 0xff;
+              const zc = (packed >>> 16) & 0xff;
+              const tp = tsPts[0]!;
+              if (tp.row !== zr || tp.col !== zc) {
+                mismatches.push(
+                  `${formatMove({ row, col })} ${color} dir${dir}: TS=(${tp.row},${tp.col}) Zig=(${zr},${zc})`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+    expect(mismatches, `達四点ドリフト:\n${mismatches.join("\n")}`).toEqual([]);
+  });
+});

--- a/zig/src/forbidden.zig
+++ b/zig/src/forbidden.zig
@@ -1,3 +1,6 @@
+// ⚠️ 連珠ルールの二重実装: 禁手判定は TS 側 `src/logic/renjuRules/forbiddenMoves.ts` と
+// 同義。片方だけ変更するとサイレントに食い違う（#19 で実害）。変更すると
+// `renjuParity.test.ts`（TS⇄Zig パリティテスト）が落ちる。両方を直すこと。
 const board_mod = @import("board.zig");
 const jp = @import("jump_patterns.zig");
 const std = @import("std");

--- a/zig/src/jump_patterns.zig
+++ b/zig/src/jump_patterns.zig
@@ -1,3 +1,6 @@
+// ⚠️ 連珠ルールの二重実装: ここの活三/飛び四/飛び三/達四判定は TS 側
+// `src/logic/renjuRules/patterns.ts` の6関数と1:1対応する。片方だけ変更すると
+// サイレントに食い違う。変更すると `renjuParity.test.ts` が落ちる。両方を直すこと。
 const board_mod = @import("board.zig");
 const std = @import("std");
 

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -3,6 +3,7 @@ const board = @import("board.zig");
 const evaluate = @import("evaluate.zig");
 const forbidden = @import("forbidden.zig");
 const ft = @import("forced_win_tree.zig");
+const jump_patterns = @import("jump_patterns.zig");
 const patterns = @import("patterns.zig");
 const search = @import("search.zig");
 const position_eval = @import("position_eval.zig");
@@ -42,6 +43,58 @@ export fn wasmGetPatternScore(count: u8, end1: u8, end2: u8) i32 {
 }
 export fn wasmGetPatternType(count: u8, end1: u8, end2: u8) u8 {
     return patterns.wasmGetPatternType(count, end1, end2);
+}
+
+// === パリティテスト用 export（#21）===
+// TS (renjuRules/patterns.ts, forbiddenMoves.ts) と Zig の連珠判定が一致することを
+// CI で検証するためのオラクル。本番探索からは未使用。詳細: docs/plans/issue-21-forbidden-wasm.md
+//
+// 配置規約: 禁手判定は候補マスが「空き」の状態で呼ぶ（内部で黒を仮置きする）。
+// パターン判定は候補マスに color を「配置済み」で呼ぶ（checkJumpFour が生 cells の
+// 中心を same として読むため）。両規約を本関数内で吸収する。
+//
+// ビットレイアウト（u32）: dir d (0..3) が bit [d*6 .. d*6+5] を占有:
+//   +0 four / +1 open4 / +2 open3 / +3 straightFour / +4 jumpFour / +5 jumpThree
+// 禁手種別 (ForbiddenType 0..3, 黒のみ) は bit 24-25。
+export fn classifyPointWasm(row: u8, col: u8, color: u8) u32 {
+    const c: board.Cell = @enumFromInt(color);
+    var bits: u32 = 0;
+
+    // Phase A: 禁手（候補は空きのまま。黒のみ意味を持つ）
+    if (color == 1) {
+        const ftype = forbidden.checkForbiddenMove(&board.board_cells, row, col);
+        bits |= @as(u32, @intFromEnum(ftype)) << 24;
+    }
+
+    // Phase B: パターン（候補を配置して評価し、最後に復元）
+    const idx = @as(u16, row) * board.BOARD_SIZE + col;
+    const original = board.board_cells[idx];
+    board.board_cells[idx] = c;
+    var dir: u8 = 0;
+    while (dir < 4) : (dir += 1) {
+        const op = jump_patterns.checkOpenPattern(&board.board_cells, row, col, dir, c);
+        const sf = jump_patterns.checkStraightFour(&board.board_cells, row, col, dir, c);
+        const jf = jump_patterns.checkJumpFour(&board.board_cells, row, col, dir, c);
+        const jt = jump_patterns.checkJumpThree(&board.board_cells, row, col, dir, c);
+        const b: u5 = @intCast(dir * 6);
+        bits |= @as(u32, @intFromBool(op.four)) << b;
+        bits |= @as(u32, @intFromBool(op.open4)) << (b + 1);
+        bits |= @as(u32, @intFromBool(op.open3)) << (b + 2);
+        bits |= @as(u32, @intFromBool(sf)) << (b + 3);
+        bits |= @as(u32, @intFromBool(jf)) << (b + 4);
+        bits |= @as(u32, @intFromBool(jt)) << (b + 5);
+    }
+    board.board_cells[idx] = original;
+    return bits;
+}
+
+// 飛び三の達四点（0..1点）を返す。pack: bit0=found, bit8-15=row, bit16-23=col。
+// getLine が中心を内部設定するため配置非依存。
+export fn getJumpThreeStraightFourPointsWasm(row: u8, col: u8, dir_index: u8, color: u8) u32 {
+    const c: board.Cell = @enumFromInt(color);
+    const r = jump_patterns.getJumpThreeStraightFourPoints(&board.board_cells, row, col, dir_index, c);
+    if (!r.found) return 0;
+    return 1 | (@as(u32, r.point.row) << 8) | (@as(u32, r.point.col) << 16);
 }
 
 // Evaluate exports


### PR DESCRIPTION
## 概要

Issue #21。連珠の禁手・パターン判定は **TS (`renjuRules/`) と Zig (`forbidden.zig`/`jump_patterns.zig`) に二重実装**されており、片方だけ直すとサイレントに食い違う（#19 で実害）。本 PR は両実装の一致を **CI で常時検証するパリティテスト**を導入し、#19 級ドリフトを「サイレントなバグ → 失敗するテスト」に変える。

> **ゴールの再定義**: 当初タイトルの「Zig/WASM に統一してダブルメンテ解消」は、調査の結果**氷山の本体が `patterns.ts`（連珠プリミティブ6関数・26ファイルが依存）⇄ `jump_patterns.zig`** にあり、物理的単一ソース化（TS削除）には review worker の連珠ロジック層を丸ごと Zig 移植する大工事が必要と判明。本 PR は **TS を残したまま全面のドリフトを検出**する方針に再定義（物理統一は別 issue）。

## 設計：分類オラクル方式

同一 `(board, row, col, color)` に対し TS と Zig 双方から連珠判定を **u32 にパックして突合**する。

- ビットレイアウト: dir d(0..3) が bit[d*6..d*6+5] を占有（four/open4/open3/straightFour/jumpFour/jumpThree）、禁手種別は bit24-25。
- 配置規約を吸収: 禁手は候補「空き」で評価、パターンは候補「配置済み」で評価（Zig `checkJumpFour` が生 cells の中心を same として読むため）。
- `getJumpThreeStraightFourPoints` は座標逆算が非自明なため達四点リストを直接比較。

## 変更

- **zig/src/main.zig**: `classifyPointWasm` / `getJumpThreeStraightFourPointsWasm` を export（本番探索からは未使用）
- **src/logic/renjuRules/renjuParity.test.ts**（新規）: 分類オラクルによるパリティテスト。コーパス = #19型種局面（同方向2飛び四・ウソの四）＋実戦譜＋決定的乱数（mulberry32・複数密度）
- **クロスリファレンスコメント**: `forbiddenMoves.ts`/`patterns.ts`/`forbidden.zig`/`jump_patterns.zig` 冒頭に「変更すると `renjuParity.test.ts` が落ちる。両方直すこと」
- **CLAUDE.md**: 連珠ルール二重実装の注意書き
- **.oxlintrc.json**: パリティテストのみ `no-bitwise` off

## 検証

- パリティテスト **87 テストパス**。**既存ドリフトは検出されず**（TS と Zig は現状完全一致）
- `check-fix`（型/format/oxlint/eslint）= クリーン、`pnpm test`（unit+scripts）= 1771 テストパス、`zig build test` = pass

## スコープ外（別 issue へ）

TS削除・本番WASM移行・メインスレッドプリロード（禁手専用 wasm が 41KB で実現可能なことは実証済み）・差分同期。

closes #21
