### PR TITLE
test(review): P3安全網としてreview戦術プリミティブ出力を凍結 (#42 P0)

### DIFF
--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -1,0 +1,111 @@
+# #37 P3 (#42) — review 戦術解析を Zig 構造化 API へ移行
+
+親: #37 ／ 依存: P0(#44 スナップショット) ／ 前段: P1(#45 メイン禁手Zig化), P2(#46 vcfPuzzle禁手Zig化) マージ済。
+
+多エージェント設計（理解5→敵対検証2→設計パネル3→統合1）で策定。ボス合意: 2026-06-07。
+
+## 北極星（#37 全体）
+
+review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン＋ワークフロー」に徹する。副作用で `patterns.ts`/`forbiddenMoves.ts` が削除可能になる（P4 #43）。
+
+## 統合方針
+
+出力契約を先に凍結（安全網）→ Zig オラクル正確化 → thin wasm の橋を**無接続で**敷設 → 利用点を**葉から1ファイル単位**で張替（各PR revert 容易）。
+
+## 確定した技術判断（敵対検証で固めた）
+
+1. **真の橋は `vct.classifyThreat`（`zig/src/vct.zig:48`、pub、黒長連除外を内包、TS `threatMoves.ts:135 classifyThreat` と 1:1 構造一致）。**
+   - `main.zig:59 classifyPointWasm` は**使わない**: 生パターンビットで `isJumpFourOverline`/`checkEndsForFour` の黒長連除外を欠き、TS `createsFour`/`createsOpenThree` と**非同値**。そのまま OR すると黒の四・跳び四判定がズレる。
+   - `classifyPointWasm` は #21 パリティ用オラクルとして維持・正確化（PR1）。
+2. **thin wasm は `board_cells` 同期に加え `bitboard.initFromCells` 同期が必須**（P1 `forbidden_wasm` との唯一の構造差）。`vct.classifyThreat` が `ll.queryPatternByCell` 経由で `bitboard.global_bb` に依存するため。
+3. **API 粒度＝小 export 群**（`classifyThreat` / `detectOpponentThreats` / 各ヘルパー）。`analyzePositionForReview` 一本化はしない: detectForcedWin/checkForcedLoss の段取り（AND-OR木合成・isForbiddenTrap・needsVCTCheck フェーズ協調）が worker の Phase 1/2/3 分割と密結合で、一本化すると 1PR 巨大化＋二分切り分け不能。段取りは TS に残し、中の戦術判定だけ Zig。
+4. **thin wasm 新設**（`threat_wasm.zig`）: vcfPuzzle がメインスレッド実行で engine wasm を持たない（`createsFour` を TS 直呼び、禁手のみ P2 thin wasm）ことを確認済 → 橋には thin wasm が必須。
+5. **評価関数（`evaluatePositionWithBreakdown`/`evaluateBoardWithBreakdown`）は P3 から除外**（ボス合意）。これらは評価関数(#22領域)依存で review-live かつ main-search-live＝棋力レグレッションが別階層。別 issue で扱う。
+6. **列挙順序は座標ソートで順序非依存化**（ボス合意）: 防御位置・`findThreatMoves`・ThreatInfo 各リストは snapshot/利用側で座標昇順正規化。ただし `forcedWin.sequence` のように順序が探索結果に意味を持つ箇所は個別に TS/Zig 完全一致を要する。
+
+## /review 反映（3観点LGTM・2026-06-07）
+
+- **PR2 盤面同期キャッシュ必須**: forbiddenAdapter の無条件 `boardInit` を `syncBoardIfChanged`（盤面ハッシュ比較で再同期スキップ）または差分同期に upgrade。`createsFour` 単点でも毎回 `bitboard.initFromCells` 全盤再構築になるため、盤面全走査で呼ぶ利用点があると O(225²)。adapter 新設時から組込む。
+- **threatAdapter は `classifyThreat` 一括 API を基本**: `classifyThreat(board,r,c,color)→{createsFour,createsOpenThree}`（wasm の `classifyThreatWasm` が bit0/bit1 を返す）。candidateVerification が four/openThree を両方呼ぶ→往復1回に削減。`createsFour`/`createsOpenThree` は内部で一括を呼ぶ薄いラッパとして提供。
+- **PR4 は PR5/PR6 の前提**（並行不可）: `PR0→PR1→PR2→PR3→PR4→{PR5, PR6}→PR7`。PR5(Mise)/PR6(VCT) は PR4 の Zig-side detectOpponentThreats を前提にする。
+- **thin wasm テンプレ化**: `build.zig` に「3つ目以降の thin wasm 追加チェックリスト」を JSDoc で明記（依存を board+次数1モジュールに限定、`bitboard.initFromCells` 要否の判定）。`threatLoader` は `loader.ts:loadWasmBuffer` を再利用（DRY）。
+- イシュー観点: 土台主張6点すべて検証「正」（橋=vct.classifyThreat / bitboard同期必須 / sequence非ソート / PR0凍結漏れなし / PR1=#21オラクル目的 / patterns.ts見落としなし）。
+
+## ゲート（毎PR）
+
+- #21 `renjuParity.test.ts` 緑（TS==Zig）
+- P0 `reviewSnapshot.test.ts` が1ビットも変わらない
+- `pnpm check-fix` 緑、`cd zig && zig build` 緑
+
+## PR 列
+
+### PR0 — reviewSnapshot を P3 移植対象の戦術プリミティブまで拡張（安全網のみ・ロジック不変）【最初のPR・実装済】
+
+- **実装方針の改善（着手時に確定）**: 当初案は非決定的な `executeFullEval` 出力（candidates[]）を凍結する想定だったが、実装時に判明 — **P3 が移植する関数の大半（`detectOpponentThreats`/`findDoubleMiseMoves`/`hasOpenThree`/`hasFourThreeAvailable`/`createsFour` 等）は時間非依存の純粋関数で完全決定的**。時間依存は VCF/VCT 探索のみで、それは `checkCandidateForcedLoss` に `timeLimit=Infinity`（node-bound）で凍結可能。よって **`executeFullEval` の wall-clock 経路を避け、P3 が実際に置き換える関数を直接凍結**する方が堅牢かつ的確（`candidates[].opponentForcedWin` 等の出力は元々これら関数が算出するため、SSoT 的にも正しい）。`verifyCandidates` は `performance.now()` 配分で非決定なので凍結対象にしない（その戦術核 `checkCandidateForcedLoss` を凍結）。
+- **Zigに移す**: なし
+- **触る**: `src/logic/cpu/review/reviewSnapshot.test.ts`（新 describe ブロック追加）、`src/logic/cpu/review/candidateVerification.ts`（`annotateFukumiMoves` に optional `vcfOptions` フック追加、本番デフォルト=`REVIEW_VCF_OPTIONS` で挙動不変）
+- **凍結する関数（→対応PR）**: `detectOpponentThreats`両色（PR4）／`findDoubleMiseMoves`両色（PR5）／`hasOpenThree`+`hasFourThreeAvailable`両色（PR6）／`checkCandidateForcedLoss`（PR3/PR4 被必勝層、Infinity options）／`annotateFukumiMoves`（PR3 の createsFour/createsOpenThree を使う isFukumi/fukumiDepth、Infinity options）
+- **正規化**: ThreatInfo の5リスト・両ミセ手は座標昇順ソート（探索順非依存）。被必勝は {type, sequence}。
+- **決定性検証**: 3回連続実行で snapshot 完全一致を確認済。コーパスは既存 P0 の forcing 局面（mise-vcf-#18 / white29-m20 / white29-m24）を流用。白29で `isFukumi:true/fukumiDepth:3`・`type:"vcf"` 被必勝列など実データを捕捉。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / review+parity 145 tests 緑（parity は wasm 再ビルド後）。
+
+### PR1 — `classifyPointWasm` 黒長連対応＋パリティ拡張（Zig only・本番未接続）
+
+- **Zigに移す**: `classifyPointWasm` の four/jumpFour ビットに黒限定 overline 除外を組込。`vct.zig` の `isJumpFourOverline`/`isOverlineEnd` を pub 化して再利用
+- **触る**: `zig/src/main.zig`、`zig/src/vct.zig`(pub化)、`src/logic/renjuRules/renjuParity.test.ts`（Test A=黒跳び四overline / Test B=黒4連の先に黒石(checkEndsForFour) を追加、現状RED→Zig修正でGREEN）
+- **利用点削減**: ±0（#21 オラクル正確化のみ）
+- 目的は「本番で使うため」でなく **#21 オラクルの正確性向上**。橋本体は PR2。
+
+### PR2 — threat 専用 thin wasm + adapter を新設（橋だけ・利用者ゼロ）
+
+- **Zigに移す**: 新規 `zig/src/threat_wasm.zig`(thin)。export: `boardInit`/`boardSet`/`syncBitboard`(=`bitboard.initFromCells`) + `classifyThreatWasm(row,col,color)->u8`（bit0=four, bit1=openThree、内部で `vct.classifyThreat`）。依存を board+jump_patterns+threats+vct に限定
+- **触る**: `zig/src/threat_wasm.zig`(新)、`zig/build.zig`(3つ目の thin wasm target, forbidden 同型)、`src/logic/cpu/wasm/threatLoader.ts`(新)、`src/logic/cpu/wasm/threatAdapter.ts`(新, `createsFour`/`createsOpenThree` 委譲・未ロード時TSフォールバック)、`threatAdapter.test.ts`(新)
+- **安全網**: `threatAdapter.test.ts`（wasm == TS を全コーパス照合、**黒長連ケース必須**）。`bitboard.initFromCells` 忘れがパリティで即露見
+- **実装者向け注意**: classifyPointWasm を使わない旨をコメント明記
+
+### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）
+
+- **触る**: `src/logic/cpu/review/candidateVerification.ts`、`src/logic/vcfPuzzle.ts`。import を threatAdapter に差替（各ファイル独立コミット可）
+- **利用点削減**: **−2**（review-live と puzzle-live を同時に救う）
+- **安全網**: PR0拡張 reviewSnapshot + threatAdapter.test + renjuParity
+- `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）
+
+### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）
+
+- **Zigに移す**: `threats.detectOpponentThreats`(既存) を threat_wasm に export、ThreatInfo を wire 化（`forced_win_tree` の wire が前例）
+- **触る**: `zig/src/threat_wasm.zig`、`threatAdapter.ts`、`src/logic/cpu/review/fullEval.ts`、`forcedLossCheck.ts`。**main search の `moveOrdering.ts` は別系統＝触らない**（`detectOpponentThreatsFast` との混同注意）
+- **利用点削減**: **−3**
+- **安全網**: PR0拡張 reviewSnapshot + adapter test に ThreatInfo 全フィールド照合（各リスト座標ソート）
+
+### PR5 — Mise系（`createsFourThree`/`findMiseTargets`/`findDoubleMiseMoves`）差分検証→委譲
+
+- **Zigに移す**: `evaluate.createsFourThree`(既存)、`mise_vcf.findMiseTargetsLite`。**フル版 `findMiseTargets`(±2近傍走査) が Lite で足りるかの差分検証が前提**（不一致ならフル版 Zig 新規実装に分岐）
+- **触る**: `threat_wasm.zig`、`threatAdapter.ts`、`review/fullEval.ts`、`forcedWinDetection.ts`、`forcedLossCheck.ts`、`doubleMiseBranches.ts`
+- **利用点削減**: **−3〜4**（forbiddenMoves.ts 依存が外れる）
+- **リスク**: 高。先に差分 test で可視化してから実装。
+
+### PR6 — VCT安全性ヘルパー（`hasFourThreeAvailable`/`hasOpenThree`/`findThreatMoves`）委譲
+
+- **Zigに移す**: 盤面全走査版（per-direction 部品 `vct.classifyThreat`/`createsOpenThree` は既存、統合ループを Zig に）
+- **触る**: `threat_wasm.zig`、`threatAdapter.ts`、`forcedLossCheck.ts`(isMiseVCTSafe)、`forcedWinDetection.ts`
+- **利用点削減**: **−3〜4**
+- **リスク**: `findThreatMoves` の列挙順序が VCT 探索順に影響し `forcedWin.sequence` を変える恐れ → 座標昇順正規化、ただし sequence が意味を持つ箇所は完全一致
+
+### PR7 — 削除可否の棚卸し（P4 #43 への前置き・調査PR）
+
+- review path 直接利用ゼロを grep 証明。dead 確認済（`countThreatDirections`/`hasDefenseThatBlocksBoth`）は削除候補に印
+- **報告**: 物理削除（P4）は **main search（moveOrdering/threatDetectionFast）の Zig 化**に依存（P3 スコープ外の可能性大）
+
+## P4 への距離（利用点の減り方）
+
+PR3→PR6 で **review path の patterns.ts/forbiddenMoves.ts 直接利用がゼロ**。物理削除は main search の Zig 化に依存する点を PR7 で確定報告。
+
+## load-bearing な参照箇所
+
+- `zig/src/vct.zig:48 classifyThreat`（真の橋）、`vct.zig` の `isJumpFourOverline`/`isOverlineEnd`
+- `zig/src/main.zig:59 classifyPointWasm`（橋に使わない。PR1 で #21 オラクルとしてのみ正確化）
+- `src/logic/cpu/search/threatMoves.ts:27 createsFour` / `:82 createsOpenThree` / `:213 isJumpFourOverline`
+- `src/logic/cpu/core/lineAnalysis.ts checkEndsForFour`（黒長連端の無効化）
+- `src/logic/cpu/wasm/forbiddenAdapter.ts` / `zig/src/forbidden_wasm.zig` / `zig/build.zig`（PR2 のテンプレ、唯一差は `bitboard.initFromCells`）
+- `src/logic/cpu/review/reviewSnapshot.test.ts`（PR0 拡張対象）
+- `src/logic/cpu/review/fullEval.ts` / `forcedLossCheck.ts`（PR4 の detectOpponentThreats 利用点）

--- a/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
+++ b/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
@@ -1,5 +1,276 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > annotateFukumiMoves: 'mise-vcf-#18' 1`] = `[]`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > annotateFukumiMoves: 'white29-m20' 1`] = `
+[
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 9,
+      "row": 6,
+    },
+  },
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 9,
+      "row": 7,
+    },
+  },
+  {
+    "fukumiDepth": 3,
+    "isFukumi": true,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > annotateFukumiMoves: 'white29-m24' 1`] = `
+[
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 8,
+      "row": 5,
+    },
+  },
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 6,
+      "row": 3,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > checkCandidateForcedLoss: 'mise-vcf-#18' 1`] = `[]`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > checkCandidateForcedLoss: 'white29-m20' 1`] = `
+[
+  {
+    "loss": null,
+    "position": {
+      "col": 9,
+      "row": 6,
+    },
+  },
+  {
+    "loss": null,
+    "position": {
+      "col": 9,
+      "row": 7,
+    },
+  },
+  {
+    "loss": null,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > checkCandidateForcedLoss: 'white29-m24' 1`] = `
+[
+  {
+    "loss": null,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+  {
+    "loss": {
+      "sequence": [
+        {
+          "col": 10,
+          "row": 11,
+        },
+        {
+          "col": 8,
+          "row": 9,
+        },
+        {
+          "col": 10,
+          "row": 8,
+        },
+      ],
+      "type": "vcf",
+    },
+    "position": {
+      "col": 8,
+      "row": 5,
+    },
+  },
+  {
+    "loss": {
+      "sequence": [
+        {
+          "col": 10,
+          "row": 11,
+        },
+        {
+          "col": 8,
+          "row": 9,
+        },
+        {
+          "col": 10,
+          "row": 8,
+        },
+      ],
+      "type": "vcf",
+    },
+    "position": {
+      "col": 6,
+      "row": 3,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > counterThreatGuards: 'mise-vcf-#18' 1`] = `
+{
+  "hasFourThreeOpponent": false,
+  "hasFourThreeSelf": false,
+  "hasOpenThreeOpponent": false,
+  "hasOpenThreeSelf": false,
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > counterThreatGuards: 'white29-m20' 1`] = `
+{
+  "hasFourThreeOpponent": false,
+  "hasFourThreeSelf": false,
+  "hasOpenThreeOpponent": false,
+  "hasOpenThreeSelf": false,
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > counterThreatGuards: 'white29-m24' 1`] = `
+{
+  "hasFourThreeOpponent": true,
+  "hasFourThreeSelf": true,
+  "hasOpenThreeOpponent": false,
+  "hasOpenThreeSelf": false,
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > detectOpponentThreats: 'mise-vcf-#18' 1`] = `
+{
+  "opponent": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+  "self": {
+    "doubleThrees": [
+      {
+        "col": 8,
+        "row": 11,
+      },
+    ],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > detectOpponentThreats: 'white29-m20' 1`] = `
+{
+  "opponent": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+  "self": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > detectOpponentThreats: 'white29-m24' 1`] = `
+{
+  "opponent": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [
+      {
+        "col": 10,
+        "row": 11,
+      },
+    ],
+    "openFours": [],
+    "openThrees": [],
+  },
+  "self": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [
+      {
+        "col": 10,
+        "row": 7,
+      },
+    ],
+    "openFours": [],
+    "openThrees": [],
+  },
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > findDoubleMiseMoves: 'mise-vcf-#18' 1`] = `
+{
+  "opponent": [],
+  "self": [],
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > findDoubleMiseMoves: 'white29-m20' 1`] = `
+{
+  "opponent": [],
+  "self": [],
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > findDoubleMiseMoves: 'white29-m24' 1`] = `
+{
+  "opponent": [
+    {
+      "col": 5,
+      "row": 7,
+    },
+  ],
+  "self": [],
+}
+`;
+
 exports[`review 戦術出力スナップショット (#37 P0) > checkForcedLoss: 'mise-vcf-#18' 1`] = `
 {
   "sequence": [

--- a/src/logic/cpu/review/candidateVerification.ts
+++ b/src/logic/cpu/review/candidateVerification.ts
@@ -7,6 +7,7 @@
 import type { BoardState } from "@/types/game";
 import type { ForcedLossResult, ReviewCandidate } from "@/types/review";
 
+import type { VCFSearchOptions } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { createsFour, createsOpenThree } from "../search/threatMoves";
@@ -145,13 +146,15 @@ export function annotateFukumiMoves(
   board: BoardState,
   color: "black" | "white",
   wasmSearchEngine: WasmSearchEngine,
+  // テスト時に timeLimit=Infinity を注入し決定的にするためのフック（本番は既定値）。
+  vcfOptions: VCFSearchOptions = REVIEW_VCF_OPTIONS,
 ): void {
   // 置く前にVCFがあるならフクミ手は存在しない（既に強制勝ち局面）
   const existingVcf = wasmFindVCFSequence(
     wasmSearchEngine,
     board,
     color,
-    REVIEW_VCF_OPTIONS,
+    vcfOptions,
   );
   if (existingVcf) {
     return;
@@ -179,7 +182,7 @@ export function annotateFukumiMoves(
         wasmSearchEngine,
         board,
         color,
-        REVIEW_VCF_OPTIONS,
+        vcfOptions,
       );
       if (vcfResult) {
         cand.isFukumi = true;

--- a/src/logic/cpu/review/reviewSnapshot.test.ts
+++ b/src/logic/cpu/review/reviewSnapshot.test.ts
@@ -22,13 +22,20 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { ForcedWinNode } from "@/types/review";
+import type { BoardState, Position } from "@/types/game";
+import type { ForcedWinNode, ReviewCandidate } from "@/types/review";
 
 import { loadWasmModule } from "@/logic/cpu/wasm/loader";
 import { WasmSearchEngine } from "@/logic/cpu/wasm/searchEngine";
 import { createBoardFromRecord } from "@/logic/gameRecordParser";
 
+import { countStones } from "../core/boardUtils";
+import { detectOpponentThreats } from "../evaluation";
+import { findDoubleMiseMoves } from "../evaluation/tactics";
+import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
+import { annotateFukumiMoves } from "./candidateVerification";
 import {
+  checkCandidateForcedLoss,
   checkForcedLoss,
   FORCED_LOSS_VCT_OPTIONS,
   REVIEW_MISE_VCF_OPTIONS,
@@ -70,10 +77,65 @@ const CORPUS: { name: string; record: string; moveCount: number }[] = [
   },
 ];
 
+/** 決定的な候補手検証オプション（被必勝層を timeLimit=Infinity で node-bound 化） */
+const DETERMINISTIC_CANDIDATE_OPTIONS: ForcedLossCheckOptions = {
+  vcfOptions: { ...REVIEW_VCF_OPTIONS, timeLimit: Infinity },
+  miseVcfOptions: { ...REVIEW_MISE_VCF_OPTIONS, timeLimit: Infinity },
+  vctOptions: { ...FORCED_LOSS_VCT_OPTIONS, timeLimit: Infinity },
+};
+
 const sortPos = (
   a: { row: number; col: number },
   b: { row: number; col: number },
 ): number => a.row - b.row || a.col - b.col;
+
+/** 棋譜の1手（例 "H8"）を盤面座標へ変換（左下原点。fullEval と同じ規約） */
+function parseMove(token: string): Position {
+  const col = token.charCodeAt(0) - "A".charCodeAt(0);
+  const row = 15 - parseInt(token.slice(1), 10);
+  return { row, col };
+}
+
+/** ThreatInfo の全リストを座標昇順に正規化（探索順非依存化） */
+function normalizeThreatInfo(t: {
+  openFours: Position[];
+  fours: Position[];
+  openThrees: Position[];
+  mises: Position[];
+  doubleThrees: Position[];
+}): unknown {
+  return {
+    openFours: [...t.openFours].sort(sortPos),
+    fours: [...t.fours].sort(sortPos),
+    openThrees: [...t.openThrees].sort(sortPos),
+    mises: [...t.mises].sort(sortPos),
+    doubleThrees: [...t.doubleThrees].sort(sortPos),
+  };
+}
+
+/**
+ * 棋譜の moveCount 以降から `color` の着手候補を最大3点抽出する。
+ * board（moveCount 手前の局面）で空きのものだけを返す（決定的）。
+ */
+function candidatePositions(
+  board: BoardState,
+  moves: string[],
+  moveCount: number,
+): Position[] {
+  const result: Position[] = [];
+  // moveCount, +2, +4 は同色（color）の着手
+  for (const offset of [0, 2, 4]) {
+    const token = moves[moveCount + offset];
+    if (!token) {
+      continue;
+    }
+    const pos = parseMove(token);
+    if (board[pos.row]?.[pos.col] === null) {
+      result.push(pos);
+    }
+  }
+  return result;
+}
 
 /** 詰み木を分岐順非依存に正規化（defenses を defenderMove 座標でソート） */
 function normalizeTree(node: ForcedWinNode): unknown {
@@ -124,5 +186,106 @@ describe("review 戦術出力スナップショット (#37 P0)", () => {
       DETERMINISTIC_LOSS_OPTIONS,
     );
     expect(result ?? null).toMatchSnapshot();
+  });
+});
+
+/**
+ * P3 #42 で Zig へ移す戦術ヘルパーの**直接出力**を凍結する安全網。
+ *
+ * detectForcedWin / checkForcedLoss は上の describe が top-level（type/sequence）で凍結済だが、
+ * P3 の各 PR が置き換えるのは中の戦術プリミティブ（脅威検出・両ミセ・活三/四三・被必勝層）。
+ * これらは VCF/VCT と違い**時間非依存の純粋関数**（または timeLimit=Infinity で node-bound 化
+ * できる被必勝層）なので、ここで直接凍結すれば各移行 PR の「1ビット不変」を細粒度で検知できる。
+ *
+ * 対応する P3 PR:
+ *   detectOpponentThreats        → PR4（fullEval / forcedLossCheck の脅威検出）
+ *   findDoubleMiseMoves          → PR5（両ミセ）
+ *   hasOpenThree/hasFourThree    → PR6（filterByCounterThreats / VCT 安全性）
+ *   checkCandidateForcedLoss     → PR3/PR4（候補手の被必勝＝opponentForcedWin の出所）
+ *   annotateFukumiMoves          → PR3（createsFour/createsOpenThree を使う isFukumi 判定）
+ */
+describe("review 戦術プリミティブ出力スナップショット (#37 P3 安全網)", () => {
+  it.each(CORPUS)("detectOpponentThreats: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const opponentColor = nextColor === "black" ? "white" : "black";
+    const snapshot = {
+      // 手番側の脅威（fullEval の selfThreats 経路 / 着手後の自分の四判定）
+      self: normalizeThreatInfo(detectOpponentThreats(board, nextColor)),
+      // 相手の脅威（fullEval L385 / forcedLossCheck L324 の経路）
+      opponent: normalizeThreatInfo(
+        detectOpponentThreats(board, opponentColor),
+      ),
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it.each(CORPUS)("findDoubleMiseMoves: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const opponentColor = nextColor === "black" ? "white" : "black";
+    const snapshot = {
+      self: [...findDoubleMiseMoves(board, nextColor)].sort(sortPos),
+      opponent: [...findDoubleMiseMoves(board, opponentColor)].sort(sortPos),
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it.each(CORPUS)("counterThreatGuards: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const opponentColor = nextColor === "black" ? "white" : "black";
+    const snapshot = {
+      hasOpenThreeSelf: hasOpenThree(board, nextColor),
+      hasOpenThreeOpponent: hasOpenThree(board, opponentColor),
+      hasFourThreeSelf: hasFourThreeAvailable(board, nextColor),
+      hasFourThreeOpponent: hasFourThreeAvailable(board, opponentColor),
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it.each(CORPUS)(
+    "checkCandidateForcedLoss: $name",
+    ({ record, moveCount }) => {
+      const { board, nextColor } = createBoardFromRecord(record, moveCount);
+      const opponentColor = nextColor === "black" ? "white" : "black";
+      const moves = record.trim().split(/\s+/);
+      const stoneCount = countStones(board);
+      // moveCount 以降の手番側着手を候補に、被必勝（opponentForcedWin 相当）を凍結
+      const snapshot = candidatePositions(board, moves, moveCount).map(
+        (pos) => ({
+          position: pos,
+          loss:
+            checkCandidateForcedLoss(
+              board,
+              pos,
+              nextColor,
+              opponentColor,
+              stoneCount,
+              engine,
+              DETERMINISTIC_CANDIDATE_OPTIONS,
+            ) ?? null,
+        }),
+      );
+      expect(snapshot).toMatchSnapshot();
+    },
+  );
+
+  it.each(CORPUS)("annotateFukumiMoves: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const moves = record.trim().split(/\s+/);
+    const candidates: ReviewCandidate[] = candidatePositions(
+      board,
+      moves,
+      moveCount,
+    ).map((position) => ({ position, score: 0, searchScore: 0 }));
+    // timeLimit=Infinity を注入して node-bound 決定化
+    annotateFukumiMoves(candidates, board, nextColor, engine, {
+      ...REVIEW_VCF_OPTIONS,
+      timeLimit: Infinity,
+    });
+    const snapshot = candidates.map((c) => ({
+      position: c.position,
+      isFukumi: c.isFukumi ?? false,
+      fukumiDepth: c.fukumiDepth ?? null,
+    }));
+    expect(snapshot).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## 概要
#37 P3（#42）の最初のPR。P3でZigへ移植する review 戦術ヘルパーの出力を `reviewSnapshot.test.ts` に**直接凍結**し、各移行PR（PR1〜）が「1ビットも変えない」ことを細粒度で機械検知できる安全網を敷く。**ロジック不変・テスト追加のみ**。

## 設計方針（着手時の改善）
当初は非決定的な `executeFullEval` 出力（candidates[]）を凍結する想定だったが、実装時に判明 — **P3が移植する関数の大半（`detectOpponentThreats`/`findDoubleMiseMoves`/`hasOpenThree`/`hasFourThreeAvailable`/`createsFour` 等）は時間非依存の純粋関数で完全決定的**。時間依存は VCF/VCT 探索のみで、それは `timeLimit=Infinity`（node-bound）で凍結可能。よって **`executeFullEval` の wall-clock 経路を避け、P3が実際に置き換える関数を直接凍結**する方が堅牢かつ的確（`candidates[].opponentForcedWin` 等の出力は元々これら関数が算出するため SSoT 的にも正しい）。

## 凍結する関数（→対応する後続PR）
- `detectOpponentThreats` 両色 → PR4
- `findDoubleMiseMoves` 両色 → PR5
- `hasOpenThree` + `hasFourThreeAvailable` 両色 → PR6
- `checkCandidateForcedLoss`（Infinity options）→ PR3/PR4（被必勝＝`opponentForcedWin` の出所）
- `annotateFukumiMoves`（Infinity options）→ PR3（createsFour/createsOpenThree を使う isFukumi/fukumiDepth）

## 変更
- `reviewSnapshot.test.ts`: 新 describe ブロック追加。ThreatInfo 5リスト・両ミセは座標昇順正規化、被必勝は {type,sequence}。
- `candidateVerification.ts`: `annotateFukumiMoves` に optional `vcfOptions` フック追加（**本番デフォルト=`REVIEW_VCF_OPTIONS` で挙動不変**）。

## 決定性・ゲート
- snapshot を**3回連続実行で完全一致**を確認。白29で `isFukumi:true/fukumiDepth:3`・`type:"vcf"` 被必勝列など実データを捕捉。
- vue-tsc 0 / oxlint 0 / unit 1772 tests 緑 / zig build test 緑。

設計・分解の全体像（PR0〜PR7）は `docs/plans/issue-37-p3-review-zig.md` を参照。

関連: #37 (親) / #42 (P3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)