### PR TITLE
feat(cpu): メインスレッドの禁手判定を Zig thin wasm 経由に (#40)

### DIFF
--- a/docs/plans/issue-37-p1-forbidden.md
+++ b/docs/plans/issue-37-p1-forbidden.md
@@ -1,0 +1,68 @@
+# Issue #37 P1 (#40): メインスレッドの禁手を Zig 化（禁手マップキャッシュ＋thin wasm 基盤）
+
+## 目的
+
+北極星「戦術＝Zig、TS＝プレゼン」の最初の実例。**盤面変更時に Zig（41KB 禁手専用 thin wasm）で「黒の禁手点マップ」を1回計算 → store にキャッシュ → CpuGamePlayer は参照のみ**。thin wasm/ローダー/起動プリロード基盤を新設し、P2 以降の前提を作る。
+
+## スコープ
+
+- thin wasm（禁手）ビルド＋ローダー＋起動プリロード。
+- 禁手マップ・キャッシュ（boardStore の盤面変更に連動して再計算）。
+- `CpuGamePlayer.vue:194` の `checkForbiddenMove` をキャッシュ参照へ置換。
+
+**対象外**: `vcfPuzzle`（P2）、worker（P3）、`forbiddenMoves.ts` 削除（P4。バレル経由で worker がまだ使う）。
+
+## 設計確定（レビュー反映）：マップ撤回・単点判定
+
+レビュー総意＋ボス整理で、**禁手マップ／キャッシュ／boardStore watch は撤回**。CpuGamePlayer は「クリックした1点」だけ判定すれば足り、`checkForbiddenMove` は**その1点を達四点再帰込みで完全に正しく**判定する。マップは proactive 表示や P2 の多点文脈で初めて要る（その際の影響範囲は「着手筋＋達四点再帰の近傍」。単純な4筋だと三三禁のウソの三を取りこぼす）。→ **P1 は単点 WASM 化のみ**。
+
+## Phase 1: 禁手専用 thin wasm（資産）
+
+### Zig
+
+- 新規ルート `zig/src/forbidden_wasm.zig`（`board.board_cells` 利用）:
+  - `boardInit()` / `boardSet(row,col,value)`（盤面同期）
+  - `checkForbiddenPointWasm(row,col) u8` — `forbidden.checkForbiddenMove` の `ForbiddenType`（0=none/1=overline/2=double_four/3=double_three）を返す（黒のみ意味を持つ。候補は空きで呼ぶ）。
+  - 依存は forbidden.zig + jump_patterns.zig + board.zig のみ（#21 調査で実測 ~41KB）。
+- `zig/build.zig`: 2つ目の executable ターゲット（wasm32-freestanding / ReleaseFast / entry=.disabled / rdynamic）→ `zig-out/bin/forbidden.wasm`。既存 cpu-engine・test step に非干渉。
+- **サイズ回帰ゲート**: `forbidden.wasm` が想定（~数十KB）に収まることを確認（誤って search 等を引かない担保）。
+
+### TS ローダー
+
+- `src/logic/cpu/wasm/forbiddenLoader.ts`: `loadForbiddenWasm()`。既存 `loader.ts` の node/browser 分岐 `loadWasmBuffer` を**共通化して再利用**（DRY）。`new URL(".../forbidden.wasm", import.meta.url)`。vite が自動 asset 化。
+- 型 `ForbiddenWasmContext`（boardInit/boardSet/checkForbiddenPointWasm のみ。最小 ISP）。
+
+## Phase 2: CpuGamePlayer 単点移行
+
+- `src/logic/cpu/wasm/forbiddenAdapter.ts`（薄いアダプタ）:
+  - `preloadForbiddenWasm(): Promise<void>`（起動時発火）。
+  - `isForbiddenForBlack(board, row, col): boolean` — 盤面を thin wasm に全同期 → `checkForbiddenPointWasm` → `!= 0`。**wasm 未ロード時は TS `checkForbiddenMove` にフォールバック**（#21 パリティ保証下で挙動同値・クラッシュ回避。フォールバックは移行期の保険で、P4 の `forbiddenMoves.ts` 削除条件に「この経路撤去」を含める）。
+- `main.ts`: `app.mount` 後に `preloadForbiddenWasm().catch(...)` を非ブロッキング発火（41KB・数ms。未ハンドル rejection を出さない）。
+- `CpuGamePlayer.vue:194`: `checkForbiddenMove(...).isForbidden` を `isForbiddenForBlack(...)` に置換。`renjuRules` からの `checkForbiddenMove` 直 import を撤去。boardStore/watch/cache は触らない。
+
+## テスト
+
+- **#21 パリティ**が TS==WASM(単点) を保証。
+- 新規 `forbiddenAdapter.test.ts`: コーパス局面の全空き点で `isForbiddenForBlack`（wasm）== TS `checkForbiddenMove(...).isForbidden`。フォールバック経路（wasm 未注入時に TS 一致）も検証。
+- 既存テスト緑（CpuGamePlayer 周辺は挙動不変）。
+
+## 検証ゲート
+
+- `pnpm check-fix` / `pnpm test` / `zig build test`（両 wasm 生成）緑。
+- `pnpm build` で `dist/assets/forbidden-*.wasm` が出る。
+- 手動 or e2e: CPU 対戦で黒の禁手マークが従来通り出る。
+
+## リスク
+
+- 起動レース → フォールバック＋ロード後再計算で吸収。
+- 2つ目 wasm のバンドル → dist 確認。
+- 挙動同値 → パリティ＋マップ一致テスト。性能無関係（盤面変更時1回＝1着手1回）。
+
+## バーンダウン（#37）
+
+- CpuGamePlayer の `checkForbiddenMove`（バレル経由）利用を撤去。`forbiddenMoves.ts` 自体はバレル経由で worker/vcfPuzzle が使うため P1 では削除されない（P4）。
+
+## ワークツリー運用
+
+- コミット前: `cd zig && zig build`（両 wasm）＋ `CI=true pnpm install --frozen-lockfile --ignore-scripts`（lefthook用、worktree が main の node_modules link を当 worktree に向ける副作用あり＝worktree 削除時に main で再 install 要）＋ `pnpm check-fix`。
+- ステージは個別ファイル指定（`git add -A` は deny）。

--- a/src/components/cpu/CpuGamePlayer.vue
+++ b/src/components/cpu/CpuGamePlayer.vue
@@ -34,7 +34,7 @@ import { useBoardStore, type Mark } from "@/stores/boardStore";
 import { useDialogStore } from "@/stores/dialogStore";
 import { usePreferencesStore } from "@/stores/preferencesStore";
 import { useAudioStore } from "@/stores/audioStore";
-import { checkForbiddenMove } from "@/logic/renjuRules";
+import { isForbiddenForBlack } from "@/logic/cpu/wasm/forbiddenAdapter";
 import { formatMove } from "@/logic/gameRecordParser";
 import type { BattleResult } from "@/types/cpu";
 import type { Position } from "@/types/game";
@@ -190,14 +190,9 @@ function handlePlaceStone(position: Position): void {
     return;
   }
 
-  // 黒番の場合は禁手チェック
+  // 黒番の場合は禁手チェック（Zig 単一ソースの thin wasm 経由。#37 P1）
   if (cpuGameStore.currentTurn === "black") {
-    const forbidden = checkForbiddenMove(
-      boardStore.board,
-      position.row,
-      position.col,
-    );
-    if (forbidden.isForbidden) {
+    if (isForbiddenForBlack(boardStore.board, position.row, position.col)) {
       // 禁手位置にcrossマークを表示
       showForbiddenMark(position);
       return;

--- a/src/logic/cpu/wasm/forbiddenAdapter.test.ts
+++ b/src/logic/cpu/wasm/forbiddenAdapter.test.ts
@@ -1,0 +1,74 @@
+/**
+ * 禁手アダプタ（#37 P1）のテスト。
+ *
+ * wasm 経由の `isForbiddenForBlack` が、全空き点で TS `checkForbiddenMove(...).isForbidden`
+ * と一致すること（#21 パリティの実利用面での担保）と、wasm 未注入時の TS フォールバックを検証。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createBoardFromRecord } from "@/logic/gameRecordParser";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import {
+  isForbiddenForBlack,
+  preloadForbiddenWasm,
+  setForbiddenWasmForTest,
+} from "./forbiddenAdapter";
+
+// 禁手が絡む代表局面
+const RECORDS = [
+  "H8 H9 I8 G8 I9 I10 F7 G7 G9 H10 F9 J11",
+  "H8 G8 H9 G7 G9 H7 I7 F10 F9 E9 I8 I9 G10 F11 H11 E8 J6 K5 J7 K6 J9 J5 J8 J10 K8 L8 I10 L7 G12",
+];
+
+// wasm を1回ロード（テスト全体で共有）
+await preloadForbiddenWasm();
+
+afterEach(async () => {
+  // 各テスト後に wasm を復帰（fallback テストで未注入にするため）
+  await preloadForbiddenWasm();
+});
+
+describe("forbiddenAdapter (#37 P1)", () => {
+  it.each(RECORDS)("wasm == TS（全空き点・黒）: %s", async (record) => {
+    await preloadForbiddenWasm();
+    const { board } = createBoardFromRecord(record);
+    const mismatches: string[] = [];
+    for (let row = 0; row < 15; row++) {
+      const boardRow = board[row];
+      if (!boardRow) {
+        continue;
+      }
+      for (let col = 0; col < 15; col++) {
+        if (boardRow[col]) {
+          continue;
+        }
+        const wasmResult = isForbiddenForBlack(board, row, col);
+        const tsResult = checkForbiddenMove(board, row, col).isForbidden;
+        if (wasmResult !== tsResult) {
+          mismatches.push(`(${row},${col}): wasm=${wasmResult} ts=${tsResult}`);
+        }
+      }
+    }
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  });
+
+  it("wasm 未ロード時は TS フォールバックする", () => {
+    setForbiddenWasmForTest(undefined);
+    const { board } = createBoardFromRecord(RECORDS[0]!);
+    for (let row = 0; row < 15; row++) {
+      const boardRow = board[row];
+      if (!boardRow) {
+        continue;
+      }
+      for (let col = 0; col < 15; col++) {
+        if (boardRow[col]) {
+          continue;
+        }
+        expect(isForbiddenForBlack(board, row, col)).toBe(
+          checkForbiddenMove(board, row, col).isForbidden,
+        );
+      }
+    }
+  });
+});

--- a/src/logic/cpu/wasm/forbiddenAdapter.ts
+++ b/src/logic/cpu/wasm/forbiddenAdapter.ts
@@ -1,0 +1,68 @@
+/**
+ * メインスレッド用 禁手判定アダプタ（#37 P1）
+ *
+ * 北極星「戦術＝Zig、TS＝プレゼン」の最初の実例。CpuGamePlayer の黒石禁手チェックを
+ * 禁手専用 thin wasm（Zig 単一ソース）経由にする。クリック時に1点だけ判定する。
+ *
+ * wasm 未ロード時は TS `checkForbiddenMove` にフォールバック（#21 パリティで TS==WASM を
+ * 保証済みのため挙動同値・クラッシュ回避）。このフォールバックは移行期の保険であり、
+ * #37 P4 の `forbiddenMoves.ts` 削除時にこの経路も撤去する。
+ */
+import type { BoardState } from "@/types/game";
+
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import {
+  loadForbiddenWasm,
+  type ForbiddenWasmContext,
+} from "./forbiddenLoader";
+import { CELL } from "./types";
+
+let wasm: ForbiddenWasmContext | undefined = undefined;
+
+/** 起動時に1回プリロード（非ブロッキング発火を想定）。 */
+export async function preloadForbiddenWasm(): Promise<void> {
+  if (wasm) {
+    return;
+  }
+  wasm = await loadForbiddenWasm();
+}
+
+/** テスト用: wasm インスタンスを直接注入/解除する。 */
+export function setForbiddenWasmForTest(
+  w: ForbiddenWasmContext | undefined,
+): void {
+  wasm = w;
+}
+
+function syncBoard(w: ForbiddenWasmContext, board: BoardState): void {
+  w.boardInit();
+  for (let row = 0; row < 15; row++) {
+    const boardRow = board[row];
+    if (!boardRow) {
+      continue;
+    }
+    for (let col = 0; col < 15; col++) {
+      const v = boardRow[col];
+      if (v === "black") {
+        w.boardSet(row, col, CELL.BLACK);
+      } else if (v === "white") {
+        w.boardSet(row, col, CELL.WHITE);
+      }
+    }
+  }
+}
+
+/** 黒が (row,col) に打つと禁手か。候補マスは空き前提。 */
+export function isForbiddenForBlack(
+  board: BoardState,
+  row: number,
+  col: number,
+): boolean {
+  if (wasm) {
+    syncBoard(wasm, board);
+    return wasm.checkForbiddenPointWasm(row, col) !== 0;
+  }
+  // フォールバック（wasm 未ロード時）
+  return checkForbiddenMove(board, row, col).isForbidden;
+}

--- a/src/logic/cpu/wasm/forbiddenLoader.ts
+++ b/src/logic/cpu/wasm/forbiddenLoader.ts
@@ -1,0 +1,23 @@
+import { loadWasmBuffer } from "./loader";
+
+/**
+ * 禁手専用 thin wasm（~41KB）のエクスポート（#37 P1）。
+ * メインスレッドが 48MB エンジン wasm を載せずに禁手判定（Zig 単一ソース）を使うための最小面。
+ */
+export interface ForbiddenWasmContext {
+  boardInit: () => void;
+  boardSet: (row: number, col: number, value: number) => void;
+  /** 0=none / 1=overline / 2=double_four / 3=double_three（黒のみ意味を持つ） */
+  checkForbiddenPointWasm: (row: number, col: number) => number;
+}
+
+export async function loadForbiddenWasm(): Promise<ForbiddenWasmContext> {
+  const wasmUrl = new URL(
+    "../../../../zig/zig-out/bin/forbidden.wasm",
+    import.meta.url,
+  );
+  const buffer = await loadWasmBuffer(wasmUrl);
+  // forbidden.wasm は extern import を持たない（freestanding）
+  const { instance } = await WebAssembly.instantiate(buffer, {});
+  return instance.exports as unknown as ForbiddenWasmContext;
+}

--- a/src/logic/cpu/wasm/loader.ts
+++ b/src/logic/cpu/wasm/loader.ts
@@ -1,6 +1,6 @@
 import type { WasmModuleContext } from "./types";
 
-async function loadWasmBuffer(wasmUrl: URL): Promise<ArrayBuffer> {
+export async function loadWasmBuffer(wasmUrl: URL): Promise<ArrayBuffer> {
   // Node.js: use fs.readFileSync + fileURLToPath
   // Browser: use fetch
   if ("process" in globalThis) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { createApp } from "vue";
 import VueKonva from "vue-konva";
 
 import "./style.css";
+import { preloadForbiddenWasm } from "@/logic/cpu/wasm/forbiddenAdapter";
+
 import App from "./App.vue";
 
 const app = createApp(App);
@@ -12,6 +14,12 @@ const pinia = createPinia();
 app.use(pinia);
 app.use(VueKonva);
 app.mount("#app");
+
+// 禁手専用 thin wasm（41KB）を非ブロッキングでプリロード（#37 P1）。
+// 失敗しても isForbiddenForBlack が TS フォールバックするためクラッシュしない。
+preloadForbiddenWasm().catch((e: unknown) => {
+  console.error("禁手 wasm のプリロードに失敗（TS フォールバックで継続）", e);
+});
 
 const updateSW = registerSW({
   onNeedRefresh() {

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -21,6 +21,20 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(lib);
 
+    // 禁手専用 thin wasm（#37 P1。メインスレッド用。forbidden.zig を唯一の真実とする2つ目の出力）
+    const forbidden_module = b.createModule(.{
+        .root_source_file = b.path("src/forbidden_wasm.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseFast,
+    });
+    const forbidden_lib = b.addExecutable(.{
+        .name = "forbidden",
+        .root_module = forbidden_module,
+    });
+    forbidden_lib.entry = .disabled;
+    forbidden_lib.rdynamic = true;
+    b.installArtifact(forbidden_lib);
+
     // Native test step (runs on host, not WASM)
     const native_target = b.resolveTargetQuery(.{});
 

--- a/zig/src/forbidden_wasm.zig
+++ b/zig/src/forbidden_wasm.zig
@@ -1,0 +1,21 @@
+// 禁手専用 thin wasm（Issue #37 P1）
+//
+// メインスレッドが 48MB のエンジン wasm を載せずに「禁手判定（Zig 単一ソース）」を
+// 使うための最小 wasm。`forbidden.zig` を唯一の真実とし、エンジンとは別の
+// コンパイル先として出力する（依存は board.zig + jump_patterns.zig + std のみ ≒ 数十KB）。
+const board = @import("board.zig");
+const forbidden = @import("forbidden.zig");
+
+export fn boardInit() void {
+    board.boardInit();
+}
+
+export fn boardSet(row: u8, col: u8, value: u8) void {
+    board.boardSet(row, col, value);
+}
+
+/// 候補マス（空き想定）に黒が打った場合の禁手種別を返す。
+/// 0=none / 1=overline / 2=double_four / 3=double_three（黒のみ意味を持つ）。
+export fn checkForbiddenPointWasm(row: u8, col: u8) u8 {
+    return @intFromEnum(forbidden.checkForbiddenMove(&board.board_cells, row, col));
+}


### PR DESCRIPTION
## 概要

#37 P1。北極星「**戦術=Zig, TS=プレゼン**」の最初の実例。CpuGamePlayer の黒石禁手チェックを、`forbidden.zig` を唯一の真実とする **41KB 禁手専用 thin wasm** 経由に移行する。

## 設計（レビュー反映）

- **禁手マップ/キャッシュは撤回し単点判定**に。CpuGamePlayer はクリック時に1点だけ判定すれば足り、`checkForbiddenMove`（=単点 wasm）はその点を達四点再帰込みで完全に正しく判定する。マップ＋boardStore watch は YAGNI（proactive 表示や P2 の多点文脈で初めて要る。その際の影響範囲は「着手筋＋達四点再帰の近傍」）。

## 変更

- **zig**: `forbidden_wasm.zig`（forbidden.zig の2つ目のコンパイル先）＋ `build.zig` に `forbidden.wasm` ターゲット追加。**実測 41KB**（エンジン 48MB をメインに載せない）。
- **wasm 層**: `forbiddenLoader`（`loader.ts` の `loadWasmBuffer` を共通化・DRY）＋ `forbiddenAdapter`（`isForbiddenForBlack`: 盤面同期→`checkForbiddenPointWasm`。**未ロード時は TS `checkForbiddenMove` にフォールバック**＝#21 パリティで挙動同値・クラッシュ回避）。
- **main.ts**: 起動時に非ブロッキングでプリロード。
- **CpuGamePlayer**: `checkForbiddenMove` 直呼びを `isForbiddenForBlack` に置換。`renjuRules` 直 import 撤去。

## 検証

- #21 パリティ＋新規 `forbiddenAdapter.test.ts` で **wasm == TS を全空き点検証**＋フォールバック経路。
- `check-fix` / `pnpm test`(1757) / `zig build test` 緑。挙動・強度不変。

## バーンダウン / 後続

- `forbiddenMoves.ts` はバレル経由で worker・vcfPuzzle がまだ使うため削除は **P4**（その際フォールバック経路も撤去）。
- メインスレッドの残り（vcfPuzzle）は **P2 #41**。

## 関連
- 親 #37 / P1 #40
