### PR TITLE
feat(cpu): #37 P3 — review 戦術解析を Zig 構造化 API へ移行（本体）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -63,7 +63,7 @@
       }
     },
     {
-      "files": ["**/renjuParity.test.ts"],
+      "files": ["**/renjuParity.test.ts", "**/threatAdapter.test.ts"],
       "rules": {
         "no-bitwise": "off"
       }

--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -82,12 +82,23 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **安全網**: 等価テストは**合法局面**で照合（非合法盤は review 非対象なので除外、classifyThreat の乱数照合は per-point なので維持）。**reviewSnapshot を threat wasm preload 付きに強化**＝本番(worker)と同じ Zig 経路で実戦コーパス（candidate 仮置き盤含む checkCandidateForcedLoss/annotateFukumiMoves）を golden(TS) と照合し**バイト不変を実証**（最強ガード）。
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1802 緑 / reviewSnapshot 不変。
 
-### PR5 — Mise系（`createsFourThree`/`findMiseTargets`/`findDoubleMiseMoves`）差分検証→委譲
+### PR5 — Mise系 → 2分割（着手時に判明: Zig 等価は `createsFourThree` のみ存在）
 
-- **Zigに移す**: `evaluate.createsFourThree`(既存)、`mise_vcf.findMiseTargetsLite`。**フル版 `findMiseTargets`(±2近傍走査) が Lite で足りるかの差分検証が前提**（不一致ならフル版 Zig 新規実装に分岐）
-- **触る**: `threat_wasm.zig`、`threatAdapter.ts`、`review/fullEval.ts`、`forcedWinDetection.ts`、`forcedLossCheck.ts`、`doubleMiseBranches.ts`
-- **利用点削減**: **−3〜4**（forbiddenMoves.ts 依存が外れる）
-- **リスク**: 高。先に差分 test で可視化してから実装。
+**発見**: Zig には `evaluate.createsFourThree` しか無い。`findMiseTargets`/`findMiseTargetsLite`/`findDoubleMiseMoves` の Zig 等価は**存在しない**（プランの `mise_vcf.findMiseTargetsLite` は誤り）。→ PR5 を分割。
+
+#### PR5a — `createsFourThree` を Zig 委譲（gap:none）【実装済】
+
+- **Zigに移す**: `evaluate.createsFourThree`（既存）を `threat_wasm` に export（`createsFourThreeWasm`、候補は空き前提で内部仮置き）。
+- **触る**: `threat_wasm.zig`/`threatLoader.ts`/`threatAdapter.ts`（`createsFourThree`、未ロード時TSフォールバック）/`threatAdapter.test.ts`（合法局面・全空き点・両色で Zig==TS）/`doubleMiseBranches.ts`(L90)/`forcedWinDetection.ts`(L140)。両 call site とも空き候補で contract 一致を確認。
+- **利用点削減**: **−2**（createsFourThree が winningPatterns→ を踏まなくなった）
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / unit 1805 緑 / reviewSnapshot バイト不変。
+
+#### PR5b — `findMiseTargets`/`findDoubleMiseMoves` を Zig 新規実装【未着手・要新規Zig】
+
+- **Zigに移す**: 両関数の Zig 等価が無いため**新規実装**が必要（plan の「new-impl 分岐」）。`findMiseTargets`(±2近傍走査・達四点列挙)、`findDoubleMiseMoves`(全空き点で四三2つ以上)。
+- **触る（予定）**: `threat_wasm.zig`(新規fn+wire)/`threatAdapter.ts`/`fullEval.ts`(L647 findMiseTargets)/`forcedLossCheck.ts`(L185 findDoubleMiseMoves)/`forcedWinDetection.ts`(L113 findDoubleMiseMoves)。
+- **安全網**: 合法局面で Zig==TS（reviewSnapshot は doubleMiseTargets/missedDoubleMise を凍結済＝最終ガード）。
+- **リスク**: 高（新規Zig実装＋wire）。
 
 ### PR6 — VCT安全性ヘルパー（`hasFourThreeAvailable`/`hasOpenThree`/`findThreatMoves`）委譲
 

--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -73,12 +73,14 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / unit 1799 緑。
 - `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）。残る createsFour 利用点（threatPatterns/vcfCheck/vctValidation/search index export）は PR4+ 対象。
 
-### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）
+### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）【実装済】
 
-- **Zigに移す**: `threats.detectOpponentThreats`(既存) を threat_wasm に export、ThreatInfo を wire 化（`forced_win_tree` の wire が前例）
-- **触る**: `zig/src/threat_wasm.zig`、`threatAdapter.ts`、`src/logic/cpu/review/fullEval.ts`、`forcedLossCheck.ts`。**main search の `moveOrdering.ts` は別系統＝触らない**（`detectOpponentThreatsFast` との混同注意）
-- **利用点削減**: **−3**
-- **安全網**: PR0拡張 reviewSnapshot + adapter test に ThreatInfo 全フィールド照合（各リスト座標ソート）
+- **重大な発見（着手時に検証）**: Zig `threats.detectOpponentThreats` と TS `detectOpponentThreats` は**非合法盤（多重四・長連・盤端の不能配置）で食い違う**（mises/openFours 等、合成ロジックの差）。が、**review が処理するのは合法な実戦局面のみ**で、実測で**実戦棋譜の全手数前置・両色 約168局面が 100% 一致**、不一致は非合法ランダム盤のみ。よって Zig 委譲は実戦で挙動同値＝安全。
+- **Zigに移す**: `threats.detectOpponentThreats`(既存) を threat_wasm に export。ThreatInfo(5リスト×PositionList cap=64) を `[u8 count][count*(row,col)]` でバッファ wire（`getThreatInfoBuffer` + `memory` 読み出し）。threat.wasm は 27.9KB→**113KB**（evaluate スタックを引く）。
+- **触る**: `zig/src/threat_wasm.zig`(export追加)、`threatLoader.ts`(memory/buffer)、`threatAdapter.ts`(detectOpponentThreats)、`threatAdapter.test.ts`(**合法局面ベース**の等価テスト)、`fullEval.ts`(L385/L407)、`forcedLossCheck.ts`(L324)、`review.worker.ts`(L79)。**main search の `moveOrdering.ts`/`detectOpponentThreatsFast` は不触**。
+- **利用点削減**: **−3**（fullEval/forcedLossCheck/worker が evaluation の detectOpponentThreats→patterns.ts を踏まなくなった）
+- **安全網**: 等価テストは**合法局面**で照合（非合法盤は review 非対象なので除外、classifyThreat の乱数照合は per-point なので維持）。**reviewSnapshot を threat wasm preload 付きに強化**＝本番(worker)と同じ Zig 経路で実戦コーパス（candidate 仮置き盤含む checkCandidateForcedLoss/annotateFukumiMoves）を golden(TS) と照合し**バイト不変を実証**（最強ガード）。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1802 緑 / reviewSnapshot 不変。
 
 ### PR5 — Mise系（`createsFourThree`/`findMiseTargets`/`findDoubleMiseMoves`）差分検証→委譲
 

--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -49,19 +49,20 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **決定性検証**: 3回連続実行で snapshot 完全一致を確認済。コーパスは既存 P0 の forcing 局面（mise-vcf-#18 / white29-m20 / white29-m24）を流用。白29で `isFukumi:true/fukumiDepth:3`・`type:"vcf"` 被必勝列など実データを捕捉。
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / review+parity 145 tests 緑（parity は wasm 再ビルド後）。
 
-### PR1 — `classifyPointWasm` 黒長連対応＋パリティ拡張（Zig only・本番未接続）
+### PR1 — ~~classifyPointWasm 黒長連対応~~【DROP（着手時に誤りと判明）】
 
-- **Zigに移す**: `classifyPointWasm` の four/jumpFour ビットに黒限定 overline 除外を組込。`vct.zig` の `isJumpFourOverline`/`isOverlineEnd` を pub 化して再利用
-- **触る**: `zig/src/main.zig`、`zig/src/vct.zig`(pub化)、`src/logic/renjuRules/renjuParity.test.ts`（Test A=黒跳び四overline / Test B=黒4連の先に黒石(checkEndsForFour) を追加、現状RED→Zig修正でGREEN）
-- **利用点削減**: ±0（#21 オラクル正確化のみ）
-- 目的は「本番で使うため」でなく **#21 オラクルの正確性向上**。橋本体は PR2。
+**取りやめ理由**: `classifyPointWasm` と TS オラクル `classifyPointTs` の bit は**生のパターンプリミティブ**（`four`/`jumpFour` は `checkJumpFour` 等をそのまま反映＝黒長連でも true、長連は別途 forbidden bit 24-25 で符号化）。#21 はこの**共有プリミティブの TS==Zig** を検証する設計で正しい。ここに黒長連除外を組み込むと (1) TS 側も変えないとパリティが壊れ (2) 生プリミティブ(checkJumpFour)と合成(createsFour)を混同させ #21 の粒度を下げる＝**有害**。`classifyPointWasm` は橋でもない（橋は `vct.classifyThreat`）ので触らない。
+**意図の受け皿**: 「vct.classifyThreat == TS createsFour を黒長連含め検証」は **PR2 の `threatAdapter.test`** が全空き点・両色・高密度局面で照合し内包済。既存 renjuParity が生プリミティブを、PR0 が createsFour 消費側 review 出力をガード済。
 
-### PR2 — threat 専用 thin wasm + adapter を新設（橋だけ・利用者ゼロ）
+### PR2 — threat 専用 thin wasm + adapter を新設（橋だけ・利用者ゼロ）【実装済】
 
-- **Zigに移す**: 新規 `zig/src/threat_wasm.zig`(thin)。export: `boardInit`/`boardSet`/`syncBitboard`(=`bitboard.initFromCells`) + `classifyThreatWasm(row,col,color)->u8`（bit0=four, bit1=openThree、内部で `vct.classifyThreat`）。依存を board+jump_patterns+threats+vct に限定
-- **触る**: `zig/src/threat_wasm.zig`(新)、`zig/build.zig`(3つ目の thin wasm target, forbidden 同型)、`src/logic/cpu/wasm/threatLoader.ts`(新)、`src/logic/cpu/wasm/threatAdapter.ts`(新, `createsFour`/`createsOpenThree` 委譲・未ロード時TSフォールバック)、`threatAdapter.test.ts`(新)
-- **安全網**: `threatAdapter.test.ts`（wasm == TS を全コーパス照合、**黒長連ケース必須**）。`bitboard.initFromCells` 忘れがパリティで即露見
-- **実装者向け注意**: classifyPointWasm を使わない旨をコメント明記
+- **Zigに移す**: 新規 `zig/src/threat_wasm.zig`(thin、**実測 27.9KB**)。export: `boardInit`/`boardSet`/`syncBitboard`(=`bitboard.initFromCells`) + `classifyThreatWasm(row,col,color)->u8`（bit0=four, bit1=openThree、内部で `vct.classifyThreat`、(r,c) 配置済前提）。vct.zig を import するが Zig のデッドコード削除で classifyThreat 到達グラフのみ＝thin。
+- **触る**: `zig/src/threat_wasm.zig`(新)、`zig/build.zig`(3つ目 thin wasm target `threat` + チェックリスト JSDoc)、`src/logic/cpu/wasm/threatLoader.ts`(新, `loadWasmBuffer` 再利用)、`src/logic/cpu/wasm/threatAdapter.ts`(新, `classifyThreat`/`createsFour`/`createsOpenThree`・未ロード時TSフォールバック)、`threatAdapter.test.ts`(新)、`.oxlintrc.json`(test の no-bitwise override 追加)
+- **API**: `classifyThreat(board,r,c,color)→{createsFour,createsOpenThree}` 一括（候補は配置済規約=TS createsFour と同一）。`createsFour`/`createsOpenThree` は一括の薄いラッパ。bit 展開は算術（`bits===1||bits===3` 等、no-bitwise 準拠）。
+- **安全網**: `threatAdapter.test.ts`（wasm == TS createsFour/createsOpenThree を全空き点・両色・決定的乱数局面 d=0.25/0.4/0.55＝**黒長連を踏む**で照合、27 tests 緑）。
+- **性能ノート（/review 反映）**: 1呼び出し=全盤同期 O(225)。PR3 の利用点（候補少数）は問題なし。盤面全走査用途（PR6）は基盤盤面を1度同期し wasm 内で各点評価する**バッチAPI**を別途用意し O(n²) を回避すること（ハッシュキャッシュは盤面が点ごとに変わるため無効＝採用せず、adapter にノート明記）。
+- **利用者ゼロ**: 起動時 preload（main.ts）は **PR3 で配線**（PR2 は adapter 未呼び出し＝完全 no-op）。PR3 で preloadThreatWasm を忘れると TS フォールバックのまま（正しさは不変だが Zig 未使用）になる点に注意。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1799 tests 緑。
 
 ### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）
 

--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -64,12 +64,14 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **利用者ゼロ**: 起動時 preload（main.ts）は **PR3 で配線**（PR2 は adapter 未呼び出し＝完全 no-op）。PR3 で preloadThreatWasm を忘れると TS フォールバックのまま（正しさは不変だが Zig 未使用）になる点に注意。
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1799 tests 緑。
 
-### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）
+### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）【実装済】
 
-- **触る**: `src/logic/cpu/review/candidateVerification.ts`、`src/logic/vcfPuzzle.ts`。import を threatAdapter に差替（各ファイル独立コミット可）
-- **利用点削減**: **−2**（review-live と puzzle-live を同時に救う）
-- **安全網**: PR0拡張 reviewSnapshot + threatAdapter.test + renjuParity
-- `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）
+- **触る**: `candidateVerification.ts`（annotateFukumiMoves）/ `vcfPuzzle.ts`（L96 四判定）の import を threatAdapter へ差替。**preload 配線**: `main.ts`（vcfPuzzle 用・非ブロッキング）/ `review.worker.ts`（getWasmModule 内で await＝candidateVerification 実行前にロード）。
+- **利用点削減**: **−2**（candidateVerification + vcfPuzzle が threatMoves→patterns.ts を踏まなくなった。grep で直接 import 消滅を確認）
+- **preload 必須**: 未 preload だと TS フォールバックのまま＝Zig 未使用。両コンテキストで preloadThreatWasm を配線済。失敗時は TS フォールバックでクラッシュ回避。
+- **安全網**: reviewSnapshot **バイト不変**（test は preload せず TS フォールバック＝同値）/ threatAdapter.test（wasm==TS）/ renjuParity / vcfPuzzle.test 15 緑。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / unit 1799 緑。
+- `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）。残る createsFour 利用点（threatPatterns/vcfCheck/vctValidation/search index export）は PR4+ 対象。
 
 ### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）
 

--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -1,0 +1,111 @@
+# #37 P3 (#42) — review 戦術解析を Zig 構造化 API へ移行
+
+親: #37 ／ 依存: P0(#44 スナップショット) ／ 前段: P1(#45 メイン禁手Zig化), P2(#46 vcfPuzzle禁手Zig化) マージ済。
+
+多エージェント設計（理解5→敵対検証2→設計パネル3→統合1）で策定。ボス合意: 2026-06-07。
+
+## 北極星（#37 全体）
+
+review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン＋ワークフロー」に徹する。副作用で `patterns.ts`/`forbiddenMoves.ts` が削除可能になる（P4 #43）。
+
+## 統合方針
+
+出力契約を先に凍結（安全網）→ Zig オラクル正確化 → thin wasm の橋を**無接続で**敷設 → 利用点を**葉から1ファイル単位**で張替（各PR revert 容易）。
+
+## 確定した技術判断（敵対検証で固めた）
+
+1. **真の橋は `vct.classifyThreat`（`zig/src/vct.zig:48`、pub、黒長連除外を内包、TS `threatMoves.ts:135 classifyThreat` と 1:1 構造一致）。**
+   - `main.zig:59 classifyPointWasm` は**使わない**: 生パターンビットで `isJumpFourOverline`/`checkEndsForFour` の黒長連除外を欠き、TS `createsFour`/`createsOpenThree` と**非同値**。そのまま OR すると黒の四・跳び四判定がズレる。
+   - `classifyPointWasm` は #21 パリティ用オラクルとして維持・正確化（PR1）。
+2. **thin wasm は `board_cells` 同期に加え `bitboard.initFromCells` 同期が必須**（P1 `forbidden_wasm` との唯一の構造差）。`vct.classifyThreat` が `ll.queryPatternByCell` 経由で `bitboard.global_bb` に依存するため。
+3. **API 粒度＝小 export 群**（`classifyThreat` / `detectOpponentThreats` / 各ヘルパー）。`analyzePositionForReview` 一本化はしない: detectForcedWin/checkForcedLoss の段取り（AND-OR木合成・isForbiddenTrap・needsVCTCheck フェーズ協調）が worker の Phase 1/2/3 分割と密結合で、一本化すると 1PR 巨大化＋二分切り分け不能。段取りは TS に残し、中の戦術判定だけ Zig。
+4. **thin wasm 新設**（`threat_wasm.zig`）: vcfPuzzle がメインスレッド実行で engine wasm を持たない（`createsFour` を TS 直呼び、禁手のみ P2 thin wasm）ことを確認済 → 橋には thin wasm が必須。
+5. **評価関数（`evaluatePositionWithBreakdown`/`evaluateBoardWithBreakdown`）は P3 から除外**（ボス合意）。これらは評価関数(#22領域)依存で review-live かつ main-search-live＝棋力レグレッションが別階層。別 issue で扱う。
+6. **列挙順序は座標ソートで順序非依存化**（ボス合意）: 防御位置・`findThreatMoves`・ThreatInfo 各リストは snapshot/利用側で座標昇順正規化。ただし `forcedWin.sequence` のように順序が探索結果に意味を持つ箇所は個別に TS/Zig 完全一致を要する。
+
+## /review 反映（3観点LGTM・2026-06-07）
+
+- **PR2 盤面同期キャッシュ必須**: forbiddenAdapter の無条件 `boardInit` を `syncBoardIfChanged`（盤面ハッシュ比較で再同期スキップ）または差分同期に upgrade。`createsFour` 単点でも毎回 `bitboard.initFromCells` 全盤再構築になるため、盤面全走査で呼ぶ利用点があると O(225²)。adapter 新設時から組込む。
+- **threatAdapter は `classifyThreat` 一括 API を基本**: `classifyThreat(board,r,c,color)→{createsFour,createsOpenThree}`（wasm の `classifyThreatWasm` が bit0/bit1 を返す）。candidateVerification が four/openThree を両方呼ぶ→往復1回に削減。`createsFour`/`createsOpenThree` は内部で一括を呼ぶ薄いラッパとして提供。
+- **PR4 は PR5/PR6 の前提**（並行不可）: `PR0→PR1→PR2→PR3→PR4→{PR5, PR6}→PR7`。PR5(Mise)/PR6(VCT) は PR4 の Zig-side detectOpponentThreats を前提にする。
+- **thin wasm テンプレ化**: `build.zig` に「3つ目以降の thin wasm 追加チェックリスト」を JSDoc で明記（依存を board+次数1モジュールに限定、`bitboard.initFromCells` 要否の判定）。`threatLoader` は `loader.ts:loadWasmBuffer` を再利用（DRY）。
+- イシュー観点: 土台主張6点すべて検証「正」（橋=vct.classifyThreat / bitboard同期必須 / sequence非ソート / PR0凍結漏れなし / PR1=#21オラクル目的 / patterns.ts見落としなし）。
+
+## ゲート（毎PR）
+
+- #21 `renjuParity.test.ts` 緑（TS==Zig）
+- P0 `reviewSnapshot.test.ts` が1ビットも変わらない
+- `pnpm check-fix` 緑、`cd zig && zig build` 緑
+
+## PR 列
+
+### PR0 — reviewSnapshot を P3 移植対象の戦術プリミティブまで拡張（安全網のみ・ロジック不変）【最初のPR・実装済】
+
+- **実装方針の改善（着手時に確定）**: 当初案は非決定的な `executeFullEval` 出力（candidates[]）を凍結する想定だったが、実装時に判明 — **P3 が移植する関数の大半（`detectOpponentThreats`/`findDoubleMiseMoves`/`hasOpenThree`/`hasFourThreeAvailable`/`createsFour` 等）は時間非依存の純粋関数で完全決定的**。時間依存は VCF/VCT 探索のみで、それは `checkCandidateForcedLoss` に `timeLimit=Infinity`（node-bound）で凍結可能。よって **`executeFullEval` の wall-clock 経路を避け、P3 が実際に置き換える関数を直接凍結**する方が堅牢かつ的確（`candidates[].opponentForcedWin` 等の出力は元々これら関数が算出するため、SSoT 的にも正しい）。`verifyCandidates` は `performance.now()` 配分で非決定なので凍結対象にしない（その戦術核 `checkCandidateForcedLoss` を凍結）。
+- **Zigに移す**: なし
+- **触る**: `src/logic/cpu/review/reviewSnapshot.test.ts`（新 describe ブロック追加）、`src/logic/cpu/review/candidateVerification.ts`（`annotateFukumiMoves` に optional `vcfOptions` フック追加、本番デフォルト=`REVIEW_VCF_OPTIONS` で挙動不変）
+- **凍結する関数（→対応PR）**: `detectOpponentThreats`両色（PR4）／`findDoubleMiseMoves`両色（PR5）／`hasOpenThree`+`hasFourThreeAvailable`両色（PR6）／`checkCandidateForcedLoss`（PR3/PR4 被必勝層、Infinity options）／`annotateFukumiMoves`（PR3 の createsFour/createsOpenThree を使う isFukumi/fukumiDepth、Infinity options）
+- **正規化**: ThreatInfo の5リスト・両ミセ手は座標昇順ソート（探索順非依存）。被必勝は {type, sequence}。
+- **決定性検証**: 3回連続実行で snapshot 完全一致を確認済。コーパスは既存 P0 の forcing 局面（mise-vcf-#18 / white29-m20 / white29-m24）を流用。白29で `isFukumi:true/fukumiDepth:3`・`type:"vcf"` 被必勝列など実データを捕捉。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / review+parity 145 tests 緑（parity は wasm 再ビルド後）。
+
+### PR1 — `classifyPointWasm` 黒長連対応＋パリティ拡張（Zig only・本番未接続）
+
+- **Zigに移す**: `classifyPointWasm` の four/jumpFour ビットに黒限定 overline 除外を組込。`vct.zig` の `isJumpFourOverline`/`isOverlineEnd` を pub 化して再利用
+- **触る**: `zig/src/main.zig`、`zig/src/vct.zig`(pub化)、`src/logic/renjuRules/renjuParity.test.ts`（Test A=黒跳び四overline / Test B=黒4連の先に黒石(checkEndsForFour) を追加、現状RED→Zig修正でGREEN）
+- **利用点削減**: ±0（#21 オラクル正確化のみ）
+- 目的は「本番で使うため」でなく **#21 オラクルの正確性向上**。橋本体は PR2。
+
+### PR2 — threat 専用 thin wasm + adapter を新設（橋だけ・利用者ゼロ）
+
+- **Zigに移す**: 新規 `zig/src/threat_wasm.zig`(thin)。export: `boardInit`/`boardSet`/`syncBitboard`(=`bitboard.initFromCells`) + `classifyThreatWasm(row,col,color)->u8`（bit0=four, bit1=openThree、内部で `vct.classifyThreat`）。依存を board+jump_patterns+threats+vct に限定
+- **触る**: `zig/src/threat_wasm.zig`(新)、`zig/build.zig`(3つ目の thin wasm target, forbidden 同型)、`src/logic/cpu/wasm/threatLoader.ts`(新)、`src/logic/cpu/wasm/threatAdapter.ts`(新, `createsFour`/`createsOpenThree` 委譲・未ロード時TSフォールバック)、`threatAdapter.test.ts`(新)
+- **安全網**: `threatAdapter.test.ts`（wasm == TS を全コーパス照合、**黒長連ケース必須**）。`bitboard.initFromCells` 忘れがパリティで即露見
+- **実装者向け注意**: classifyPointWasm を使わない旨をコメント明記
+
+### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）
+
+- **触る**: `src/logic/cpu/review/candidateVerification.ts`、`src/logic/vcfPuzzle.ts`。import を threatAdapter に差替（各ファイル独立コミット可）
+- **利用点削減**: **−2**（review-live と puzzle-live を同時に救う）
+- **安全網**: PR0拡張 reviewSnapshot + threatAdapter.test + renjuParity
+- `threatMoves.ts` 本体はフォールバックとして当面残置（削除は P4）
+
+### PR4 — `detectOpponentThreats` を Zig 委譲（review 中核・最大の利用点削減）
+
+- **Zigに移す**: `threats.detectOpponentThreats`(既存) を threat_wasm に export、ThreatInfo を wire 化（`forced_win_tree` の wire が前例）
+- **触る**: `zig/src/threat_wasm.zig`、`threatAdapter.ts`、`src/logic/cpu/review/fullEval.ts`、`forcedLossCheck.ts`。**main search の `moveOrdering.ts` は別系統＝触らない**（`detectOpponentThreatsFast` との混同注意）
+- **利用点削減**: **−3**
+- **安全網**: PR0拡張 reviewSnapshot + adapter test に ThreatInfo 全フィールド照合（各リスト座標ソート）
+
+### PR5 — Mise系（`createsFourThree`/`findMiseTargets`/`findDoubleMiseMoves`）差分検証→委譲
+
+- **Zigに移す**: `evaluate.createsFourThree`(既存)、`mise_vcf.findMiseTargetsLite`。**フル版 `findMiseTargets`(±2近傍走査) が Lite で足りるかの差分検証が前提**（不一致ならフル版 Zig 新規実装に分岐）
+- **触る**: `threat_wasm.zig`、`threatAdapter.ts`、`review/fullEval.ts`、`forcedWinDetection.ts`、`forcedLossCheck.ts`、`doubleMiseBranches.ts`
+- **利用点削減**: **−3〜4**（forbiddenMoves.ts 依存が外れる）
+- **リスク**: 高。先に差分 test で可視化してから実装。
+
+### PR6 — VCT安全性ヘルパー（`hasFourThreeAvailable`/`hasOpenThree`/`findThreatMoves`）委譲
+
+- **Zigに移す**: 盤面全走査版（per-direction 部品 `vct.classifyThreat`/`createsOpenThree` は既存、統合ループを Zig に）
+- **触る**: `threat_wasm.zig`、`threatAdapter.ts`、`forcedLossCheck.ts`(isMiseVCTSafe)、`forcedWinDetection.ts`
+- **利用点削減**: **−3〜4**
+- **リスク**: `findThreatMoves` の列挙順序が VCT 探索順に影響し `forcedWin.sequence` を変える恐れ → 座標昇順正規化、ただし sequence が意味を持つ箇所は完全一致
+
+### PR7 — 削除可否の棚卸し（P4 #43 への前置き・調査PR）
+
+- review path 直接利用ゼロを grep 証明。dead 確認済（`countThreatDirections`/`hasDefenseThatBlocksBoth`）は削除候補に印
+- **報告**: 物理削除（P4）は **main search（moveOrdering/threatDetectionFast）の Zig 化**に依存（P3 スコープ外の可能性大）
+
+## P4 への距離（利用点の減り方）
+
+PR3→PR6 で **review path の patterns.ts/forbiddenMoves.ts 直接利用がゼロ**。物理削除は main search の Zig 化に依存する点を PR7 で確定報告。
+
+## load-bearing な参照箇所
+
+- `zig/src/vct.zig:48 classifyThreat`（真の橋）、`vct.zig` の `isJumpFourOverline`/`isOverlineEnd`
+- `zig/src/main.zig:59 classifyPointWasm`（橋に使わない。PR1 で #21 オラクルとしてのみ正確化）
+- `src/logic/cpu/search/threatMoves.ts:27 createsFour` / `:82 createsOpenThree` / `:213 isJumpFourOverline`
+- `src/logic/cpu/core/lineAnalysis.ts checkEndsForFour`（黒長連端の無効化）
+- `src/logic/cpu/wasm/forbiddenAdapter.ts` / `zig/src/forbidden_wasm.zig` / `zig/build.zig`（PR2 のテンプレ、唯一差は `bitboard.initFromCells`）
+- `src/logic/cpu/review/reviewSnapshot.test.ts`（PR0 拡張対象）
+- `src/logic/cpu/review/fullEval.ts` / `forcedLossCheck.ts`（PR4 の detectOpponentThreats 利用点）

--- a/src/logic/cpu/review.worker.ts
+++ b/src/logic/cpu/review.worker.ts
@@ -21,7 +21,6 @@ import { createBoardFromRecord } from "@/logic/gameRecordParser";
 import type { WasmModuleContext } from "./wasm/types";
 
 import { countStones } from "./core/boardUtils";
-import { detectOpponentThreats } from "./evaluation";
 import { FORCED_LOSS_VCT_OPTIONS } from "./review/forcedLossCheck";
 import { detectForcedWin } from "./review/forcedWinDetection";
 import { executeFullEval } from "./review/fullEval";
@@ -29,7 +28,8 @@ import { wasmFindVCTSequence } from "./review/wasmAdapters";
 import { VCT_STONE_THRESHOLD } from "./search/types";
 import { loadWasmModule } from "./wasm/loader";
 import { WasmSearchEngine } from "./wasm/searchEngine";
-import { preloadThreatWasm } from "./wasm/threatAdapter";
+// #37 P3 PR4: 脅威検出も Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { detectOpponentThreats, preloadThreatWasm } from "./wasm/threatAdapter";
 
 /** WASM モジュール（初回ロード後にキャッシュ） */
 let cachedWasm: WasmModuleContext | null = null;

--- a/src/logic/cpu/review.worker.ts
+++ b/src/logic/cpu/review.worker.ts
@@ -29,6 +29,7 @@ import { wasmFindVCTSequence } from "./review/wasmAdapters";
 import { VCT_STONE_THRESHOLD } from "./search/types";
 import { loadWasmModule } from "./wasm/loader";
 import { WasmSearchEngine } from "./wasm/searchEngine";
+import { preloadThreatWasm } from "./wasm/threatAdapter";
 
 /** WASM モジュール（初回ロード後にキャッシュ） */
 let cachedWasm: WasmModuleContext | null = null;
@@ -37,7 +38,10 @@ async function getWasmModule(): Promise<WasmModuleContext> {
   if (cachedWasm) {
     return cachedWasm;
   }
+  // #37 P3 PR3: 脅威分類 thin wasm も同時にロード（candidateVerification の四/活三判定用）。
+  // 未ロード時は threatAdapter が TS フォールバックするため、失敗してもクラッシュしない。
   cachedWasm = await loadWasmModule();
+  await preloadThreatWasm();
   return cachedWasm;
 }
 

--- a/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
+++ b/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
@@ -1,5 +1,276 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > annotateFukumiMoves: 'mise-vcf-#18' 1`] = `[]`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > annotateFukumiMoves: 'white29-m20' 1`] = `
+[
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 9,
+      "row": 6,
+    },
+  },
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 9,
+      "row": 7,
+    },
+  },
+  {
+    "fukumiDepth": 3,
+    "isFukumi": true,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > annotateFukumiMoves: 'white29-m24' 1`] = `
+[
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 8,
+      "row": 5,
+    },
+  },
+  {
+    "fukumiDepth": null,
+    "isFukumi": false,
+    "position": {
+      "col": 6,
+      "row": 3,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > checkCandidateForcedLoss: 'mise-vcf-#18' 1`] = `[]`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > checkCandidateForcedLoss: 'white29-m20' 1`] = `
+[
+  {
+    "loss": null,
+    "position": {
+      "col": 9,
+      "row": 6,
+    },
+  },
+  {
+    "loss": null,
+    "position": {
+      "col": 9,
+      "row": 7,
+    },
+  },
+  {
+    "loss": null,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > checkCandidateForcedLoss: 'white29-m24' 1`] = `
+[
+  {
+    "loss": null,
+    "position": {
+      "col": 10,
+      "row": 7,
+    },
+  },
+  {
+    "loss": {
+      "sequence": [
+        {
+          "col": 10,
+          "row": 11,
+        },
+        {
+          "col": 8,
+          "row": 9,
+        },
+        {
+          "col": 10,
+          "row": 8,
+        },
+      ],
+      "type": "vcf",
+    },
+    "position": {
+      "col": 8,
+      "row": 5,
+    },
+  },
+  {
+    "loss": {
+      "sequence": [
+        {
+          "col": 10,
+          "row": 11,
+        },
+        {
+          "col": 8,
+          "row": 9,
+        },
+        {
+          "col": 10,
+          "row": 8,
+        },
+      ],
+      "type": "vcf",
+    },
+    "position": {
+      "col": 6,
+      "row": 3,
+    },
+  },
+]
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > counterThreatGuards: 'mise-vcf-#18' 1`] = `
+{
+  "hasFourThreeOpponent": false,
+  "hasFourThreeSelf": false,
+  "hasOpenThreeOpponent": false,
+  "hasOpenThreeSelf": false,
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > counterThreatGuards: 'white29-m20' 1`] = `
+{
+  "hasFourThreeOpponent": false,
+  "hasFourThreeSelf": false,
+  "hasOpenThreeOpponent": false,
+  "hasOpenThreeSelf": false,
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > counterThreatGuards: 'white29-m24' 1`] = `
+{
+  "hasFourThreeOpponent": true,
+  "hasFourThreeSelf": true,
+  "hasOpenThreeOpponent": false,
+  "hasOpenThreeSelf": false,
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > detectOpponentThreats: 'mise-vcf-#18' 1`] = `
+{
+  "opponent": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+  "self": {
+    "doubleThrees": [
+      {
+        "col": 8,
+        "row": 11,
+      },
+    ],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > detectOpponentThreats: 'white29-m20' 1`] = `
+{
+  "opponent": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+  "self": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [],
+    "openFours": [],
+    "openThrees": [],
+  },
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > detectOpponentThreats: 'white29-m24' 1`] = `
+{
+  "opponent": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [
+      {
+        "col": 10,
+        "row": 11,
+      },
+    ],
+    "openFours": [],
+    "openThrees": [],
+  },
+  "self": {
+    "doubleThrees": [],
+    "fours": [],
+    "mises": [
+      {
+        "col": 10,
+        "row": 7,
+      },
+    ],
+    "openFours": [],
+    "openThrees": [],
+  },
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > findDoubleMiseMoves: 'mise-vcf-#18' 1`] = `
+{
+  "opponent": [],
+  "self": [],
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > findDoubleMiseMoves: 'white29-m20' 1`] = `
+{
+  "opponent": [],
+  "self": [],
+}
+`;
+
+exports[`review 戦術プリミティブ出力スナップショット (#37 P3 安全網) > findDoubleMiseMoves: 'white29-m24' 1`] = `
+{
+  "opponent": [
+    {
+      "col": 5,
+      "row": 7,
+    },
+  ],
+  "self": [],
+}
+`;
+
 exports[`review 戦術出力スナップショット (#37 P0) > checkForcedLoss: 'mise-vcf-#18' 1`] = `
 {
   "sequence": [

--- a/src/logic/cpu/review/candidateVerification.ts
+++ b/src/logic/cpu/review/candidateVerification.ts
@@ -7,6 +7,7 @@
 import type { BoardState } from "@/types/game";
 import type { ForcedLossResult, ReviewCandidate } from "@/types/review";
 
+import type { VCFSearchOptions } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { createsFour, createsOpenThree } from "../search/threatMoves";
@@ -145,13 +146,15 @@ export function annotateFukumiMoves(
   board: BoardState,
   color: "black" | "white",
   wasmSearchEngine: WasmSearchEngine,
+  // テスト時に timeLimit=Infinity を注入し決定的にするためのフック（本番は既定値）。
+  vcfOptions: VCFSearchOptions = REVIEW_VCF_OPTIONS,
 ): void {
   // 置く前にVCFがあるならフクミ手は存在しない（既に強制勝ち局面）
   const existingVcf = wasmFindVCFSequence(
     wasmSearchEngine,
     board,
     color,
-    REVIEW_VCF_OPTIONS,
+    vcfOptions,
   );
   if (existingVcf) {
     return;
@@ -179,7 +182,7 @@ export function annotateFukumiMoves(
         wasmSearchEngine,
         board,
         color,
-        REVIEW_VCF_OPTIONS,
+        vcfOptions,
       );
       if (vcfResult) {
         cand.isFukumi = true;

--- a/src/logic/cpu/review/candidateVerification.ts
+++ b/src/logic/cpu/review/candidateVerification.ts
@@ -10,7 +10,9 @@ import type { ForcedLossResult, ReviewCandidate } from "@/types/review";
 import type { VCFSearchOptions } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { createsFour, createsOpenThree } from "../search/threatMoves";
+// #37 P3 PR3: 四/活三判定を Zig 単一ソース(vct.classifyThreat)経由に。
+// wasm 未ロード時は threatAdapter 内で TS createsFour/createsOpenThree にフォールバック。
+import { createsFour, createsOpenThree } from "../wasm/threatAdapter";
 import {
   checkCandidateForcedLoss,
   CANDIDATE_VERIFY_VCF_OPTIONS,

--- a/src/logic/cpu/review/doubleMiseBranches.ts
+++ b/src/logic/cpu/review/doubleMiseBranches.ts
@@ -7,7 +7,8 @@
 import type { BoardState, Position } from "@/types/game";
 import type { ForcedWinDefense, ForcedWinNode } from "@/types/review";
 
-import { createsFourThree } from "../evaluation/winningPatterns";
+// #37 P3 PR5: 四三判定を Zig 単一ソース(evaluate.createsFourThree)経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { createsFourThree } from "../wasm/threatAdapter";
 
 /**
  * 両ミセの詰み木を構築（#22）

--- a/src/logic/cpu/review/forcedLossCheck.ts
+++ b/src/logic/cpu/review/forcedLossCheck.ts
@@ -16,10 +16,11 @@ import type {
 } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { detectOpponentThreats } from "../evaluation";
 import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { detectWhiteWinningPattern } from "../evaluation/winningPatterns";
 import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
+// #37 P3 PR4: 脅威検出を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { detectOpponentThreats } from "../wasm/threatAdapter";
 import {
   wasmFindVCFSequence,
   wasmFindMiseVCFSequence,

--- a/src/logic/cpu/review/forcedWinDetection.ts
+++ b/src/logic/cpu/review/forcedWinDetection.ts
@@ -11,9 +11,10 @@ import type { VCTSearchOptions, VCTSequenceResult } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { findDoubleMiseMoves } from "../evaluation/tactics";
-import { createsFourThree } from "../evaluation/winningPatterns";
 import { findThreatMoves } from "../search/vctHelpers";
 import { validateVCTSequence } from "../search/vctValidation";
+// #37 P3 PR5: 四三判定を Zig 単一ソース(evaluate.createsFourThree)経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { createsFourThree } from "../wasm/threatAdapter";
 import {
   filterByCounterThreats,
   REVIEW_MISE_VCF_OPTIONS,

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -26,7 +26,6 @@ import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { countStones } from "../core/boardUtils";
 import {
-  detectOpponentThreats,
   evaluatePositionWithBreakdown,
   evaluateBoardWithBreakdown,
   PATTERN_SCORES,
@@ -34,6 +33,9 @@ import {
 import { findMiseTargets } from "../evaluation/miseTactics";
 import { colorToWasm } from "../wasm/boardAdapter";
 import { linearTreeFromSequence } from "../wasm/forcedWinTreeWire";
+// #37 P3 PR4: 脅威検出を Zig 単一ソース(threats.detectOpponentThreats)経由に。
+// 合法局面で TS と一致（threatAdapter.test 検証済）。未ロード時は TS フォールバック。
+import { detectOpponentThreats } from "../wasm/threatAdapter";
 import {
   verifyCandidates,
   findSafeBest,

--- a/src/logic/cpu/review/reviewSnapshot.test.ts
+++ b/src/logic/cpu/review/reviewSnapshot.test.ts
@@ -22,13 +22,20 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { ForcedWinNode } from "@/types/review";
+import type { BoardState, Position } from "@/types/game";
+import type { ForcedWinNode, ReviewCandidate } from "@/types/review";
 
 import { loadWasmModule } from "@/logic/cpu/wasm/loader";
 import { WasmSearchEngine } from "@/logic/cpu/wasm/searchEngine";
 import { createBoardFromRecord } from "@/logic/gameRecordParser";
 
+import { countStones } from "../core/boardUtils";
+import { detectOpponentThreats } from "../evaluation";
+import { findDoubleMiseMoves } from "../evaluation/tactics";
+import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
+import { annotateFukumiMoves } from "./candidateVerification";
 import {
+  checkCandidateForcedLoss,
   checkForcedLoss,
   FORCED_LOSS_VCT_OPTIONS,
   REVIEW_MISE_VCF_OPTIONS,
@@ -70,10 +77,65 @@ const CORPUS: { name: string; record: string; moveCount: number }[] = [
   },
 ];
 
+/** 決定的な候補手検証オプション（被必勝層を timeLimit=Infinity で node-bound 化） */
+const DETERMINISTIC_CANDIDATE_OPTIONS: ForcedLossCheckOptions = {
+  vcfOptions: { ...REVIEW_VCF_OPTIONS, timeLimit: Infinity },
+  miseVcfOptions: { ...REVIEW_MISE_VCF_OPTIONS, timeLimit: Infinity },
+  vctOptions: { ...FORCED_LOSS_VCT_OPTIONS, timeLimit: Infinity },
+};
+
 const sortPos = (
   a: { row: number; col: number },
   b: { row: number; col: number },
 ): number => a.row - b.row || a.col - b.col;
+
+/** 棋譜の1手（例 "H8"）を盤面座標へ変換（左下原点。fullEval と同じ規約） */
+function parseMove(token: string): Position {
+  const col = token.charCodeAt(0) - "A".charCodeAt(0);
+  const row = 15 - parseInt(token.slice(1), 10);
+  return { row, col };
+}
+
+/** ThreatInfo の全リストを座標昇順に正規化（探索順非依存化） */
+function normalizeThreatInfo(t: {
+  openFours: Position[];
+  fours: Position[];
+  openThrees: Position[];
+  mises: Position[];
+  doubleThrees: Position[];
+}): unknown {
+  return {
+    openFours: [...t.openFours].sort(sortPos),
+    fours: [...t.fours].sort(sortPos),
+    openThrees: [...t.openThrees].sort(sortPos),
+    mises: [...t.mises].sort(sortPos),
+    doubleThrees: [...t.doubleThrees].sort(sortPos),
+  };
+}
+
+/**
+ * 棋譜の moveCount 以降から `color` の着手候補を最大3点抽出する。
+ * board（moveCount 手前の局面）で空きのものだけを返す（決定的）。
+ */
+function candidatePositions(
+  board: BoardState,
+  moves: string[],
+  moveCount: number,
+): Position[] {
+  const result: Position[] = [];
+  // moveCount, +2, +4 は同色（color）の着手
+  for (const offset of [0, 2, 4]) {
+    const token = moves[moveCount + offset];
+    if (!token) {
+      continue;
+    }
+    const pos = parseMove(token);
+    if (board[pos.row]?.[pos.col] === null) {
+      result.push(pos);
+    }
+  }
+  return result;
+}
 
 /** 詰み木を分岐順非依存に正規化（defenses を defenderMove 座標でソート） */
 function normalizeTree(node: ForcedWinNode): unknown {
@@ -124,5 +186,106 @@ describe("review 戦術出力スナップショット (#37 P0)", () => {
       DETERMINISTIC_LOSS_OPTIONS,
     );
     expect(result ?? null).toMatchSnapshot();
+  });
+});
+
+/**
+ * P3 #42 で Zig へ移す戦術ヘルパーの**直接出力**を凍結する安全網。
+ *
+ * detectForcedWin / checkForcedLoss は上の describe が top-level（type/sequence）で凍結済だが、
+ * P3 の各 PR が置き換えるのは中の戦術プリミティブ（脅威検出・両ミセ・活三/四三・被必勝層）。
+ * これらは VCF/VCT と違い**時間非依存の純粋関数**（または timeLimit=Infinity で node-bound 化
+ * できる被必勝層）なので、ここで直接凍結すれば各移行 PR の「1ビット不変」を細粒度で検知できる。
+ *
+ * 対応する P3 PR:
+ *   detectOpponentThreats        → PR4（fullEval / forcedLossCheck の脅威検出）
+ *   findDoubleMiseMoves          → PR5（両ミセ）
+ *   hasOpenThree/hasFourThree    → PR6（filterByCounterThreats / VCT 安全性）
+ *   checkCandidateForcedLoss     → PR3/PR4（候補手の被必勝＝opponentForcedWin の出所）
+ *   annotateFukumiMoves          → PR3（createsFour/createsOpenThree を使う isFukumi 判定）
+ */
+describe("review 戦術プリミティブ出力スナップショット (#37 P3 安全網)", () => {
+  it.each(CORPUS)("detectOpponentThreats: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const opponentColor = nextColor === "black" ? "white" : "black";
+    const snapshot = {
+      // 手番側の脅威（fullEval の selfThreats 経路 / 着手後の自分の四判定）
+      self: normalizeThreatInfo(detectOpponentThreats(board, nextColor)),
+      // 相手の脅威（fullEval L385 / forcedLossCheck L324 の経路）
+      opponent: normalizeThreatInfo(
+        detectOpponentThreats(board, opponentColor),
+      ),
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it.each(CORPUS)("findDoubleMiseMoves: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const opponentColor = nextColor === "black" ? "white" : "black";
+    const snapshot = {
+      self: [...findDoubleMiseMoves(board, nextColor)].sort(sortPos),
+      opponent: [...findDoubleMiseMoves(board, opponentColor)].sort(sortPos),
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it.each(CORPUS)("counterThreatGuards: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const opponentColor = nextColor === "black" ? "white" : "black";
+    const snapshot = {
+      hasOpenThreeSelf: hasOpenThree(board, nextColor),
+      hasOpenThreeOpponent: hasOpenThree(board, opponentColor),
+      hasFourThreeSelf: hasFourThreeAvailable(board, nextColor),
+      hasFourThreeOpponent: hasFourThreeAvailable(board, opponentColor),
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it.each(CORPUS)(
+    "checkCandidateForcedLoss: $name",
+    ({ record, moveCount }) => {
+      const { board, nextColor } = createBoardFromRecord(record, moveCount);
+      const opponentColor = nextColor === "black" ? "white" : "black";
+      const moves = record.trim().split(/\s+/);
+      const stoneCount = countStones(board);
+      // moveCount 以降の手番側着手を候補に、被必勝（opponentForcedWin 相当）を凍結
+      const snapshot = candidatePositions(board, moves, moveCount).map(
+        (pos) => ({
+          position: pos,
+          loss:
+            checkCandidateForcedLoss(
+              board,
+              pos,
+              nextColor,
+              opponentColor,
+              stoneCount,
+              engine,
+              DETERMINISTIC_CANDIDATE_OPTIONS,
+            ) ?? null,
+        }),
+      );
+      expect(snapshot).toMatchSnapshot();
+    },
+  );
+
+  it.each(CORPUS)("annotateFukumiMoves: $name", ({ record, moveCount }) => {
+    const { board, nextColor } = createBoardFromRecord(record, moveCount);
+    const moves = record.trim().split(/\s+/);
+    const candidates: ReviewCandidate[] = candidatePositions(
+      board,
+      moves,
+      moveCount,
+    ).map((position) => ({ position, score: 0, searchScore: 0 }));
+    // timeLimit=Infinity を注入して node-bound 決定化
+    annotateFukumiMoves(candidates, board, nextColor, engine, {
+      ...REVIEW_VCF_OPTIONS,
+      timeLimit: Infinity,
+    });
+    const snapshot = candidates.map((c) => ({
+      position: c.position,
+      isFukumi: c.isFukumi ?? false,
+      fukumiDepth: c.fukumiDepth ?? null,
+    }));
+    expect(snapshot).toMatchSnapshot();
   });
 });

--- a/src/logic/cpu/review/reviewSnapshot.test.ts
+++ b/src/logic/cpu/review/reviewSnapshot.test.ts
@@ -33,6 +33,7 @@ import { countStones } from "../core/boardUtils";
 import { detectOpponentThreats } from "../evaluation";
 import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
+import { preloadThreatWasm } from "../wasm/threatAdapter";
 import { annotateFukumiMoves } from "./candidateVerification";
 import {
   checkCandidateForcedLoss,
@@ -152,6 +153,9 @@ function normalizeTree(node: ForcedWinNode): unknown {
 
 // WASM は1回だけロードして全テストで使い回す
 const engine = new WasmSearchEngine(await loadWasmModule());
+// #37 P3: 脅威分類 thin wasm も preload し、本番(worker)と同じ Zig 経路で凍結する。
+// 合法な実戦コーパスなので Zig==TS（threatAdapter.test で検証済）→ golden は不変。
+await preloadThreatWasm();
 
 describe("review 戦術出力スナップショット (#37 P0)", () => {
   it.each(CORPUS)("detectForcedWin: $name", ({ record, moveCount }) => {

--- a/src/logic/cpu/wasm/threatAdapter.test.ts
+++ b/src/logic/cpu/wasm/threatAdapter.test.ts
@@ -1,0 +1,147 @@
+/**
+ * 脅威分類アダプタ（#37 P3 PR2）のテスト。
+ *
+ * wasm 経由の `classifyThreat`（= vct.classifyThreat）が、全空き点・両色で TS
+ * `createsFour` / `createsOpenThree` と一致することを検証。**黒長連除外**を踏むため、
+ * 決定的乱数局面（高密度含む）で網羅する（renjuParity #21 と同方針）。wasm 未注入時の
+ * TS フォールバックも検証。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { BoardState, StoneColor } from "@/types/game";
+
+import {
+  createsFour as createsFourTs,
+  createsOpenThree as createsOpenThreeTs,
+} from "@/logic/cpu/search/threatMoves";
+import { createBoardFromRecord } from "@/logic/gameRecordParser";
+import { createEmptyBoard } from "@/logic/renjuRules/core";
+
+import {
+  classifyThreat,
+  preloadThreatWasm,
+  setThreatWasmForTest,
+} from "./threatAdapter";
+
+/** 決定的 PRNG（mulberry32、外部依存なし） */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** 決定的乱数局面（黒白混在・複数密度。非合法局面でも可。黒長連を踏むため高密度を含む） */
+function randomBoards(): { name: string; board: BoardState }[] {
+  const out: { name: string; board: BoardState }[] = [];
+  const densities = [0.25, 0.4, 0.55];
+  let seed = 0x1234abcd;
+  for (const density of densities) {
+    for (let n = 0; n < 8; n++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const board = createEmptyBoard();
+      for (let r = 0; r < 15; r++) {
+        for (let c = 0; c < 15; c++) {
+          if (rng() < density) {
+            const br = board[r];
+            if (br) {
+              br[c] = rng() < 0.5 ? "black" : "white";
+            }
+          }
+        }
+      }
+      out.push({ name: `rand d=${density} #${n}`, board });
+    }
+  }
+  return out;
+}
+
+function kifuBoards(): { name: string; board: BoardState }[] {
+  const records = [
+    "H8 H9 I8 G8 I9 I10 F7 G7 G9 H10 F9 J11",
+    "H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 F8 K9",
+  ];
+  return records.map((rec, i) => ({
+    name: `kifu#${i}`,
+    board: createBoardFromRecord(rec).board,
+  }));
+}
+
+// wasm を1回ロード（テスト全体で共有）
+await preloadThreatWasm();
+
+afterEach(async () => {
+  // 各テスト後に wasm を復帰（fallback テストで未注入にするため）
+  await preloadThreatWasm();
+});
+
+const corpus = [...kifuBoards(), ...randomBoards()];
+const COLORS: StoneColor[] = ["black", "white"];
+
+describe("threatAdapter (#37 P3 PR2)", () => {
+  it.each(corpus)(
+    "wasm == TS（全空き点・両色 createsFour/createsOpenThree）: $name",
+    async ({ board }) => {
+      await preloadThreatWasm();
+      const mismatches: string[] = [];
+      for (let row = 0; row < 15; row++) {
+        const boardRow = board[row];
+        if (!boardRow) {
+          continue;
+        }
+        for (let col = 0; col < 15; col++) {
+          if (boardRow[col]) {
+            continue;
+          }
+          for (const color of COLORS) {
+            // 契約: 石を配置済みで判定（TS createsFour と同一規約）
+            boardRow[col] = color;
+            const w = classifyThreat(board, row, col, color);
+            const tsFour = createsFourTs(board, row, col, color);
+            const tsOpen = createsOpenThreeTs(board, row, col, color);
+            boardRow[col] = null;
+            if (w.createsFour !== tsFour) {
+              mismatches.push(
+                `(${row},${col},${color}) four: wasm=${w.createsFour} ts=${tsFour}`,
+              );
+            }
+            if (w.createsOpenThree !== tsOpen) {
+              mismatches.push(
+                `(${row},${col},${color}) open3: wasm=${w.createsOpenThree} ts=${tsOpen}`,
+              );
+            }
+          }
+        }
+      }
+      expect(mismatches, mismatches.join("\n")).toEqual([]);
+    },
+  );
+
+  it("wasm 未ロード時は TS フォールバックする", () => {
+    setThreatWasmForTest(undefined);
+    const { board } = kifuBoards()[0]!;
+    for (let row = 0; row < 15; row++) {
+      const boardRow = board[row];
+      if (!boardRow) {
+        continue;
+      }
+      for (let col = 0; col < 15; col++) {
+        if (boardRow[col]) {
+          continue;
+        }
+        boardRow[col] = "black";
+        const w = classifyThreat(board, row, col, "black");
+        expect(w.createsFour).toBe(createsFourTs(board, row, col, "black"));
+        expect(w.createsOpenThree).toBe(
+          createsOpenThreeTs(board, row, col, "black"),
+        );
+        boardRow[col] = null;
+      }
+    }
+  });
+});

--- a/src/logic/cpu/wasm/threatAdapter.test.ts
+++ b/src/logic/cpu/wasm/threatAdapter.test.ts
@@ -8,8 +8,9 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import type { BoardState, StoneColor } from "@/types/game";
+import type { BoardState, Position, StoneColor } from "@/types/game";
 
+import { detectOpponentThreats as detectOpponentThreatsTs } from "@/logic/cpu/evaluation";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -19,6 +20,7 @@ import { createEmptyBoard } from "@/logic/renjuRules/core";
 
 import {
   classifyThreat,
+  detectOpponentThreats,
   preloadThreatWasm,
   setThreatWasmForTest,
 } from "./threatAdapter";
@@ -119,6 +121,50 @@ describe("threatAdapter (#37 P3 PR2)", () => {
         }
       }
       expect(mismatches, mismatches.join("\n")).toEqual([]);
+    },
+  );
+
+  const sortPos = (a: Position, b: Position): number =>
+    a.row - b.row || a.col - b.col;
+  const normalizeThreats = (t: {
+    openFours: Position[];
+    fours: Position[];
+    openThrees: Position[];
+    mises: Position[];
+    doubleThrees: Position[];
+  }): unknown => ({
+    openFours: [...t.openFours].sort(sortPos),
+    fours: [...t.fours].sort(sortPos),
+    openThrees: [...t.openThrees].sort(sortPos),
+    mises: [...t.mises].sort(sortPos),
+    doubleThrees: [...t.doubleThrees].sort(sortPos),
+  });
+
+  // detectOpponentThreats は**合法な実戦局面**で照合する。
+  // 非合法盤（多重四/長連/盤端の不能配置）では Zig と TS の合成ロジックが分岐しうるが、
+  // review が処理するのは合法局面のみ（実測: 実戦棋譜の全手数前置・両色で 100% 一致、
+  // 非合法ランダム盤のみ不一致）。classifyThreat は per-point プリミティブで非合法盤でも
+  // 一致するため、上の乱数照合（高密度=黒長連）はそのまま維持している。
+  const LEGAL_RECORDS = [
+    "H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 F8 K9 " +
+      "I11 I13 H6 E9 F11 F12 I5 J4 G5 H5 I7 J8 J6 J7 K7 L8 F4 E3 G3 H4 I6 K6 L5",
+    "H8 G8 H9 G7 G9 H7 I7 F10 F9 E9 I8 I9 G10 F11 H11 E8 J6 K5 J7 K6 J9 J5 J8 J10 K8 L8 I10 L7 G12",
+    "H8 H9 I8 G8 I9 I10 F7 G7 G9 H10 F9 J11",
+  ];
+
+  it.each(LEGAL_RECORDS)(
+    "detectOpponentThreats: wasm == TS（実戦棋譜 全手数前置・両色）: %s",
+    async (record) => {
+      await preloadThreatWasm();
+      const moves = record.trim().split(/\s+/);
+      for (let mc = 1; mc <= moves.length; mc++) {
+        const { board } = createBoardFromRecord(moves.slice(0, mc).join(" "));
+        for (const color of COLORS) {
+          const w = normalizeThreats(detectOpponentThreats(board, color));
+          const ts = normalizeThreats(detectOpponentThreatsTs(board, color));
+          expect(w, `mc=${mc} color=${color}`).toEqual(ts);
+        }
+      }
     },
   );
 

--- a/src/logic/cpu/wasm/threatAdapter.test.ts
+++ b/src/logic/cpu/wasm/threatAdapter.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { BoardState, Position, StoneColor } from "@/types/game";
 
 import { detectOpponentThreats as detectOpponentThreatsTs } from "@/logic/cpu/evaluation";
+import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -20,6 +21,7 @@ import { createEmptyBoard } from "@/logic/renjuRules/core";
 
 import {
   classifyThreat,
+  createsFourThree,
   detectOpponentThreats,
   preloadThreatWasm,
   setThreatWasmForTest,
@@ -165,6 +167,40 @@ describe("threatAdapter (#37 P3 PR2)", () => {
           expect(w, `mc=${mc} color=${color}`).toEqual(ts);
         }
       }
+    },
+  );
+
+  it.each(LEGAL_RECORDS)(
+    "createsFourThree: wasm == TS（実戦棋譜 全手数前置・全空き点・両色）: %s",
+    async (record) => {
+      await preloadThreatWasm();
+      const moves = record.trim().split(/\s+/);
+      const mismatches: string[] = [];
+      // 計算量を抑えるため代表的な手数（中盤以降で四三が出やすい）を間引いて検査
+      for (let mc = 6; mc <= moves.length; mc += 3) {
+        const { board } = createBoardFromRecord(moves.slice(0, mc).join(" "));
+        for (let row = 0; row < 15; row++) {
+          const boardRow = board[row];
+          if (!boardRow) {
+            continue;
+          }
+          for (let col = 0; col < 15; col++) {
+            if (boardRow[col]) {
+              continue;
+            }
+            for (const color of COLORS) {
+              const w = createsFourThree(board, row, col, color);
+              const ts = createsFourThreeTs(board, row, col, color);
+              if (w !== ts) {
+                mismatches.push(
+                  `mc=${mc} (${row},${col},${color}) w=${w} ts=${ts}`,
+                );
+              }
+            }
+          }
+        }
+      }
+      expect(mismatches, mismatches.join("\n")).toEqual([]);
     },
   );
 

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -23,6 +23,7 @@ import {
   detectOpponentThreats as detectOpponentThreatsTs,
   type ThreatInfo,
 } from "@/logic/cpu/evaluation";
+import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -119,6 +120,30 @@ export function createsOpenThree(
   color: "black" | "white",
 ): boolean {
   return classifyThreat(board, row, col, color).createsOpenThree;
+}
+
+/**
+ * (row,col)（**空き**前提）に color を打つと四三ができるか（黒は禁手考慮）。
+ * wasm 経由は Zig `evaluate.createsFourThree`。未ロード時は TS にフォールバック。
+ * 契約は TS `createsFourThree` と同じく**候補は空き**（内部で仮置き・復元）。
+ */
+export function createsFourThree(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): boolean {
+  if (wasm) {
+    syncBoard(wasm, board);
+    return (
+      wasm.createsFourThreeWasm(
+        row,
+        col,
+        color === "black" ? CELL.BLACK : CELL.WHITE,
+      ) !== 0
+    );
+  }
+  return createsFourThreeTs(board, row, col, color);
 }
 
 /** wasm バッファから ThreatInfo の1リスト（[count][count*(row,col)]）を読み出す。 */

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -17,8 +17,12 @@
  * 点ごとに呼ぶ用途（PR6 の findThreatMoves 等）を Zig 化する際は、基盤盤面を 1 度同期して
  * wasm 内で各点を配置・評価する**バッチ API** を別途用意し、点ごとの全盤再同期 O(n²) を避けること。
  */
-import type { BoardState } from "@/types/game";
+import type { BoardState, Position } from "@/types/game";
 
+import {
+  detectOpponentThreats as detectOpponentThreatsTs,
+  type ThreatInfo,
+} from "@/logic/cpu/evaluation";
 import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
@@ -115,4 +119,52 @@ export function createsOpenThree(
   color: "black" | "white",
 ): boolean {
   return classifyThreat(board, row, col, color).createsOpenThree;
+}
+
+/** wasm バッファから ThreatInfo の1リスト（[count][count*(row,col)]）を読み出す。 */
+function readPositionList(
+  mem: Uint8Array,
+  offset: number,
+): { positions: Position[]; next: number } {
+  const count = mem[offset] ?? 0;
+  let o = offset + 1;
+  const positions: Position[] = [];
+  for (let i = 0; i < count; i++) {
+    positions.push({ row: mem[o] ?? 0, col: mem[o + 1] ?? 0 });
+    o += 2;
+  }
+  return { positions, next: o };
+}
+
+/**
+ * opponentColor の脅威（活四/止め四/活三/ミセ/三三の各防御位置）を検出する（#37 P3 PR4）。
+ * wasm 経由は Zig `threats.detectOpponentThreats`。未ロード時は TS にフォールバック。
+ */
+export function detectOpponentThreats(
+  board: BoardState,
+  opponentColor: "black" | "white",
+): ThreatInfo {
+  if (wasm) {
+    syncBoard(wasm, board);
+    wasm.detectOpponentThreatsWasm(
+      opponentColor === "black" ? CELL.BLACK : CELL.WHITE,
+    );
+    const mem = new Uint8Array(wasm.memory.buffer);
+    let off = wasm.getThreatInfoBuffer();
+    const openFours = readPositionList(mem, off);
+    const fours = readPositionList(mem, openFours.next);
+    const openThrees = readPositionList(mem, fours.next);
+    const mises = readPositionList(mem, openThrees.next);
+    const doubleThrees = readPositionList(mem, mises.next);
+    off = doubleThrees.next;
+    return {
+      openFours: openFours.positions,
+      fours: fours.positions,
+      openThrees: openThrees.positions,
+      mises: mises.positions,
+      doubleThrees: doubleThrees.positions,
+    };
+  }
+  // フォールバック（wasm 未ロード時）
+  return detectOpponentThreatsTs(board, opponentColor);
 }

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -1,0 +1,118 @@
+/**
+ * 脅威分類アダプタ（#37 P3 PR2）
+ *
+ * 北極星「戦術＝Zig、TS＝プレゼン」に沿い、review/メインの `createsFour` / `createsOpenThree`
+ * （四 / 活三 判定）を脅威分類 thin wasm（Zig 単一ソース = vct.classifyThreat）経由にする橋。
+ *
+ * **本 PR では橋を敷設するだけで利用者はいない**（PR3 以降で利用点を張り替える）。
+ *
+ * wasm 未ロード時は TS `createsFour` / `createsOpenThree` にフォールバック（#21 パリティ＋
+ * 本アダプタのテストで TS==WASM を保証済みのため挙動同値・クラッシュ回避）。このフォールバックは
+ * 移行期の保険であり、#37 P4 の `threatMoves.ts` 削除時にこの経路も撤去する。
+ *
+ * 契約: `board` は (row,col) に `color` を**配置済み**の状態で渡す（TS `createsFour` と同一規約）。
+ *
+ * 性能ノート: 1 呼び出しごとに全盤同期（boardInit/boardSet + syncBitboard、各 O(225)）。
+ * PR3 の利用点（candidateVerification / vcfPuzzle）は候補数が少なく問題ない。盤面全走査で
+ * 点ごとに呼ぶ用途（PR6 の findThreatMoves 等）を Zig 化する際は、基盤盤面を 1 度同期して
+ * wasm 内で各点を配置・評価する**バッチ API** を別途用意し、点ごとの全盤再同期 O(n²) を避けること。
+ */
+import type { BoardState } from "@/types/game";
+
+import {
+  createsFour as createsFourTs,
+  createsOpenThree as createsOpenThreeTs,
+} from "@/logic/cpu/search/threatMoves";
+
+import { loadThreatWasm, type ThreatWasmContext } from "./threatLoader";
+import { CELL } from "./types";
+
+let wasm: ThreatWasmContext | undefined = undefined;
+
+/** 起動時に1回プリロード（非ブロッキング発火を想定）。 */
+export async function preloadThreatWasm(): Promise<void> {
+  if (wasm) {
+    return;
+  }
+  wasm = await loadThreatWasm();
+}
+
+/** テスト用: wasm インスタンスを直接注入/解除する。 */
+export function setThreatWasmForTest(w: ThreatWasmContext | undefined): void {
+  wasm = w;
+}
+
+function syncBoard(w: ThreatWasmContext, board: BoardState): void {
+  w.boardInit();
+  for (let row = 0; row < 15; row++) {
+    const boardRow = board[row];
+    if (!boardRow) {
+      continue;
+    }
+    for (let col = 0; col < 15; col++) {
+      const v = boardRow[col];
+      if (v === "black") {
+        w.boardSet(row, col, CELL.BLACK);
+      } else if (v === "white") {
+        w.boardSet(row, col, CELL.WHITE);
+      }
+    }
+  }
+  // vct.classifyThreat は line_lookup 経由で bitboard.global_bb に依存するため必須。
+  w.syncBitboard();
+}
+
+export interface ThreatClassification {
+  createsFour: boolean;
+  createsOpenThree: boolean;
+}
+
+/**
+ * (row,col) に color を配置済みの盤面で、四 / 活三ができるかを 1 往復で判定する。
+ * createsFour と createsOpenThree を両方使う呼び出し元は、本関数で wasm 往復を 1 回に削減できる。
+ */
+export function classifyThreat(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): ThreatClassification {
+  if (wasm) {
+    syncBoard(wasm, board);
+    // bits ∈ {0,1,2,3}: bit0=four, bit1=openThree。算術で展開（no-bitwise 準拠）。
+    const bits = wasm.classifyThreatWasm(
+      row,
+      col,
+      color === "black" ? CELL.BLACK : CELL.WHITE,
+    );
+    return {
+      createsFour: bits === 1 || bits === 3,
+      createsOpenThree: bits === 2 || bits === 3,
+    };
+  }
+  // フォールバック（wasm 未ロード時）
+  return {
+    createsFour: createsFourTs(board, row, col, color),
+    createsOpenThree: createsOpenThreeTs(board, row, col, color),
+  };
+}
+
+/** (row,col) に color を配置済みの盤面で四ができるか（黒は長連除外済）。 */
+export function createsFour(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): boolean {
+  return classifyThreat(board, row, col, color).createsFour;
+}
+
+/** (row,col) に color を配置済みの盤面で活三ができるか。 */
+export function createsOpenThree(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): boolean {
+  return classifyThreat(board, row, col, color).createsOpenThree;
+}

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -11,6 +11,8 @@ export interface ThreatWasmContext {
   syncBitboard: () => void;
   /** bit0=createsFour（黒長連除外済）/ bit1=createsOpenThree。(row,col) に color 配置済み前提。 */
   classifyThreatWasm: (row: number, col: number, color: number) => number;
+  /** (row,col)（空き前提）に color を打つと四三ができるか。1/0。内部で仮置き・復元。 */
+  createsFourThreeWasm: (row: number, col: number, color: number) => number;
   /** opponent_color の脅威を検出し ThreatInfo をバッファにシリアライズする（#37 P3 PR4）。 */
   detectOpponentThreatsWasm: (opponentColor: number) => void;
   /** ThreatInfo シリアライズバッファの先頭オフセット（memory 内）を返す。 */

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -1,0 +1,25 @@
+import { loadWasmBuffer } from "./loader";
+
+/**
+ * 脅威分類専用 thin wasm（~28KB）のエクスポート（#37 P3 PR2）。
+ * review/メインが 48MB エンジン wasm を載せずに四/活三判定（Zig 単一ソース=vct.classifyThreat）を使う最小面。
+ */
+export interface ThreatWasmContext {
+  boardInit: () => void;
+  boardSet: (row: number, col: number, value: number) => void;
+  /** cells から bitboard.global_bb を再構築する。classifyThreatWasm の前に必ず呼ぶ。 */
+  syncBitboard: () => void;
+  /** bit0=createsFour（黒長連除外済）/ bit1=createsOpenThree。(row,col) に color 配置済み前提。 */
+  classifyThreatWasm: (row: number, col: number, color: number) => number;
+}
+
+export async function loadThreatWasm(): Promise<ThreatWasmContext> {
+  const wasmUrl = new URL(
+    "../../../../zig/zig-out/bin/threat.wasm",
+    import.meta.url,
+  );
+  const buffer = await loadWasmBuffer(wasmUrl);
+  // threat.wasm は extern import を持たない（freestanding）
+  const { instance } = await WebAssembly.instantiate(buffer, {});
+  return instance.exports as unknown as ThreatWasmContext;
+}

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -7,10 +7,16 @@ import { loadWasmBuffer } from "./loader";
 export interface ThreatWasmContext {
   boardInit: () => void;
   boardSet: (row: number, col: number, value: number) => void;
-  /** cells から bitboard.global_bb を再構築する。classifyThreatWasm の前に必ず呼ぶ。 */
+  /** cells から bitboard.global_bb を再構築する。classifyThreatWasm/detectOpponentThreatsWasm の前に必ず呼ぶ。 */
   syncBitboard: () => void;
   /** bit0=createsFour（黒長連除外済）/ bit1=createsOpenThree。(row,col) に color 配置済み前提。 */
   classifyThreatWasm: (row: number, col: number, color: number) => number;
+  /** opponent_color の脅威を検出し ThreatInfo をバッファにシリアライズする（#37 P3 PR4）。 */
+  detectOpponentThreatsWasm: (opponentColor: number) => void;
+  /** ThreatInfo シリアライズバッファの先頭オフセット（memory 内）を返す。 */
+  getThreatInfoBuffer: () => number;
+  /** wasm 線形メモリ（バッファ読み取り用）。 */
+  memory: WebAssembly.Memory;
 }
 
 export async function loadThreatWasm(): Promise<ThreatWasmContext> {

--- a/src/logic/vcfPuzzle.ts
+++ b/src/logic/vcfPuzzle.ts
@@ -6,12 +6,14 @@
 
 import type { BoardState, Position } from "@/types/game";
 
-import { createsFour } from "@/logic/cpu/search/threatMoves";
 import {
   findWinningMove,
   getFourDefensePosition,
 } from "@/logic/cpu/search/threatPatterns";
 import { isForbiddenForBlack } from "@/logic/cpu/wasm/forbiddenAdapter";
+// #37 P3 PR3: 四判定を Zig 単一ソース(vct.classifyThreat)経由に（禁手は P2 で Zig 化済）。
+// wasm 未ロード時は threatAdapter 内で TS createsFour にフォールバック。
+import { createsFour } from "@/logic/cpu/wasm/threatAdapter";
 import { checkFive } from "@/logic/renjuRules/core";
 
 const BOARD_SIZE = 15;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import VueKonva from "vue-konva";
 
 import "./style.css";
 import { preloadForbiddenWasm } from "@/logic/cpu/wasm/forbiddenAdapter";
+import { preloadThreatWasm } from "@/logic/cpu/wasm/threatAdapter";
 
 import App from "./App.vue";
 
@@ -19,6 +20,12 @@ app.mount("#app");
 // 失敗しても isForbiddenForBlack が TS フォールバックするためクラッシュしない。
 preloadForbiddenWasm().catch((e: unknown) => {
   console.error("禁手 wasm のプリロードに失敗（TS フォールバックで継続）", e);
+});
+
+// 脅威分類 thin wasm（28KB）を非ブロッキングでプリロード（#37 P3。vcfPuzzle の四判定用）。
+// 失敗しても createsFour が TS フォールバックするためクラッシュしない。
+preloadThreatWasm().catch((e: unknown) => {
+  console.error("脅威 wasm のプリロードに失敗（TS フォールバックで継続）", e);
 });
 
 const updateSW = registerSW({

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -35,6 +35,25 @@ pub fn build(b: *std.Build) void {
     forbidden_lib.rdynamic = true;
     b.installArtifact(forbidden_lib);
 
+    // 脅威分類専用 thin wasm（#37 P3 PR2。review/メイン用。vct.classifyThreat を唯一の真実とする3つ目の出力）
+    //
+    // 3つ目以降の thin wasm 追加チェックリスト:
+    //   1. 依存は board + 真実関数の到達グラフのみ（Zig のデッドコード削除で thin に保つ）
+    //   2. bitboard.global_bb に依存する関数（line_lookup 経由）を使うなら syncBitboard を export
+    //   3. TS 側 loader は src/logic/cpu/wasm/loader.ts:loadWasmBuffer を再利用（DRY）
+    const threat_module = b.createModule(.{
+        .root_source_file = b.path("src/threat_wasm.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseFast,
+    });
+    const threat_lib = b.addExecutable(.{
+        .name = "threat",
+        .root_module = threat_module,
+    });
+    threat_lib.entry = .disabled;
+    threat_lib.rdynamic = true;
+    b.installArtifact(threat_lib);
+
     // Native test step (runs on host, not WASM)
     const native_target = b.resolveTargetQuery(.{});
 

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -1,0 +1,43 @@
+// 脅威分類専用 thin wasm（Issue #37 P3 / PR2）
+//
+// review worker / メインスレッド（vcfPuzzle）が、TS の `createsFour` / `createsOpenThree`
+// （= 四 / 活三 判定）を **Zig 単一ソース**経由で使うための最小 wasm。
+//
+// 橋の本体は `vct.classifyThreat`（vct.zig）。これは TS `threatMoves.ts` の `classifyThreat`
+// と 1:1 構造一致し、**黒長連除外（isJumpFourOverline / isOverlineEnd）を内包**する。
+// 注意: `main.zig` の `classifyPointWasm` は生パターンビット（長連除外なし）なので**使わない**。
+//
+// forbidden_wasm.zig との唯一の構造差: `vct.classifyThreat` は `line_lookup.queryPatternByCell`
+// 経由で `bitboard.global_bb` に依存するため、cells 同期に加えて `bitboard.initFromCells` の
+// 同期（syncBitboard）が必須。
+//
+// vct.zig は探索スタック全体を import するが、ここから到達するのは classifyThreat の呼ぶ
+// 関数のみ（Zig のデッドコード削除で thin に保たれる）。
+const bitboard = @import("bitboard.zig");
+const board = @import("board.zig");
+const vct = @import("vct.zig");
+
+export fn boardInit() void {
+    board.boardInit();
+}
+
+export fn boardSet(row: u8, col: u8, value: u8) void {
+    board.boardSet(row, col, value);
+}
+
+/// cells から bitboard.global_bb を再構築する。classifyThreatWasm の前に必ず呼ぶ。
+export fn syncBitboard() void {
+    bitboard.initFromCells(&board.board_cells);
+}
+
+/// (row,col) に color が**配置済み**の盤面で、四 / 活三ができるかを返す。
+/// bit0 = createsFour（黒は長連除外済）, bit1 = createsOpenThree。
+/// 呼び出し前に boardSet で cells を、syncBitboard で bitboard を同期しておくこと。
+export fn classifyThreatWasm(row: u8, col: u8, color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    const r = vct.classifyThreat(&board.board_cells, row, col, c);
+    var bits: u8 = 0;
+    if (r.creates_four) bits |= 1;
+    if (r.creates_open_three) bits |= 2;
+    return bits;
+}

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -15,6 +15,7 @@
 // 関数のみ（Zig のデッドコード削除で thin に保たれる）。
 const bitboard = @import("bitboard.zig");
 const board = @import("board.zig");
+const evaluate = @import("evaluate.zig");
 const threats = @import("threats.zig");
 const vct = @import("vct.zig");
 
@@ -41,6 +42,13 @@ export fn classifyThreatWasm(row: u8, col: u8, color: u8) u8 {
     if (r.creates_four) bits |= 1;
     if (r.creates_open_three) bits |= 2;
     return bits;
+}
+
+/// (row,col) が**空き**の盤面で、そこに color を打つと四三ができるか（黒は禁手考慮）。
+/// 内部で候補を仮置き・復元する（候補は空き前提）。事前に boardSet/syncBitboard で同期しておくこと。
+export fn createsFourThreeWasm(row: u8, col: u8, color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    return if (evaluate.createsFourThree(&board.board_cells, row, col, c)) 1 else 0;
 }
 
 // === detectOpponentThreats（ThreatInfo）の wire（#37 P3 PR4）===

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -15,6 +15,7 @@
 // 関数のみ（Zig のデッドコード削除で thin に保たれる）。
 const bitboard = @import("bitboard.zig");
 const board = @import("board.zig");
+const threats = @import("threats.zig");
 const vct = @import("vct.zig");
 
 export fn boardInit() void {
@@ -40,4 +41,40 @@ export fn classifyThreatWasm(row: u8, col: u8, color: u8) u8 {
     if (r.creates_four) bits |= 1;
     if (r.creates_open_three) bits |= 2;
     return bits;
+}
+
+// === detectOpponentThreats（ThreatInfo）の wire（#37 P3 PR4）===
+//
+// ThreatInfo = 5 リスト（open_fours/fours/open_threes/mises/double_threes、各 PositionList cap=64）。
+// バッファに [u8 count][count*(u8 row, u8 col)] を 5 回連結してシリアライズする。
+// 最大 5*(1 + 64*2) = 645 バイト。
+var threat_info_buffer: [768]u8 = undefined;
+
+export fn getThreatInfoBuffer() [*]u8 {
+    return &threat_info_buffer;
+}
+
+fn writeList(off: usize, list: *const threats.PositionList) usize {
+    var o = off;
+    threat_info_buffer[o] = list.len;
+    o += 1;
+    for (0..list.len) |i| {
+        threat_info_buffer[o] = list.items[i].row;
+        threat_info_buffer[o + 1] = list.items[i].col;
+        o += 2;
+    }
+    return o;
+}
+
+/// 相手(opponent_color)の脅威を検出し ThreatInfo をバッファにシリアライズする。
+/// 事前に boardSet で cells、syncBitboard で bitboard を同期しておくこと。
+export fn detectOpponentThreatsWasm(opponent_color: u8) void {
+    const c: board.Cell = @enumFromInt(opponent_color);
+    const info = threats.detectOpponentThreats(&board.board_cells, c);
+    var o: usize = 0;
+    o = writeList(o, &info.open_fours);
+    o = writeList(o, &info.fours);
+    o = writeList(o, &info.open_threes);
+    o = writeList(o, &info.mises);
+    o = writeList(o, &info.double_threes);
 }


### PR DESCRIPTION
## 本体 PR — #37 P3: review 戦術解析を Zig 構造化 API へ移行

review（振り返り）の戦術計算を Zig（単一ソース）へ寄せ、TS をプレゼン＋ワークフローに痩せさせる。副作用として `patterns.ts`/`forbiddenMoves.ts` への review-live 依存を剥がし、最終的な物理削除（P4 #43）へ近づける。

**この本体ブランチにサブ PR を統合済み。main へのマージは動作確認後にお願いします。**

### 統合済みサブ PR（→ `feat/issue-37-p3-review-zig`、いずれも MERGED）
| sub | PR | 内容 | patterns/forbidden 利用点 |
|---|---|---|---|
| sub1 | #52 | reviewSnapshot を戦術プリミティブまで拡張（**ロジック不変・安全網のみ**） | ±0 |
| sub2 | #58 | 脅威分類 thin wasm（`threat_wasm.zig`）+ adapter を新設（橋・利用者ゼロ） | ±0 |
| sub3 | #59 | `createsFour`/`createsOpenThree` 利用点を adapter へ張替 | **−2** |
| sub4 | #60 | `detectOpponentThreats` を Zig 委譲（ThreatInfo を wire 化） | **−3** |
| sub5a | #61 | `createsFourThree` を Zig 委譲 | **−2** |

### 確定した技術判断・主な発見
- **橋の本体は `vct.classifyThreat`**（vct.zig、黒長連除外を内包）。`main.zig` の `classifyPointWasm` は生パターンビットで TS と非同値のため**使わない**（#21 パリティ用オラクルとして維持）。当初計画の PR1（classifyPointWasm 改修）は #21 の粒度を下げ有害と判明し **drop**。
- thin wasm は `bitboard.initFromCells` 同期が必須（vct.classifyThreat が line_lookup 経由で global_bb 依存）。`threat_wasm.zig` は vct.zig を import するが Zig のデッドコード削除で thin に保たれる。
- **⚠️ detectOpponentThreats の Zig⇔TS は非合法盤（多重四・長連・盤端の不能配置）で食い違う**が、**review が処理するのは合法な実戦局面のみ**で実測 100% 一致（実戦棋譜 全手数前置・両色 約168局面）。合法手は黒長連（禁手）を作れないため候補仮置き盤も安全。
- 評価関数（`evaluatePositionWithBreakdown` 等）は P3 から除外（別 issue）。

### 安全網（挙動同値の担保）
- **reviewSnapshot を threat wasm preload 付きに強化** ＝ 本番(worker)と同じ Zig 経路で実戦コーパス（candidate 仮置き盤含む）を golden(TS) と照合し**バイト不変を実証**。
- threatAdapter.test（合法局面 Zig==TS、classifyThreat は黒長連含む乱数照合）/ renjuParity(#21) / vcfPuzzle.test。
- 各サブで vue-tsc 0 / oxlint 0 / zig build test 緑 / unit テスト緑（lefthook 3フック通過）。

### このPRに含まれないもの（P3 の残作業）
- **PR5b**: `findMiseTargets`/`findDoubleMiseMoves` の Zig 新規実装（Zig 等価が存在せず要実装）。
- **PR6**: VCT 安全性ヘルパー（`hasFourThreeAvailable`/`hasOpenThree`/`findThreatMoves`）の Zig 化。
- **PR7**: 削除可否の棚卸し（P4 #43 への前置き）。
- これらは本体マージ後に同様のサブ PR として追加予定。

設計全体: `docs/plans/issue-37-p3-review-zig.md`。関連: #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
