### PR TITLE
sub2: feat(cpu) 脅威分類 thin wasm + adapter 新設（橋・利用者ゼロ）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -63,7 +63,7 @@
       }
     },
     {
-      "files": ["**/renjuParity.test.ts"],
+      "files": ["**/renjuParity.test.ts", "**/threatAdapter.test.ts"],
       "rules": {
         "no-bitwise": "off"
       }

--- a/docs/plans/issue-37-p3-review-zig.md
+++ b/docs/plans/issue-37-p3-review-zig.md
@@ -49,19 +49,20 @@ review（振り返り）の戦術計算はすべて Zig。TS は「プレゼン�
 - **決定性検証**: 3回連続実行で snapshot 完全一致を確認済。コーパスは既存 P0 の forcing 局面（mise-vcf-#18 / white29-m20 / white29-m24）を流用。白29で `isFukumi:true/fukumiDepth:3`・`type:"vcf"` 被必勝列など実データを捕捉。
 - **ゲート結果**: vue-tsc 0 / oxlint 0 / review+parity 145 tests 緑（parity は wasm 再ビルド後）。
 
-### PR1 — `classifyPointWasm` 黒長連対応＋パリティ拡張（Zig only・本番未接続）
+### PR1 — ~~classifyPointWasm 黒長連対応~~【DROP（着手時に誤りと判明）】
 
-- **Zigに移す**: `classifyPointWasm` の four/jumpFour ビットに黒限定 overline 除外を組込。`vct.zig` の `isJumpFourOverline`/`isOverlineEnd` を pub 化して再利用
-- **触る**: `zig/src/main.zig`、`zig/src/vct.zig`(pub化)、`src/logic/renjuRules/renjuParity.test.ts`（Test A=黒跳び四overline / Test B=黒4連の先に黒石(checkEndsForFour) を追加、現状RED→Zig修正でGREEN）
-- **利用点削減**: ±0（#21 オラクル正確化のみ）
-- 目的は「本番で使うため」でなく **#21 オラクルの正確性向上**。橋本体は PR2。
+**取りやめ理由**: `classifyPointWasm` と TS オラクル `classifyPointTs` の bit は**生のパターンプリミティブ**（`four`/`jumpFour` は `checkJumpFour` 等をそのまま反映＝黒長連でも true、長連は別途 forbidden bit 24-25 で符号化）。#21 はこの**共有プリミティブの TS==Zig** を検証する設計で正しい。ここに黒長連除外を組み込むと (1) TS 側も変えないとパリティが壊れ (2) 生プリミティブ(checkJumpFour)と合成(createsFour)を混同させ #21 の粒度を下げる＝**有害**。`classifyPointWasm` は橋でもない（橋は `vct.classifyThreat`）ので触らない。
+**意図の受け皿**: 「vct.classifyThreat == TS createsFour を黒長連含め検証」は **PR2 の `threatAdapter.test`** が全空き点・両色・高密度局面で照合し内包済。既存 renjuParity が生プリミティブを、PR0 が createsFour 消費側 review 出力をガード済。
 
-### PR2 — threat 専用 thin wasm + adapter を新設（橋だけ・利用者ゼロ）
+### PR2 — threat 専用 thin wasm + adapter を新設（橋だけ・利用者ゼロ）【実装済】
 
-- **Zigに移す**: 新規 `zig/src/threat_wasm.zig`(thin)。export: `boardInit`/`boardSet`/`syncBitboard`(=`bitboard.initFromCells`) + `classifyThreatWasm(row,col,color)->u8`（bit0=four, bit1=openThree、内部で `vct.classifyThreat`）。依存を board+jump_patterns+threats+vct に限定
-- **触る**: `zig/src/threat_wasm.zig`(新)、`zig/build.zig`(3つ目の thin wasm target, forbidden 同型)、`src/logic/cpu/wasm/threatLoader.ts`(新)、`src/logic/cpu/wasm/threatAdapter.ts`(新, `createsFour`/`createsOpenThree` 委譲・未ロード時TSフォールバック)、`threatAdapter.test.ts`(新)
-- **安全網**: `threatAdapter.test.ts`（wasm == TS を全コーパス照合、**黒長連ケース必須**）。`bitboard.initFromCells` 忘れがパリティで即露見
-- **実装者向け注意**: classifyPointWasm を使わない旨をコメント明記
+- **Zigに移す**: 新規 `zig/src/threat_wasm.zig`(thin、**実測 27.9KB**)。export: `boardInit`/`boardSet`/`syncBitboard`(=`bitboard.initFromCells`) + `classifyThreatWasm(row,col,color)->u8`（bit0=four, bit1=openThree、内部で `vct.classifyThreat`、(r,c) 配置済前提）。vct.zig を import するが Zig のデッドコード削除で classifyThreat 到達グラフのみ＝thin。
+- **触る**: `zig/src/threat_wasm.zig`(新)、`zig/build.zig`(3つ目 thin wasm target `threat` + チェックリスト JSDoc)、`src/logic/cpu/wasm/threatLoader.ts`(新, `loadWasmBuffer` 再利用)、`src/logic/cpu/wasm/threatAdapter.ts`(新, `classifyThreat`/`createsFour`/`createsOpenThree`・未ロード時TSフォールバック)、`threatAdapter.test.ts`(新)、`.oxlintrc.json`(test の no-bitwise override 追加)
+- **API**: `classifyThreat(board,r,c,color)→{createsFour,createsOpenThree}` 一括（候補は配置済規約=TS createsFour と同一）。`createsFour`/`createsOpenThree` は一括の薄いラッパ。bit 展開は算術（`bits===1||bits===3` 等、no-bitwise 準拠）。
+- **安全網**: `threatAdapter.test.ts`（wasm == TS createsFour/createsOpenThree を全空き点・両色・決定的乱数局面 d=0.25/0.4/0.55＝**黒長連を踏む**で照合、27 tests 緑）。
+- **性能ノート（/review 反映）**: 1呼び出し=全盤同期 O(225)。PR3 の利用点（候補少数）は問題なし。盤面全走査用途（PR6）は基盤盤面を1度同期し wasm 内で各点評価する**バッチAPI**を別途用意し O(n²) を回避すること（ハッシュキャッシュは盤面が点ごとに変わるため無効＝採用せず、adapter にノート明記）。
+- **利用者ゼロ**: 起動時 preload（main.ts）は **PR3 で配線**（PR2 は adapter 未呼び出し＝完全 no-op）。PR3 で preloadThreatWasm を忘れると TS フォールバックのまま（正しさは不変だが Zig 未使用）になる点に注意。
+- **ゲート結果**: vue-tsc 0 / oxlint 0 / zig build test 緑 / unit 1799 tests 緑。
 
 ### PR3 — `createsFour`/`createsOpenThree` 利用点を adapter へ張替（patterns.ts 依存を最初に剥がす）
 

--- a/src/logic/cpu/wasm/threatAdapter.test.ts
+++ b/src/logic/cpu/wasm/threatAdapter.test.ts
@@ -1,0 +1,147 @@
+/**
+ * 脅威分類アダプタ（#37 P3 PR2）のテスト。
+ *
+ * wasm 経由の `classifyThreat`（= vct.classifyThreat）が、全空き点・両色で TS
+ * `createsFour` / `createsOpenThree` と一致することを検証。**黒長連除外**を踏むため、
+ * 決定的乱数局面（高密度含む）で網羅する（renjuParity #21 と同方針）。wasm 未注入時の
+ * TS フォールバックも検証。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { BoardState, StoneColor } from "@/types/game";
+
+import {
+  createsFour as createsFourTs,
+  createsOpenThree as createsOpenThreeTs,
+} from "@/logic/cpu/search/threatMoves";
+import { createBoardFromRecord } from "@/logic/gameRecordParser";
+import { createEmptyBoard } from "@/logic/renjuRules/core";
+
+import {
+  classifyThreat,
+  preloadThreatWasm,
+  setThreatWasmForTest,
+} from "./threatAdapter";
+
+/** 決定的 PRNG（mulberry32、外部依存なし） */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** 決定的乱数局面（黒白混在・複数密度。非合法局面でも可。黒長連を踏むため高密度を含む） */
+function randomBoards(): { name: string; board: BoardState }[] {
+  const out: { name: string; board: BoardState }[] = [];
+  const densities = [0.25, 0.4, 0.55];
+  let seed = 0x1234abcd;
+  for (const density of densities) {
+    for (let n = 0; n < 8; n++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const board = createEmptyBoard();
+      for (let r = 0; r < 15; r++) {
+        for (let c = 0; c < 15; c++) {
+          if (rng() < density) {
+            const br = board[r];
+            if (br) {
+              br[c] = rng() < 0.5 ? "black" : "white";
+            }
+          }
+        }
+      }
+      out.push({ name: `rand d=${density} #${n}`, board });
+    }
+  }
+  return out;
+}
+
+function kifuBoards(): { name: string; board: BoardState }[] {
+  const records = [
+    "H8 H9 I8 G8 I9 I10 F7 G7 G9 H10 F9 J11",
+    "H8 H9 I9 I8 G7 F6 G10 G9 F9 H11 H7 F7 F10 G8 I10 H10 K11 J10 F8 K9",
+  ];
+  return records.map((rec, i) => ({
+    name: `kifu#${i}`,
+    board: createBoardFromRecord(rec).board,
+  }));
+}
+
+// wasm を1回ロード（テスト全体で共有）
+await preloadThreatWasm();
+
+afterEach(async () => {
+  // 各テスト後に wasm を復帰（fallback テストで未注入にするため）
+  await preloadThreatWasm();
+});
+
+const corpus = [...kifuBoards(), ...randomBoards()];
+const COLORS: StoneColor[] = ["black", "white"];
+
+describe("threatAdapter (#37 P3 PR2)", () => {
+  it.each(corpus)(
+    "wasm == TS（全空き点・両色 createsFour/createsOpenThree）: $name",
+    async ({ board }) => {
+      await preloadThreatWasm();
+      const mismatches: string[] = [];
+      for (let row = 0; row < 15; row++) {
+        const boardRow = board[row];
+        if (!boardRow) {
+          continue;
+        }
+        for (let col = 0; col < 15; col++) {
+          if (boardRow[col]) {
+            continue;
+          }
+          for (const color of COLORS) {
+            // 契約: 石を配置済みで判定（TS createsFour と同一規約）
+            boardRow[col] = color;
+            const w = classifyThreat(board, row, col, color);
+            const tsFour = createsFourTs(board, row, col, color);
+            const tsOpen = createsOpenThreeTs(board, row, col, color);
+            boardRow[col] = null;
+            if (w.createsFour !== tsFour) {
+              mismatches.push(
+                `(${row},${col},${color}) four: wasm=${w.createsFour} ts=${tsFour}`,
+              );
+            }
+            if (w.createsOpenThree !== tsOpen) {
+              mismatches.push(
+                `(${row},${col},${color}) open3: wasm=${w.createsOpenThree} ts=${tsOpen}`,
+              );
+            }
+          }
+        }
+      }
+      expect(mismatches, mismatches.join("\n")).toEqual([]);
+    },
+  );
+
+  it("wasm 未ロード時は TS フォールバックする", () => {
+    setThreatWasmForTest(undefined);
+    const { board } = kifuBoards()[0]!;
+    for (let row = 0; row < 15; row++) {
+      const boardRow = board[row];
+      if (!boardRow) {
+        continue;
+      }
+      for (let col = 0; col < 15; col++) {
+        if (boardRow[col]) {
+          continue;
+        }
+        boardRow[col] = "black";
+        const w = classifyThreat(board, row, col, "black");
+        expect(w.createsFour).toBe(createsFourTs(board, row, col, "black"));
+        expect(w.createsOpenThree).toBe(
+          createsOpenThreeTs(board, row, col, "black"),
+        );
+        boardRow[col] = null;
+      }
+    }
+  });
+});

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -1,0 +1,118 @@
+/**
+ * 脅威分類アダプタ（#37 P3 PR2）
+ *
+ * 北極星「戦術＝Zig、TS＝プレゼン」に沿い、review/メインの `createsFour` / `createsOpenThree`
+ * （四 / 活三 判定）を脅威分類 thin wasm（Zig 単一ソース = vct.classifyThreat）経由にする橋。
+ *
+ * **本 PR では橋を敷設するだけで利用者はいない**（PR3 以降で利用点を張り替える）。
+ *
+ * wasm 未ロード時は TS `createsFour` / `createsOpenThree` にフォールバック（#21 パリティ＋
+ * 本アダプタのテストで TS==WASM を保証済みのため挙動同値・クラッシュ回避）。このフォールバックは
+ * 移行期の保険であり、#37 P4 の `threatMoves.ts` 削除時にこの経路も撤去する。
+ *
+ * 契約: `board` は (row,col) に `color` を**配置済み**の状態で渡す（TS `createsFour` と同一規約）。
+ *
+ * 性能ノート: 1 呼び出しごとに全盤同期（boardInit/boardSet + syncBitboard、各 O(225)）。
+ * PR3 の利用点（candidateVerification / vcfPuzzle）は候補数が少なく問題ない。盤面全走査で
+ * 点ごとに呼ぶ用途（PR6 の findThreatMoves 等）を Zig 化する際は、基盤盤面を 1 度同期して
+ * wasm 内で各点を配置・評価する**バッチ API** を別途用意し、点ごとの全盤再同期 O(n²) を避けること。
+ */
+import type { BoardState } from "@/types/game";
+
+import {
+  createsFour as createsFourTs,
+  createsOpenThree as createsOpenThreeTs,
+} from "@/logic/cpu/search/threatMoves";
+
+import { loadThreatWasm, type ThreatWasmContext } from "./threatLoader";
+import { CELL } from "./types";
+
+let wasm: ThreatWasmContext | undefined = undefined;
+
+/** 起動時に1回プリロード（非ブロッキング発火を想定）。 */
+export async function preloadThreatWasm(): Promise<void> {
+  if (wasm) {
+    return;
+  }
+  wasm = await loadThreatWasm();
+}
+
+/** テスト用: wasm インスタンスを直接注入/解除する。 */
+export function setThreatWasmForTest(w: ThreatWasmContext | undefined): void {
+  wasm = w;
+}
+
+function syncBoard(w: ThreatWasmContext, board: BoardState): void {
+  w.boardInit();
+  for (let row = 0; row < 15; row++) {
+    const boardRow = board[row];
+    if (!boardRow) {
+      continue;
+    }
+    for (let col = 0; col < 15; col++) {
+      const v = boardRow[col];
+      if (v === "black") {
+        w.boardSet(row, col, CELL.BLACK);
+      } else if (v === "white") {
+        w.boardSet(row, col, CELL.WHITE);
+      }
+    }
+  }
+  // vct.classifyThreat は line_lookup 経由で bitboard.global_bb に依存するため必須。
+  w.syncBitboard();
+}
+
+export interface ThreatClassification {
+  createsFour: boolean;
+  createsOpenThree: boolean;
+}
+
+/**
+ * (row,col) に color を配置済みの盤面で、四 / 活三ができるかを 1 往復で判定する。
+ * createsFour と createsOpenThree を両方使う呼び出し元は、本関数で wasm 往復を 1 回に削減できる。
+ */
+export function classifyThreat(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): ThreatClassification {
+  if (wasm) {
+    syncBoard(wasm, board);
+    // bits ∈ {0,1,2,3}: bit0=four, bit1=openThree。算術で展開（no-bitwise 準拠）。
+    const bits = wasm.classifyThreatWasm(
+      row,
+      col,
+      color === "black" ? CELL.BLACK : CELL.WHITE,
+    );
+    return {
+      createsFour: bits === 1 || bits === 3,
+      createsOpenThree: bits === 2 || bits === 3,
+    };
+  }
+  // フォールバック（wasm 未ロード時）
+  return {
+    createsFour: createsFourTs(board, row, col, color),
+    createsOpenThree: createsOpenThreeTs(board, row, col, color),
+  };
+}
+
+/** (row,col) に color を配置済みの盤面で四ができるか（黒は長連除外済）。 */
+export function createsFour(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): boolean {
+  return classifyThreat(board, row, col, color).createsFour;
+}
+
+/** (row,col) に color を配置済みの盤面で活三ができるか。 */
+export function createsOpenThree(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): boolean {
+  return classifyThreat(board, row, col, color).createsOpenThree;
+}

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -1,0 +1,25 @@
+import { loadWasmBuffer } from "./loader";
+
+/**
+ * 脅威分類専用 thin wasm（~28KB）のエクスポート（#37 P3 PR2）。
+ * review/メインが 48MB エンジン wasm を載せずに四/活三判定（Zig 単一ソース=vct.classifyThreat）を使う最小面。
+ */
+export interface ThreatWasmContext {
+  boardInit: () => void;
+  boardSet: (row: number, col: number, value: number) => void;
+  /** cells から bitboard.global_bb を再構築する。classifyThreatWasm の前に必ず呼ぶ。 */
+  syncBitboard: () => void;
+  /** bit0=createsFour（黒長連除外済）/ bit1=createsOpenThree。(row,col) に color 配置済み前提。 */
+  classifyThreatWasm: (row: number, col: number, color: number) => number;
+}
+
+export async function loadThreatWasm(): Promise<ThreatWasmContext> {
+  const wasmUrl = new URL(
+    "../../../../zig/zig-out/bin/threat.wasm",
+    import.meta.url,
+  );
+  const buffer = await loadWasmBuffer(wasmUrl);
+  // threat.wasm は extern import を持たない（freestanding）
+  const { instance } = await WebAssembly.instantiate(buffer, {});
+  return instance.exports as unknown as ThreatWasmContext;
+}

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -35,6 +35,25 @@ pub fn build(b: *std.Build) void {
     forbidden_lib.rdynamic = true;
     b.installArtifact(forbidden_lib);
 
+    // 脅威分類専用 thin wasm（#37 P3 PR2。review/メイン用。vct.classifyThreat を唯一の真実とする3つ目の出力）
+    //
+    // 3つ目以降の thin wasm 追加チェックリスト:
+    //   1. 依存は board + 真実関数の到達グラフのみ（Zig のデッドコード削除で thin に保つ）
+    //   2. bitboard.global_bb に依存する関数（line_lookup 経由）を使うなら syncBitboard を export
+    //   3. TS 側 loader は src/logic/cpu/wasm/loader.ts:loadWasmBuffer を再利用（DRY）
+    const threat_module = b.createModule(.{
+        .root_source_file = b.path("src/threat_wasm.zig"),
+        .target = wasm_target,
+        .optimize = .ReleaseFast,
+    });
+    const threat_lib = b.addExecutable(.{
+        .name = "threat",
+        .root_module = threat_module,
+    });
+    threat_lib.entry = .disabled;
+    threat_lib.rdynamic = true;
+    b.installArtifact(threat_lib);
+
     // Native test step (runs on host, not WASM)
     const native_target = b.resolveTargetQuery(.{});
 

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -1,0 +1,43 @@
+// 脅威分類専用 thin wasm（Issue #37 P3 / PR2）
+//
+// review worker / メインスレッド（vcfPuzzle）が、TS の `createsFour` / `createsOpenThree`
+// （= 四 / 活三 判定）を **Zig 単一ソース**経由で使うための最小 wasm。
+//
+// 橋の本体は `vct.classifyThreat`（vct.zig）。これは TS `threatMoves.ts` の `classifyThreat`
+// と 1:1 構造一致し、**黒長連除外（isJumpFourOverline / isOverlineEnd）を内包**する。
+// 注意: `main.zig` の `classifyPointWasm` は生パターンビット（長連除外なし）なので**使わない**。
+//
+// forbidden_wasm.zig との唯一の構造差: `vct.classifyThreat` は `line_lookup.queryPatternByCell`
+// 経由で `bitboard.global_bb` に依存するため、cells 同期に加えて `bitboard.initFromCells` の
+// 同期（syncBitboard）が必須。
+//
+// vct.zig は探索スタック全体を import するが、ここから到達するのは classifyThreat の呼ぶ
+// 関数のみ（Zig のデッドコード削除で thin に保たれる）。
+const bitboard = @import("bitboard.zig");
+const board = @import("board.zig");
+const vct = @import("vct.zig");
+
+export fn boardInit() void {
+    board.boardInit();
+}
+
+export fn boardSet(row: u8, col: u8, value: u8) void {
+    board.boardSet(row, col, value);
+}
+
+/// cells から bitboard.global_bb を再構築する。classifyThreatWasm の前に必ず呼ぶ。
+export fn syncBitboard() void {
+    bitboard.initFromCells(&board.board_cells);
+}
+
+/// (row,col) に color が**配置済み**の盤面で、四 / 活三ができるかを返す。
+/// bit0 = createsFour（黒は長連除外済）, bit1 = createsOpenThree。
+/// 呼び出し前に boardSet で cells を、syncBitboard で bitboard を同期しておくこと。
+export fn classifyThreatWasm(row: u8, col: u8, color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    const r = vct.classifyThreat(&board.board_cells, row, col, c);
+    var bits: u8 = 0;
+    if (r.creates_four) bits |= 1;
+    if (r.creates_open_three) bits |= 2;
+    return bits;
+}


### PR DESCRIPTION
→ feat/issue-37-p3-review-zig。threat_wasm.zig(27.9KB, vct.classifyThreat) + threatLoader/threatAdapter + 等価テスト(wasm==TS)。利用者ゼロ。