### PR TITLE
test(review): review戦術出力スナップショットharnessを追加 (#39)

### DIFF
--- a/docs/plans/issue-37-p0-snapshot.md
+++ b/docs/plans/issue-37-p0-snapshot.md
@@ -1,0 +1,66 @@
+# Issue #37 P0 (#39): review 出力スナップショット harness
+
+## 目的
+
+review 解析（fullEval の戦術出力）の**現在の結果を golden 凍結**し、P3（review 戦術の Zig 移行）が **出力不変**を機械的に証明できる安全網を作る。本 PR はロジックを一切変えない（純粋に現状を固定）。
+
+## 設計方針（レビュー反映：直接関数主役・決定性は設定で担保）
+
+レビューで確認した事実：**bounded 探索は `timeLimit=Infinity/0` を渡すと完全に決定的**（Zig `search.zig`/`vcf.zig`/`vct.zig` が `time_limit==0` で時刻チェックを skip → 終了条件は maxNodes/maxDepth のみ＝マシン非依存）。一方 **`executeFullEval` 内の minimax は常に時間制限（15s/20s）**で非決定。
+
+→ **MVP は「P3 直撃の戦術関数を盤面リテラル入力で直接スナップショット」**。`executeFullEval` 全体凍結は**MVPから外す**（minimax 非決定＋粒度過大で巻き添え更新の温床）。任意で後日。
+
+### MVP スナップショット対象（P3 #42 スコープを直接カバー）
+
+盤面リテラル＋固定 color で直接呼び、**node-bound（timeLimit 無効化 or 速攻確定局面）**で決定化：
+
+- `detectForcedWin(...)`（forcedWinDetection.ts）— 既に `timeLimit:Infinity`+maxNodes で node-bound・決定的。内部で `findThreatMoves`(vctHelpers, P3直撃)も走る。
+- `checkForcedLoss(...)`（forcedLossCheck.ts）— 既定 options は有限 timeLimit。**テストでは Infinity timeLimit を渡す**（options 引数が無ければ速攻確定局面のみ採用し根拠を明記）。
+- `verifyCandidates(...)`（candidateVerification.ts）— opponentForcedWin 判定。同上。
+- `buildDoubleMiseTree` / doubleMise 生成（doubleMiseBranches.ts, `findDoubleMiseMoves`）— 純パターン走査・時間非依存。
+
+凍結フィールド＝**構造系**：`forcedWinType`/`forcedWinTree`/`forcedLossType`/`forcedLossSequence`/`opponentForcedWin(+Sequence)`/`isFukumi`/`doubleMiseTargets`。
+
+### 除外（最初から対象外と断言）
+
+- minimax 由来：`bestScore`/`playedScore`/`candidates[].searchScore`/`candidates` 順序/`completedDepth`/`timings`。これらは時間制限依存で非決定。
+- **候補スコアの Zig 化（#42 の一部）は P0 では守れない**点を明記。P3 着手時に「候補スコアは元々 minimax(Zig) 由来で TS 糊が触らない」かを切り分ける前提とする。
+
+### 正規化（探索順依存を潰す）
+
+- `forcedWinTree` の `defenses[1..]`（主筋以外の防御分岐）など**順序が探索順依存のフィールドはソートして正規化**してから凍結（既存 `forcedWinTree.wasm.test.ts` が `toContain` で順序非依存に検証している＝順序不安定の示唆）。
+- 正規化は**単一の純TS関数**に集約し、JSDoc で「凍結する契約／無視するフィールド」を明記。丸めは使わない（実差分を隠すため）。
+
+## コーパス（速攻確定する forcing 局面）
+
+`reference_review_test_kifu.md` ＋既存棋譜から、**Infinity timeLimit でも maxNodes 内で速く確定**する局面を厳選（VCT は maxNodes だけで打ち切れない設計なので特に速い局面のみ）：
+
+- Mise-VCF（#18 局面、詰み木分岐あり）／ VCF 確定 ／ VCT 確定 ／ 被必勝(forcedLoss) ／ 両ミセ。
+- コーパスは `const CORPUS = [{name, board(リテラル) or record, color}]` として**1箇所に集約**（実行ハーネスと分離）。
+
+## 実装
+
+- `src/logic/cpu/review/reviewSnapshot.test.ts`（新規）：
+  - `beforeAll` で `loadWasmModule()` → `WasmSearchEngine`（1回ロード）。
+  - `CORPUS` を `it.each` で回し、各直接関数 → 正規化 → `toMatchSnapshot()`。入力は盤面リテラル（`createBoardFromRecord` で作っても可だが固定）。
+  - `checkForcedLoss`/`verifyCandidates` には Infinity timeLimit を渡す（関数が options を受けるか実装時に確認。受けないなら速攻確定局面で代替＋根拠コメント。本番シグネチャは汚さない）。
+- `.snap` 生成後**目視レビュー**してコミット。
+
+## 検証ゲート
+
+- `pnpm test`(unit+scripts) 緑。決定性は**「node-bound 設定で呼んでいること」をコードで担保**（2回実行一致は補助的 smoke のみ＝同一マシンでは弱い指標）。
+- 既存テストに影響なし（追加のみ）。
+
+## 対象外
+
+- ロジック・Zig 変更（凍結のみ）。`executeFullEval` 全体スナップショット（任意・後日）。verdict しきい値（classifyMoveQuality、純TS・P3非対象）。
+
+## メモ
+
+- これは P3 各小 PR で「戦術出力不変」を確認する基準。P1/P2（メイン）とは無関係。
+- `checkForcedLoss` 等に Infinity timeLimit を渡す経路が無い場合、その整備自体が P3 の前提として価値がある（本番 API は汚さず、テスト用 options 渡し or 速攻確定局面で対応）。
+
+## ワークツリー運用
+
+- コミット前: `cd zig && zig build`（テストが wasm を要求）＋ `pnpm check-fix`。`pnpm install` は worktree で実行しない。
+- ステージは個別ファイル指定（`git add -A` は deny）。

--- a/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
+++ b/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
@@ -1,0 +1,516 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`review 戦術出力スナップショット (#37 P0) > checkForcedLoss: 'mise-vcf-#18' 1`] = `
+{
+  "sequence": [
+    {
+      "col": 6,
+      "row": 9,
+    },
+    {
+      "col": 8,
+      "row": 11,
+    },
+    {
+      "col": 4,
+      "row": 7,
+    },
+    {
+      "col": 3,
+      "row": 6,
+    },
+    {
+      "col": 4,
+      "row": 9,
+    },
+    {
+      "col": 3,
+      "row": 10,
+    },
+    {
+      "col": 4,
+      "row": 8,
+    },
+  ],
+  "type": "mise-vcf",
+}
+`;
+
+exports[`review 戦術出力スナップショット (#37 P0) > checkForcedLoss: 'white29-m20' 1`] = `
+{
+  "sequence": [
+    {
+      "col": 9,
+      "row": 6,
+    },
+    {
+      "col": 9,
+      "row": 5,
+    },
+    {
+      "col": 9,
+      "row": 7,
+    },
+    {
+      "col": 9,
+      "row": 10,
+    },
+    {
+      "col": 10,
+      "row": 7,
+    },
+    {
+      "col": 11,
+      "row": 7,
+    },
+    {
+      "col": 8,
+      "row": 5,
+    },
+  ],
+  "type": "vct",
+}
+`;
+
+exports[`review 戦術出力スナップショット (#37 P0) > checkForcedLoss: 'white29-m24' 1`] = `
+{
+  "sequence": [
+    {
+      "col": 10,
+      "row": 7,
+    },
+    {
+      "col": 11,
+      "row": 7,
+    },
+    {
+      "col": 8,
+      "row": 5,
+    },
+  ],
+  "type": "vcf",
+}
+`;
+
+exports[`review 戦術出力スナップショット (#37 P0) > detectForcedWin: 'mise-vcf-#18' 1`] = `
+{
+  "doubleMiseBestMove": null,
+  "doubleMiseMoves": [],
+  "forcedWin": {
+    "firstMove": {
+      "col": 6,
+      "row": 9,
+    },
+    "isForbiddenTrap": false,
+    "sequence": [
+      {
+        "col": 6,
+        "row": 9,
+      },
+      {
+        "col": 8,
+        "row": 11,
+      },
+      {
+        "col": 4,
+        "row": 7,
+      },
+      {
+        "col": 3,
+        "row": 6,
+      },
+      {
+        "col": 4,
+        "row": 9,
+      },
+      {
+        "col": 3,
+        "row": 10,
+      },
+      {
+        "col": 4,
+        "row": 8,
+      },
+    ],
+    "tree": {
+      "attackerMove": {
+        "col": 6,
+        "row": 9,
+      },
+      "defenses": [
+        {
+          "defenderMove": {
+            "col": 4,
+            "row": 7,
+          },
+          "next": {
+            "attackerMove": {
+              "col": 8,
+              "row": 11,
+            },
+            "defenses": [
+              {
+                "defenderMove": {
+                  "col": 9,
+                  "row": 12,
+                },
+                "next": {
+                  "attackerMove": {
+                    "col": 10,
+                    "row": 11,
+                  },
+                  "defenses": [],
+                },
+              },
+            ],
+          },
+        },
+        {
+          "defenderMove": {
+            "col": 8,
+            "row": 11,
+          },
+          "next": {
+            "attackerMove": {
+              "col": 4,
+              "row": 7,
+            },
+            "defenses": [
+              {
+                "defenderMove": {
+                  "col": 3,
+                  "row": 6,
+                },
+                "next": {
+                  "attackerMove": {
+                    "col": 4,
+                    "row": 9,
+                  },
+                  "defenses": [
+                    {
+                      "defenderMove": {
+                        "col": 3,
+                        "row": 10,
+                      },
+                      "next": {
+                        "attackerMove": {
+                          "col": 4,
+                          "row": 8,
+                        },
+                        "defenses": [],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  "forcedWinType": "mise-vcf",
+}
+`;
+
+exports[`review 戦術出力スナップショット (#37 P0) > detectForcedWin: 'white29-m20' 1`] = `
+{
+  "doubleMiseBestMove": null,
+  "doubleMiseMoves": [],
+  "forcedWin": {
+    "firstMove": {
+      "col": 9,
+      "row": 6,
+    },
+    "isForbiddenTrap": false,
+    "sequence": [
+      {
+        "col": 9,
+        "row": 6,
+      },
+      {
+        "col": 9,
+        "row": 5,
+      },
+      {
+        "col": 9,
+        "row": 7,
+      },
+      {
+        "col": 9,
+        "row": 10,
+      },
+      {
+        "col": 10,
+        "row": 7,
+      },
+      {
+        "col": 11,
+        "row": 7,
+      },
+      {
+        "col": 8,
+        "row": 5,
+      },
+    ],
+    "tree": {
+      "attackerMove": {
+        "col": 9,
+        "row": 6,
+      },
+      "defenses": [
+        {
+          "defenderMove": {
+            "col": 9,
+            "row": 5,
+          },
+          "next": {
+            "attackerMove": {
+              "col": 9,
+              "row": 7,
+            },
+            "defenses": [
+              {
+                "defenderMove": {
+                  "col": 9,
+                  "row": 10,
+                },
+                "next": {
+                  "attackerMove": {
+                    "col": 10,
+                    "row": 7,
+                  },
+                  "defenses": [
+                    {
+                      "defenderMove": {
+                        "col": 11,
+                        "row": 7,
+                      },
+                      "next": {
+                        "attackerMove": {
+                          "col": 8,
+                          "row": 5,
+                        },
+                        "defenses": [],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          "defenderMove": {
+            "col": 9,
+            "row": 7,
+          },
+          "next": {
+            "attackerMove": {
+              "col": 6,
+              "row": 3,
+            },
+            "defenses": [
+              {
+                "defenderMove": {
+                  "col": 5,
+                  "row": 2,
+                },
+                "next": {
+                  "attackerMove": {
+                    "col": 7,
+                    "row": 3,
+                  },
+                  "defenses": [
+                    {
+                      "defenderMove": {
+                        "col": 7,
+                        "row": 5,
+                      },
+                      "next": {
+                        "attackerMove": {
+                          "col": 8,
+                          "row": 3,
+                        },
+                        "defenses": [
+                          {
+                            "defenderMove": {
+                              "col": 9,
+                              "row": 2,
+                            },
+                            "next": {
+                              "attackerMove": {
+                                "col": 5,
+                                "row": 3,
+                              },
+                              "defenses": [],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                "defenderMove": {
+                  "col": 8,
+                  "row": 5,
+                },
+                "next": {
+                  "attackerMove": {
+                    "col": 7,
+                    "row": 3,
+                  },
+                  "defenses": [
+                    {
+                      "defenderMove": {
+                        "col": 7,
+                        "row": 5,
+                      },
+                      "next": {
+                        "attackerMove": {
+                          "col": 8,
+                          "row": 3,
+                        },
+                        "defenses": [
+                          {
+                            "defenderMove": {
+                              "col": 9,
+                              "row": 2,
+                            },
+                            "next": {
+                              "attackerMove": {
+                                "col": 5,
+                                "row": 3,
+                              },
+                              "defenses": [],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                "defenderMove": {
+                  "col": 10,
+                  "row": 7,
+                },
+                "next": {
+                  "attackerMove": {
+                    "col": 7,
+                    "row": 3,
+                  },
+                  "defenses": [
+                    {
+                      "defenderMove": {
+                        "col": 7,
+                        "row": 5,
+                      },
+                      "next": {
+                        "attackerMove": {
+                          "col": 8,
+                          "row": 3,
+                        },
+                        "defenses": [
+                          {
+                            "defenderMove": {
+                              "col": 9,
+                              "row": 2,
+                            },
+                            "next": {
+                              "attackerMove": {
+                                "col": 5,
+                                "row": 3,
+                              },
+                              "defenses": [],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          "defenderMove": {
+            "col": 9,
+            "row": 10,
+          },
+          "next": {
+            "attackerMove": {
+              "col": 9,
+              "row": 7,
+            },
+            "defenses": [
+              {
+                "defenderMove": {
+                  "col": 9,
+                  "row": 5,
+                },
+                "next": {
+                  "attackerMove": {
+                    "col": 10,
+                    "row": 7,
+                  },
+                  "defenses": [
+                    {
+                      "defenderMove": {
+                        "col": 11,
+                        "row": 7,
+                      },
+                      "next": {
+                        "attackerMove": {
+                          "col": 8,
+                          "row": 5,
+                        },
+                        "defenses": [],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  "forcedWinType": "vct",
+}
+`;
+
+exports[`review 戦術出力スナップショット (#37 P0) > detectForcedWin: 'white29-m24' 1`] = `
+{
+  "doubleMiseBestMove": null,
+  "doubleMiseMoves": [],
+  "forcedWin": {
+    "firstMove": {
+      "col": 10,
+      "row": 7,
+    },
+    "isForbiddenTrap": false,
+    "sequence": [
+      {
+        "col": 10,
+        "row": 7,
+      },
+      {
+        "col": 11,
+        "row": 7,
+      },
+      {
+        "col": 8,
+        "row": 5,
+      },
+    ],
+    "tree": undefined,
+  },
+  "forcedWinType": "vcf",
+}
+`;

--- a/src/logic/cpu/review/reviewSnapshot.test.ts
+++ b/src/logic/cpu/review/reviewSnapshot.test.ts
@@ -1,0 +1,128 @@
+/**
+ * review 戦術出力スナップショット harness（Issue #37 P0 / #39）
+ *
+ * 目的: review の戦術解析（P3 #42 で Zig へ移す対象）の**現在の出力を golden 凍結**し、
+ * P3 の各移行 PR が「出力不変」を機械的に証明できる安全網にする。本テストはロジックを
+ * 一切変えない（現状凍結のみ）。
+ *
+ * 決定性（flaky 回避）: review の minimax は時間制限探索で非決定なので**対象にしない**。
+ * 代わりに P3 直撃の bounded 探索関数（detectForcedWin / checkForcedLoss）を直接呼ぶ。
+ * これらは `timeLimit=Infinity` を渡すと探索が node/maxDepth のみで打ち切られ
+ * **マシン速度に非依存（決定的）**になる（Zig: time_limit==0 で時刻チェック skip）。
+ *
+ * 凍結する契約 = 構造的・戦術的フィールドのみ:
+ *   detectForcedWin: forcedWinType / forcedWin(firstMove,sequence,isForbiddenTrap,tree) /
+ *                    doubleMiseBestMove / doubleMiseMoves
+ *   checkForcedLoss: type / sequence
+ * 除外（非決定 or P3 非対象）: minimax 由来スコア・候補順序・completedDepth・timings。
+ *
+ * 正規化: forcedWinTree の防御分岐 `defenses` は探索順依存なので座標でソートして順序非依存化
+ * （主筋は ForcedWinInfo.sequence が別途凍結するので分岐集合の一致だけ見れば十分）。
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ForcedWinNode } from "@/types/review";
+
+import { loadWasmModule } from "@/logic/cpu/wasm/loader";
+import { WasmSearchEngine } from "@/logic/cpu/wasm/searchEngine";
+import { createBoardFromRecord } from "@/logic/gameRecordParser";
+
+import {
+  checkForcedLoss,
+  FORCED_LOSS_VCT_OPTIONS,
+  REVIEW_MISE_VCF_OPTIONS,
+  REVIEW_VCF_OPTIONS,
+  type ForcedLossCheckOptions,
+} from "./forcedLossCheck";
+import { detectForcedWin } from "./forcedWinDetection";
+
+// 決定的設定: timeLimit を Infinity にして探索を node/maxDepth のみで打ち切る
+const DETERMINISTIC_LOSS_OPTIONS: ForcedLossCheckOptions = {
+  vcfOptions: { ...REVIEW_VCF_OPTIONS, timeLimit: Infinity },
+  miseVcfOptions: { ...REVIEW_MISE_VCF_OPTIONS, timeLimit: Infinity },
+  vctOptions: { ...FORCED_LOSS_VCT_OPTIONS, timeLimit: Infinity },
+};
+
+/** コーパス: 速攻確定する forcing 局面に厳選（決定性＋CI速度の前提） */
+const CORPUS: { name: string; record: string; moveCount: number }[] = [
+  {
+    // #18 Mise-VCF 局面（44手目=白番、G6 ミセ手で追詰）
+    name: "mise-vcf-#18",
+    record:
+      "H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 " +
+      "F8 K9 I11 I13 H6 E9 F11 F12 I5 J4 G5 H5 I7 J8 J6 J7 K7 L8 " +
+      "F4 E3 G3 H4 I6 K6 L5",
+    moveCount: 43,
+  },
+  {
+    // 被追い詰め多数の白番棋譜（reference_review_test_kifu）。複数手数で凍結
+    name: "white29-m20",
+    record:
+      "H8 G8 H9 G7 G9 H7 I7 F10 F9 E9 I8 I9 G10 F11 H11 E8 J6 K5 J7 K6 J9 J5 J8 J10 K8 L8 I10 L7 G12",
+    moveCount: 20,
+  },
+  {
+    name: "white29-m24",
+    record:
+      "H8 G8 H9 G7 G9 H7 I7 F10 F9 E9 I8 I9 G10 F11 H11 E8 J6 K5 J7 K6 J9 J5 J8 J10 K8 L8 I10 L7 G12",
+    moveCount: 24,
+  },
+];
+
+const sortPos = (
+  a: { row: number; col: number },
+  b: { row: number; col: number },
+): number => a.row - b.row || a.col - b.col;
+
+/** 詰み木を分岐順非依存に正規化（defenses を defenderMove 座標でソート） */
+function normalizeTree(node: ForcedWinNode): unknown {
+  return {
+    attackerMove: node.attackerMove,
+    defenses: node.defenses
+      .map((d) => ({
+        defenderMove: d.defenderMove,
+        next: normalizeTree(d.next),
+      }))
+      .sort((x, y) => sortPos(x.defenderMove, y.defenderMove)),
+  };
+}
+
+// WASM は1回だけロードして全テストで使い回す
+const engine = new WasmSearchEngine(await loadWasmModule());
+
+describe("review 戦術出力スナップショット (#37 P0)", () => {
+  it.each(CORPUS)("detectForcedWin: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const r = detectForcedWin(board, nextColor, false, false, engine);
+    const snapshot = {
+      forcedWinType: r.forcedWinType ?? null,
+      doubleMiseBestMove: r.doubleMiseBestMove,
+      doubleMiseMoves: [...r.doubleMiseMoves].sort(sortPos),
+      forcedWin: r.forcedWin
+        ? {
+            firstMove: r.forcedWin.firstMove,
+            sequence: r.forcedWin.sequence,
+            isForbiddenTrap: r.forcedWin.isForbiddenTrap,
+            tree: r.forcedWin.tree
+              ? normalizeTree(r.forcedWin.tree)
+              : undefined,
+          }
+        : null,
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it.each(CORPUS)("checkForcedLoss: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    // 直前に着手された側の相手 = nextColor が追詰を持つか
+    const result = checkForcedLoss(
+      board,
+      nextColor,
+      moveCount,
+      engine,
+      DETERMINISTIC_LOSS_OPTIONS,
+    );
+    expect(result ?? null).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## 概要

#37 P0（#39）。後続 **P3（review 戦術の Zig 移行 / #42）** が「**出力不変**」を機械的に証明できる安全網を作る。本 PR はロジックを一切変えない（現状凍結のみ）。

## 設計（レビュー反映）

P3 直撃の bounded 探索関数を**盤面リテラル入力で直接スナップショット**：
- `detectForcedWin`（forcedWinDetection.ts）— node-bound・決定的
- `checkForcedLoss`（forcedLossCheck.ts）— `options` で `timeLimit: Infinity` を渡し node-bound 化

**決定性**: Zig 探索は `timeLimit=0/Infinity` で時刻チェックを skip し、終了条件が maxNodes/maxDepth のみ＝**マシン速度に非依存**。これを利用して flaky を回避。

**正規化**: `forcedWinTree` の防御分岐 `defenses` は探索順依存なので座標ソートで順序非依存化（主筋は `sequence` が別途凍結）。

**除外**: minimax 由来（score / 候補順序 / completedDepth / timings）は非決定なので対象外。`executeFullEval` 全体凍結は粒度過大＋minimax非決定のため MVP から外す（任意・後日）。

## コーパス

速攻確定する forcing 局面に厳選：
- Mise-VCF #18 局面（詰み木分岐あり）
- 被追い詰め多数の白29手棋譜（reference_review_test_kifu）2手数

生成スナップショットは mise-vcf / vct の手順を正しく凍結。**2回連続実行で同一**（決定性確認済み）。

## 検証

- `pnpm test`(unit+scripts) 1777 テストパス、`check-fix` クリーン、`zig build test` pass。
- 既存テストに影響なし（追加のみ）。

## 後続カバレッジ（P3着手時に拡張）

`verifyCandidates` / `buildDoubleMiseTree` の直接スナップショットは、P3 が当該関数に着手する際に同パターンで追加（本 PR は forced-win/loss の核経路をカバー）。

## 関連
- 親 #37 / P0 #39 / 守る対象 P3 #42
