### PR TITLE
[P3 4/5] feat(cpu): detectOpponentThreats を Zig 委譲（−3, ThreatInfo wire）

### DIFF
--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -73,12 +73,14 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / unit 1799 緑。
 - `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）。残る createsFour 利用点（threatPatterns/vcfCheck/vctValidation/search index export）は PR4+ 対象。
 
-### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）
+### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）【実装済】
 
-- **Zigに移す**: `threats.detectOpponentThreats`(既存) を threat_wasm に export、ThreatInfo を wire 化（`forced_win_tree` の wire が前例）
-- **触る**: `zig/src/threat_wasm.zig`、`threatAdapter.ts`、`src/logic/cpu/review/fullEval.ts`、`forcedLossCheck.ts`。**main search の `moveOrdering.ts` は別系統＝触らない**（`detectOpponentThreatsFast` との混同注意）
-- **利用点削減**: **−3**
-- **安全網**: PR0拡張 reviewSnapshot + adapter test に ThreatInfo 全フィールド照合（各リスト座標ソート）
+- **重大な発見（着手時に検証）**: Zig `threats.detectOpponentThreats` と TS `detectOpponentThreats` は**非合法盤（多重四・長連・盤端の不能配置）で食い違う**（mises/openFours 等、合成ロジックの差）。が、**review が処理するのは合法な実戦局面のみ**で、実測で**実戦棋譜の全手数前置・両色 約168局面が 100% 一致**、不一致は非合法ランダム盤のみ。よって Zig 委譲は実戦で挙動同値＝安全。
+- **Zigに移す**: `threats.detectOpponentThreats`(既存) を threat_wasm に export。ThreatInfo(5リスト×PositionList cap=64) を `[u8 count][count*(row,col)]` でバッファ wire（`getThreatInfoBuffer` + `memory` 読み出し）。threat.wasm は 27.9KB→**113KB**（evaluate スタックを引く）。
+- **触る**: `zig/src/threat_wasm.zig`(export追加)、`threatLoader.ts`(memory/buffer)、`threatAdapter.ts`(detectOpponentThreats)、`threatAdapter.test.ts`(**合法局面ベース**の等価テスト)、`fullEval.ts`(L385/L407)、`forcedLossCheck.ts`(L324)、`review.worker.ts`(L79)。**main search の `moveOrdering.ts`/`detectOpponentThreatsFast` は不触**。
+- **利用点削減**: **−3**（fullEval/forcedLossCheck/worker が evaluation の detectOpponentThreats→patterns.ts を踏まなくなった）
+- **安全網**: 等価テストは**合法局面**で照合（非合法盤は review 非対象なので除外、classifyThreat の乱数照合は per-point なので維持）。**reviewSnapshot を threat wasm preload 付きに強化**＝本番(worker)と同じ Zig 経路で実戦コーパス（candidate 仮置き盤含む checkCandidateForcedLoss/annotateFukumiMoves）を golden(TS) と照合し**バイト不変を実証**（最強ガード）。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1802 緑 / reviewSnapshot 不変。
 
 ### PR5 — Mise系（`createsFourThree`/`findMiseTargets`/`findDoubleMiseMoves`）差分検証→委譲
 

--- a/src/logic/cpu/review.worker.ts
+++ b/src/logic/cpu/review.worker.ts
@@ -21,7 +21,6 @@ import { createBoardFromRecord } from "@/logic/gameRecordParser";
 import type { WasmModuleContext } from "./wasm/types";
 
 import { countStones } from "./core/boardUtils";
-import { detectOpponentThreats } from "./evaluation";
 import { FORCED_LOSS_VCT_OPTIONS } from "./review/forcedLossCheck";
 import { detectForcedWin } from "./review/forcedWinDetection";
 import { executeFullEval } from "./review/fullEval";
@@ -29,7 +28,8 @@ import { wasmFindVCTSequence } from "./review/wasmAdapters";
 import { VCT_STONE_THRESHOLD } from "./search/types";
 import { loadWasmModule } from "./wasm/loader";
 import { WasmSearchEngine } from "./wasm/searchEngine";
-import { preloadThreatWasm } from "./wasm/threatAdapter";
+// #37 P3 PR4: 脅威検出も Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { detectOpponentThreats, preloadThreatWasm } from "./wasm/threatAdapter";
 
 /** WASM モジュール（初回ロード後にキャッシュ） */
 let cachedWasm: WasmModuleContext | null = null;

--- a/src/logic/cpu/review/forcedLossCheck.ts
+++ b/src/logic/cpu/review/forcedLossCheck.ts
@@ -16,10 +16,11 @@ import type {
 } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { detectOpponentThreats } from "../evaluation";
 import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { detectWhiteWinningPattern } from "../evaluation/winningPatterns";
 import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
+// #37 P3 PR4: 脅威検出を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { detectOpponentThreats } from "../wasm/threatAdapter";
 import {
   wasmFindVCFSequence,
   wasmFindMiseVCFSequence,

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -26,7 +26,6 @@ import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { countStones } from "../core/boardUtils";
 import {
-  detectOpponentThreats,
   evaluatePositionWithBreakdown,
   evaluateBoardWithBreakdown,
   PATTERN_SCORES,
@@ -34,6 +33,9 @@ import {
 import { findMiseTargets } from "../evaluation/miseTactics";
 import { colorToWasm } from "../wasm/boardAdapter";
 import { linearTreeFromSequence } from "../wasm/forcedWinTreeWire";
+// #37 P3 PR4: 脅威検出を Zig 単一ソース(threats.detectOpponentThreats)経由に。
+// 合法局面で TS と一致（threatAdapter.test 検証済）。未ロード時は TS フォールバック。
+import { detectOpponentThreats } from "../wasm/threatAdapter";
 import {
   verifyCandidates,
   findSafeBest,

--- a/src/logic/cpu/review/reviewSnapshot.test.ts
+++ b/src/logic/cpu/review/reviewSnapshot.test.ts
@@ -33,6 +33,7 @@ import { countStones } from "../core/boardUtils";
 import { detectOpponentThreats } from "../evaluation";
 import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
+import { preloadThreatWasm } from "../wasm/threatAdapter";
 import { annotateFukumiMoves } from "./candidateVerification";
 import {
   checkCandidateForcedLoss,
@@ -152,6 +153,9 @@ function normalizeTree(node: ForcedWinNode): unknown {
 
 // WASM は1回だけロードして全テストで使い回す
 const engine = new WasmSearchEngine(await loadWasmModule());
+// #37 P3: 脅威分類 thin wasm も preload し、本番(worker)と同じ Zig 経路で凍結する。
+// 合法な実戦コーパスなので Zig==TS（threatAdapter.test で検証済）→ golden は不変。
+await preloadThreatWasm();
 
 describe("review 戦術出力スナップショット (#37 P0)", () => {
   it.each(CORPUS)("detectForcedWin: $name", ({ record, moveCount }) => {

--- a/src/logic/cpu/wasm/threatAdapter.test.ts
+++ b/src/logic/cpu/wasm/threatAdapter.test.ts
@@ -8,8 +8,9 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import type { BoardState, StoneColor } from "@/types/game";
+import type { BoardState, Position, StoneColor } from "@/types/game";
 
+import { detectOpponentThreats as detectOpponentThreatsTs } from "@/logic/cpu/evaluation";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -19,6 +20,7 @@ import { createEmptyBoard } from "@/logic/renjuRules/core";
 
 import {
   classifyThreat,
+  detectOpponentThreats,
   preloadThreatWasm,
   setThreatWasmForTest,
 } from "./threatAdapter";
@@ -119,6 +121,50 @@ describe("threatAdapter (#37 P3 PR2)", () => {
         }
       }
       expect(mismatches, mismatches.join("\n")).toEqual([]);
+    },
+  );
+
+  const sortPos = (a: Position, b: Position): number =>
+    a.row - b.row || a.col - b.col;
+  const normalizeThreats = (t: {
+    openFours: Position[];
+    fours: Position[];
+    openThrees: Position[];
+    mises: Position[];
+    doubleThrees: Position[];
+  }): unknown => ({
+    openFours: [...t.openFours].sort(sortPos),
+    fours: [...t.fours].sort(sortPos),
+    openThrees: [...t.openThrees].sort(sortPos),
+    mises: [...t.mises].sort(sortPos),
+    doubleThrees: [...t.doubleThrees].sort(sortPos),
+  });
+
+  // detectOpponentThreats は**合法な実戦局面**で照合する。
+  // 非合法盤（多重四/長連/盤端の不能配置）では Zig と TS の合成ロジックが分岐しうるが、
+  // review が処理するのは合法局面のみ（実測: 実戦棋譜の全手数前置・両色で 100% 一致、
+  // 非合法ランダム盤のみ不一致）。classifyThreat は per-point プリミティブで非合法盤でも
+  // 一致するため、上の乱数照合（高密度=黒長連）はそのまま維持している。
+  const LEGAL_RECORDS = [
+    "H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 F8 K9 " +
+      "I11 I13 H6 E9 F11 F12 I5 J4 G5 H5 I7 J8 J6 J7 K7 L8 F4 E3 G3 H4 I6 K6 L5",
+    "H8 G8 H9 G7 G9 H7 I7 F10 F9 E9 I8 I9 G10 F11 H11 E8 J6 K5 J7 K6 J9 J5 J8 J10 K8 L8 I10 L7 G12",
+    "H8 H9 I8 G8 I9 I10 F7 G7 G9 H10 F9 J11",
+  ];
+
+  it.each(LEGAL_RECORDS)(
+    "detectOpponentThreats: wasm == TS（実戦棋譜 全手数前置・両色）: %s",
+    async (record) => {
+      await preloadThreatWasm();
+      const moves = record.trim().split(/\s+/);
+      for (let mc = 1; mc <= moves.length; mc++) {
+        const { board } = createBoardFromRecord(moves.slice(0, mc).join(" "));
+        for (const color of COLORS) {
+          const w = normalizeThreats(detectOpponentThreats(board, color));
+          const ts = normalizeThreats(detectOpponentThreatsTs(board, color));
+          expect(w, `mc=${mc} color=${color}`).toEqual(ts);
+        }
+      }
     },
   );
 

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -17,8 +17,12 @@
  * 点ごとに呼ぶ用途（PR6 の findThreatMoves 等）を Zig 化する際は、基盤盤面を 1 度同期して
  * wasm 内で各点を配置・評価する**バッチ API** を別途用意し、点ごとの全盤再同期 O(n²) を避けること。
  */
-import type { BoardState } from "@/types/game";
+import type { BoardState, Position } from "@/types/game";
 
+import {
+  detectOpponentThreats as detectOpponentThreatsTs,
+  type ThreatInfo,
+} from "@/logic/cpu/evaluation";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -115,4 +119,52 @@ export function createsOpenThree(
   color: "black" | "white",
 ): boolean {
   return classifyThreat(board, row, col, color).createsOpenThree;
+}
+
+/** wasm バッファから ThreatInfo の1リスト（[count][count*(row,col)]）を読み出す。 */
+function readPositionList(
+  mem: Uint8Array,
+  offset: number,
+): { positions: Position[]; next: number } {
+  const count = mem[offset] ?? 0;
+  let o = offset + 1;
+  const positions: Position[] = [];
+  for (let i = 0; i < count; i++) {
+    positions.push({ row: mem[o] ?? 0, col: mem[o + 1] ?? 0 });
+    o += 2;
+  }
+  return { positions, next: o };
+}
+
+/**
+ * opponentColor の脅威（活四/止め四/活三/ミセ/三三の各防御位置）を検出する（#37 P3 PR4）。
+ * wasm 経由は Zig `threats.detectOpponentThreats`。未ロード時は TS にフォールバック。
+ */
+export function detectOpponentThreats(
+  board: BoardState,
+  opponentColor: "black" | "white",
+): ThreatInfo {
+  if (wasm) {
+    syncBoard(wasm, board);
+    wasm.detectOpponentThreatsWasm(
+      opponentColor === "black" ? CELL.BLACK : CELL.WHITE,
+    );
+    const mem = new Uint8Array(wasm.memory.buffer);
+    let off = wasm.getThreatInfoBuffer();
+    const openFours = readPositionList(mem, off);
+    const fours = readPositionList(mem, openFours.next);
+    const openThrees = readPositionList(mem, fours.next);
+    const mises = readPositionList(mem, openThrees.next);
+    const doubleThrees = readPositionList(mem, mises.next);
+    off = doubleThrees.next;
+    return {
+      openFours: openFours.positions,
+      fours: fours.positions,
+      openThrees: openThrees.positions,
+      mises: mises.positions,
+      doubleThrees: doubleThrees.positions,
+    };
+  }
+  // フォールバック（wasm 未ロード時）
+  return detectOpponentThreatsTs(board, opponentColor);
 }

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -7,10 +7,16 @@ import { loadWasmBuffer } from "./loader";
 export interface ThreatWasmContext {
   boardInit: () => void;
   boardSet: (row: number, col: number, value: number) => void;
-  /** cells から bitboard.global_bb を再構築する。classifyThreatWasm の前に必ず呼ぶ。 */
+  /** cells から bitboard.global_bb を再構築する。classifyThreatWasm/detectOpponentThreatsWasm の前に必ず呼ぶ。 */
   syncBitboard: () => void;
   /** bit0=createsFour（黒長連除外済）/ bit1=createsOpenThree。(row,col) に color 配置済み前提。 */
   classifyThreatWasm: (row: number, col: number, color: number) => number;
+  /** opponent_color の脅威を検出し ThreatInfo をバッファにシリアライズする（#37 P3 PR4）。 */
+  detectOpponentThreatsWasm: (opponentColor: number) => void;
+  /** ThreatInfo シリアライズバッファの先頭オフセット（memory 内）を返す。 */
+  getThreatInfoBuffer: () => number;
+  /** wasm 線形メモリ（バッファ読み取り用）。 */
+  memory: WebAssembly.Memory;
 }
 
 export async function loadThreatWasm(): Promise<ThreatWasmContext> {

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -15,6 +15,7 @@
 // 関数のみ（Zig のデッドコード削除で thin に保たれる）。
 const bitboard = @import("bitboard.zig");
 const board = @import("board.zig");
+const threats = @import("threats.zig");
 const vct = @import("vct.zig");
 
 export fn boardInit() void {
@@ -40,4 +41,40 @@ export fn classifyThreatWasm(row: u8, col: u8, color: u8) u8 {
     if (r.creates_four) bits |= 1;
     if (r.creates_open_three) bits |= 2;
     return bits;
+}
+
+// === detectOpponentThreats（ThreatInfo）の wire（#37 P3 PR4）===
+//
+// ThreatInfo = 5 リスト（open_fours/fours/open_threes/mises/double_threes、各 PositionList cap=64）。
+// バッファに [u8 count][count*(u8 row, u8 col)] を 5 回連結してシリアライズする。
+// 最大 5*(1 + 64*2) = 645 バイト。
+var threat_info_buffer: [768]u8 = undefined;
+
+export fn getThreatInfoBuffer() [*]u8 {
+    return &threat_info_buffer;
+}
+
+fn writeList(off: usize, list: *const threats.PositionList) usize {
+    var o = off;
+    threat_info_buffer[o] = list.len;
+    o += 1;
+    for (0..list.len) |i| {
+        threat_info_buffer[o] = list.items[i].row;
+        threat_info_buffer[o + 1] = list.items[i].col;
+        o += 2;
+    }
+    return o;
+}
+
+/// 相手(opponent_color)の脅威を検出し ThreatInfo をバッファにシリアライズする。
+/// 事前に boardSet で cells、syncBitboard で bitboard を同期しておくこと。
+export fn detectOpponentThreatsWasm(opponent_color: u8) void {
+    const c: board.Cell = @enumFromInt(opponent_color);
+    const info = threats.detectOpponentThreats(&board.board_cells, c);
+    var o: usize = 0;
+    o = writeList(o, &info.open_fours);
+    o = writeList(o, &info.fours);
+    o = writeList(o, &info.open_threes);
+    o = writeList(o, &info.mises);
+    o = writeList(o, &info.double_threes);
 }


### PR DESCRIPTION
fullEval/forcedLossCheck/review.worker の脅威検出を threat_wasm(threats.detectOpponentThreats)経由に。ThreatInfo を buffer wire。**重要**: Zig⇔TS は非合法盤で食い違うが合法な実戦局面は100%一致(約168局面実測)。reviewSnapshot を threat wasm preload 付きに強化＝本番Zig経路で golden 照合。main search 不触。

---
⚠️ **stacked PR（#42 P3）**。下から順にレビュー＋**動作確認**してマージしてください。自動マージはしません。
スタック順: p3-1 → p3-2 → p3-3 → p3-4 → p3-5a。設計全体は p3-1 の `docs/plans/issue-37-p3-review-zig.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)