### PR TITLE
[P3 5a/5] feat(cpu): createsFourThree を Zig 委譲（−2）

### DIFF
--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -82,12 +82,23 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **安全網**: 等価テストは**合法局面**で照合（非合法盤は review 非対象なので除外、classifyThreat の乱数照合は per-point なので維持）。**reviewSnapshot を threat wasm preload 付きに強化**＝本番(worker)と同じ Zig 経路で実戦コーパス（candidate 仮置き盤含む checkCandidateForcedLoss/annotateFukumiMoves）を golden(TS) と照合し**バイト不変を実証**（最強ガード）。
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1802 緑 / reviewSnapshot 不変。
 
-### PR5 — Mise系（`createsFourThree`/`findMiseTargets`/`findDoubleMiseMoves`）差分検証→委譲
+### PR5 — Mise系 → 2分割（着手時に判明: Zig 等価は `createsFourThree` のみ存在）
 
-- **Zigに移す**: `evaluate.createsFourThree`(既存)、`mise_vcf.findMiseTargetsLite`。**フル版 `findMiseTargets`(±2近傍走査) が Lite で足りるかの差分検証が前提**（不一致ならフル版 Zig 新規実装に分岐）
-- **触る**: `threat_wasm.zig`、`threatAdapter.ts`、`review/fullEval.ts`、`forcedWinDetection.ts`、`forcedLossCheck.ts`、`doubleMiseBranches.ts`
-- **利用点削減**: **−3〜4**（forbiddenMoves.ts 依存が外れる）
-- **リスク**: 高。先に差分 test で可視化してから実装。
+**発見**: Zig には `evaluate.createsFourThree` しか無い。`findMiseTargets`/`findMiseTargetsLite`/`findDoubleMiseMoves` の Zig 等価は**存在しない**（プランの `mise_vcf.findMiseTargetsLite` は誤り）。→ PR5 を分割。
+
+#### PR5a — `createsFourThree` を Zig 委譲（gap:none）【実装済】
+
+- **Zigに移す**: `evaluate.createsFourThree`（既存）を `threat_wasm` に export（`createsFourThreeWasm`、候補は空き前提で内部仮置き）。
+- **触る**: `threat_wasm.zig`/`threatLoader.ts`/`threatAdapter.ts`（`createsFourThree`、未ロード時TSフォールバック）/`threatAdapter.test.ts`（合法局面・全空き点・両色で Zig==TS）/`doubleMiseBranches.ts`(L90)/`forcedWinDetection.ts`(L140)。両 call site とも空き候補で contract 一致を確認。
+- **利用点削減**: **−2**（createsFourThree が winningPatterns→ を踏まなくなった）
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / unit 1805 緑 / reviewSnapshot バイト不変。
+
+#### PR5b — `findMiseTargets`/`findDoubleMiseMoves` を Zig 新規実装【未着手・要新規Zig】
+
+- **Zigに移す**: 両関数の Zig 等価が無いため**新規実装**が必要（plan の「new-impl 分岐」）。`findMiseTargets`(±2近傍走査・達四点列挙)、`findDoubleMiseMoves`(全空き点で四三2つ以上)。
+- **触る（予定）**: `threat_wasm.zig`(新規fn+wire)/`threatAdapter.ts`/`fullEval.ts`(L647 findMiseTargets)/`forcedLossCheck.ts`(L185 findDoubleMiseMoves)/`forcedWinDetection.ts`(L113 findDoubleMiseMoves)。
+- **安全網**: 合法局面で Zig==TS（reviewSnapshot は doubleMiseTargets/missedDoubleMise を凍結済＝最終ガード）。
+- **リスク**: 高（新規Zig実装＋wire）。
 
 ### PR6 — VCT安全性ヘルパー（`hasFourThreeAvailable`/`hasOpenThree`/`findThreatMoves`）委譲
 

--- a/src/logic/cpu/review/doubleMiseBranches.ts
+++ b/src/logic/cpu/review/doubleMiseBranches.ts
@@ -7,7 +7,8 @@
 import type { BoardState, Position } from "@/types/game";
 import type { ForcedWinDefense, ForcedWinNode } from "@/types/review";
 
-import { createsFourThree } from "../evaluation/winningPatterns";
+// #37 P3 PR5: 四三判定を Zig 単一ソース(evaluate.createsFourThree)経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { createsFourThree } from "../wasm/threatAdapter";
 
 /**
  * 両ミセの詰み木を構築（#22）

--- a/src/logic/cpu/review/forcedWinDetection.ts
+++ b/src/logic/cpu/review/forcedWinDetection.ts
@@ -11,9 +11,10 @@ import type { VCTSearchOptions, VCTSequenceResult } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { findDoubleMiseMoves } from "../evaluation/tactics";
-import { createsFourThree } from "../evaluation/winningPatterns";
 import { findThreatMoves } from "../search/vctHelpers";
 import { validateVCTSequence } from "../search/vctValidation";
+// #37 P3 PR5: 四三判定を Zig 単一ソース(evaluate.createsFourThree)経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { createsFourThree } from "../wasm/threatAdapter";
 import {
   filterByCounterThreats,
   REVIEW_MISE_VCF_OPTIONS,

--- a/src/logic/cpu/wasm/threatAdapter.test.ts
+++ b/src/logic/cpu/wasm/threatAdapter.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { BoardState, Position, StoneColor } from "@/types/game";
 
 import { detectOpponentThreats as detectOpponentThreatsTs } from "@/logic/cpu/evaluation";
+import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -20,6 +21,7 @@ import { createEmptyBoard } from "@/logic/renjuRules/core";
 
 import {
   classifyThreat,
+  createsFourThree,
   detectOpponentThreats,
   preloadThreatWasm,
   setThreatWasmForTest,
@@ -165,6 +167,40 @@ describe("threatAdapter (#37 P3 PR2)", () => {
           expect(w, `mc=${mc} color=${color}`).toEqual(ts);
         }
       }
+    },
+  );
+
+  it.each(LEGAL_RECORDS)(
+    "createsFourThree: wasm == TS（実戦棋譜 全手数前置・全空き点・両色）: %s",
+    async (record) => {
+      await preloadThreatWasm();
+      const moves = record.trim().split(/\s+/);
+      const mismatches: string[] = [];
+      // 計算量を抑えるため代表的な手数（中盤以降で四三が出やすい）を間引いて検査
+      for (let mc = 6; mc <= moves.length; mc += 3) {
+        const { board } = createBoardFromRecord(moves.slice(0, mc).join(" "));
+        for (let row = 0; row < 15; row++) {
+          const boardRow = board[row];
+          if (!boardRow) {
+            continue;
+          }
+          for (let col = 0; col < 15; col++) {
+            if (boardRow[col]) {
+              continue;
+            }
+            for (const color of COLORS) {
+              const w = createsFourThree(board, row, col, color);
+              const ts = createsFourThreeTs(board, row, col, color);
+              if (w !== ts) {
+                mismatches.push(
+                  `mc=${mc} (${row},${col},${color}) w=${w} ts=${ts}`,
+                );
+              }
+            }
+          }
+        }
+      }
+      expect(mismatches, mismatches.join("\n")).toEqual([]);
     },
   );
 

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -23,6 +23,7 @@ import {
   detectOpponentThreats as detectOpponentThreatsTs,
   type ThreatInfo,
 } from "@/logic/cpu/evaluation";
+import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -119,6 +120,30 @@ export function createsOpenThree(
   color: "black" | "white",
 ): boolean {
   return classifyThreat(board, row, col, color).createsOpenThree;
+}
+
+/**
+ * (row,col)（**空き**前提）に color を打つと四三ができるか（黒は禁手考慮）。
+ * wasm 経由は Zig `evaluate.createsFourThree`。未ロード時は TS にフォールバック。
+ * 契約は TS `createsFourThree` と同じく**候補は空き**（内部で仮置き・復元）。
+ */
+export function createsFourThree(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): boolean {
+  if (wasm) {
+    syncBoard(wasm, board);
+    return (
+      wasm.createsFourThreeWasm(
+        row,
+        col,
+        color === "black" ? CELL.BLACK : CELL.WHITE,
+      ) !== 0
+    );
+  }
+  return createsFourThreeTs(board, row, col, color);
 }
 
 /** wasm バッファから ThreatInfo の1リスト（[count][count*(row,col)]）を読み出す。 */

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -11,6 +11,8 @@ export interface ThreatWasmContext {
   syncBitboard: () => void;
   /** bit0=createsFour（黒長連除外済）/ bit1=createsOpenThree。(row,col) に color 配置済み前提。 */
   classifyThreatWasm: (row: number, col: number, color: number) => number;
+  /** (row,col)（空き前提）に color を打つと四三ができるか。1/0。内部で仮置き・復元。 */
+  createsFourThreeWasm: (row: number, col: number, color: number) => number;
   /** opponent_color の脅威を検出し ThreatInfo をバッファにシリアライズする（#37 P3 PR4）。 */
   detectOpponentThreatsWasm: (opponentColor: number) => void;
   /** ThreatInfo シリアライズバッファの先頭オフセット（memory 内）を返す。 */

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -15,6 +15,7 @@
 // 関数のみ（Zig のデッドコード削除で thin に保たれる）。
 const bitboard = @import("bitboard.zig");
 const board = @import("board.zig");
+const evaluate = @import("evaluate.zig");
 const threats = @import("threats.zig");
 const vct = @import("vct.zig");
 
@@ -41,6 +42,13 @@ export fn classifyThreatWasm(row: u8, col: u8, color: u8) u8 {
     if (r.creates_four) bits |= 1;
     if (r.creates_open_three) bits |= 2;
     return bits;
+}
+
+/// (row,col) が**空き**の盤面で、そこに color を打つと四三ができるか（黒は禁手考慮）。
+/// 内部で候補を仮置き・復元する（候補は空き前提）。事前に boardSet/syncBitboard で同期しておくこと。
+export fn createsFourThreeWasm(row: u8, col: u8, color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    return if (evaluate.createsFourThree(&board.board_cells, row, col, c)) 1 else 0;
 }
 
 // === detectOpponentThreats（ThreatInfo）の wire（#37 P3 PR4）===


### PR DESCRIPTION
doubleMiseBranches/forcedWinDetection の四三判定を threat_wasm(evaluate.createsFourThree)経由に。両 call site とも空き候補で contract 一致。等価テスト(合法局面)。

---
⚠️ **stacked PR（#42 P3）**。下から順にレビュー＋**動作確認**してマージしてください。自動マージはしません。
スタック順: p3-1 → p3-2 → p3-3 → p3-4 → p3-5a。設計全体は p3-1 の `docs/plans/issue-37-p3-review-zig.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)