### PR TITLE
[P3 3/5] feat(cpu): createsFour/OpenThree 利用点を threatAdapter へ張替（−2）

### DIFF
--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -64,12 +64,14 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **利用者ゼロ**: 起動時 preload（main.ts）は **PR3 で配線**（PR2 は adapter 未呼び出し＝完全 no-op）。PR3 で preloadThreatWasm を忘れると TS フォールバックのまま（正しさは不変だが Zig 未使用）になる点に注意。
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1799 tests 緑。
 
-### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）
+### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）【実装済】
 
-- **触る**: `src/logic/cpu/review/candidateVerification.ts`、`src/logic/vcfPuzzle.ts`。import を threatAdapter に差替（各ファイル独立コミット可）
-- **利用点削減**: **−2**（review-live と puzzle-live を同時に救う）
-- **安全網**: PR0拡張 reviewSnapshot + threatAdapter.test + renjuParity
-- `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）
+- **触る**: `candidateVerification.ts`（annotateFukumiMoves）/ `vcfPuzzle.ts`（L96 四判定）の import を threatAdapter へ差替。**preload 配線**: `main.ts`（vcfPuzzle 用・非ブロッキング）/ `review.worker.ts`（getWasmModule 内で await＝candidateVerification 実行前にロード）。
+- **利用点削減**: **−2**（candidateVerification + vcfPuzzle が threatMoves→patterns.ts を踏まなくなった。grep で直接 import 消滅を確認）
+- **preload 必須**: 未 preload だと TS フォールバックのまま＝Zig 未使用。両コンテキストで preloadThreatWasm を配線済。失敗時は TS フォールバックでクラッシュ回避。
+- **安全網**: reviewSnapshot **バイト不変**（test は preload せず TS フォールバック＝同値）/ threatAdapter.test（wasm==TS）/ renjuParity / vcfPuzzle.test 15 緑。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / unit 1799 緑。
+- `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）。残る createsFour 利用点（threatPatterns/vcfCheck/vctValidation/search index export）は PR4+ 対象。
 
 ### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）
 

--- a/src/logic/cpu/review.worker.ts
+++ b/src/logic/cpu/review.worker.ts
@@ -29,6 +29,7 @@ import { wasmFindVCTSequence } from "./review/wasmAdapters";
 import { VCT_STONE_THRESHOLD } from "./search/types";
 import { loadWasmModule } from "./wasm/loader";
 import { WasmSearchEngine } from "./wasm/searchEngine";
+import { preloadThreatWasm } from "./wasm/threatAdapter";
 
 /** WASM モジュール（初回ロード後にキャッシュ） */
 let cachedWasm: WasmModuleContext | null = null;
@@ -37,7 +38,10 @@ async function getWasmModule(): Promise<WasmModuleContext> {
   if (cachedWasm) {
     return cachedWasm;
   }
+  // #37 P3 PR3: 脅威分類 thin wasm も同時にロード（candidateVerification の四/活三判定用）。
+  // 未ロード時は threatAdapter が TS フォールバックするため、失敗してもクラッシュしない。
   cachedWasm = await loadWasmModule();
+  await preloadThreatWasm();
   return cachedWasm;
 }
 

--- a/src/logic/cpu/review/candidateVerification.ts
+++ b/src/logic/cpu/review/candidateVerification.ts
@@ -10,7 +10,9 @@ import type { ForcedLossResult, ReviewCandidate } from "@/types/review";
 import type { VCFSearchOptions } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { createsFour, createsOpenThree } from "../search/threatMoves";
+// #37 P3 PR3: 四/活三判定を Zig 単一ソース(vct.classifyThreat)経由に。
+// wasm 未ロード時は threatAdapter 内で TS createsFour/createsOpenThree にフォールバック。
+import { createsFour, createsOpenThree } from "../wasm/threatAdapter";
 import {
   checkCandidateForcedLoss,
   CANDIDATE_VERIFY_VCF_OPTIONS,

--- a/src/logic/vcfPuzzle.ts
+++ b/src/logic/vcfPuzzle.ts
@@ -6,12 +6,14 @@
 
 import type { BoardState, Position } from "@/types/game";
 
-import { createsFour } from "@/logic/cpu/search/threatMoves";
 import {
   findWinningMove,
   getFourDefensePosition,
 } from "@/logic/cpu/search/threatPatterns";
 import { isForbiddenForBlack } from "@/logic/cpu/wasm/forbiddenAdapter";
+// #37 P3 PR3: 四判定を Zig 単一ソース(vct.classifyThreat)経由に（禁手は P2 で Zig 化済）。
+// wasm 未ロード時は threatAdapter 内で TS createsFour にフォールバック。
+import { createsFour } from "@/logic/cpu/wasm/threatAdapter";
 import { checkFive } from "@/logic/renjuRules/core";
 
 const BOARD_SIZE = 15;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import VueKonva from "vue-konva";
 
 import "./style.css";
 import { preloadForbiddenWasm } from "@/logic/cpu/wasm/forbiddenAdapter";
+import { preloadThreatWasm } from "@/logic/cpu/wasm/threatAdapter";
 
 import App from "./App.vue";
 
@@ -19,6 +20,12 @@ app.mount("#app");
 // 失敗しても isForbiddenForBlack が TS フォールバックするためクラッシュしない。
 preloadForbiddenWasm().catch((e: unknown) => {
   console.error("禁手 wasm のプリロードに失敗（TS フォールバックで継続）", e);
+});
+
+// 脅威分類 thin wasm（28KB）を非ブロッキングでプリロード（#37 P3。vcfPuzzle の四判定用）。
+// 失敗しても createsFour が TS フォールバックするためクラッシュしない。
+preloadThreatWasm().catch((e: unknown) => {
+  console.error("脅威 wasm のプリロードに失敗（TS フォールバックで継続）", e);
 });
 
 const updateSW = registerSW({


### PR DESCRIPTION
candidateVerification/vcfPuzzle の createsFour/createsOpenThree を threatAdapter 経由(Zig)に。preload 配線(main.ts/review.worker.ts)。patterns.ts 利用点 −2。reviewSnapshot バイト不変。

---
⚠️ **stacked PR（#42 P3）**。下から順にレビュー＋**動作確認**してマージしてください。自動マージはしません。
スタック順: p3-1 → p3-2 → p3-3 → p3-4 → p3-5a。設計全体は p3-1 の `docs/plans/issue-37-p3-review-zig.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)