### PR TITLE
feat(cpu): #37 P3 review ミセ戦術の Zig 単一ソース化

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -63,7 +63,11 @@
       }
     },
     {
-      "files": ["**/renjuParity.test.ts", "**/threatAdapter.test.ts"],
+      "files": [
+        "**/renjuParity.test.ts",
+        "**/threatAdapter.test.ts",
+        "**/createsFourThreeParity.test.ts"
+      ],
       "rules": {
         "no-bitwise": "off"
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -67,7 +67,8 @@
         "**/renjuParity.test.ts",
         "**/threatAdapter.test.ts",
         "**/createsFourThreeParity.test.ts",
-        "**/findMiseTargetsParity.test.ts"
+        "**/findMiseTargetsParity.test.ts",
+        "**/findDoubleMiseMovesParity.test.ts"
       ],
       "rules": {
         "no-bitwise": "off"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -66,7 +66,8 @@
       "files": [
         "**/renjuParity.test.ts",
         "**/threatAdapter.test.ts",
-        "**/createsFourThreeParity.test.ts"
+        "**/createsFourThreeParity.test.ts",
+        "**/findMiseTargetsParity.test.ts"
       ],
       "rules": {
         "no-bitwise": "off"

--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -55,6 +55,7 @@ interface CliOptions {
   sprtBeta: number;
   randomFactor?: number;
   verbose: boolean;
+  jobs: number;
 }
 
 function parseArgs(): CliOptions {
@@ -70,6 +71,7 @@ function parseArgs(): CliOptions {
     sprtAlpha: DEFAULT_SPRT_CONFIG.alpha,
     sprtBeta: DEFAULT_SPRT_CONFIG.beta,
     verbose: false,
+    jobs: 1,
   };
 
   for (const arg of args) {
@@ -111,6 +113,11 @@ function parseArgs(): CliOptions {
         );
         process.exit(1);
       }
+    } else if (arg.startsWith("--jobs=")) {
+      const value = parseInt(arg.slice("--jobs=".length), 10);
+      if (!isNaN(value) && value > 0) {
+        options.jobs = value;
+      }
     } else if (arg === "--verbose" || arg === "-v") {
       options.verbose = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -138,6 +145,8 @@ Options:
   --elo0=<n>             SPRT帰無仮説Elo差 (default: 0)
   --elo1=<n>             SPRT対立仮説Elo差 (default: 30)
   --randomFactor=<n>     探索にゆらぎを加える (0〜1, default: なし)
+  --jobs=<n>             同時対局数（worker ペア組数, default: 1）。ターン制なので
+                         1ゲーム≈1コア。8コアなら6前後が目安
   --verbose, -v          詳細ログ
   --help, -h             ヘルプを表示
 
@@ -514,19 +523,18 @@ async function main(): Promise<void> {
 
   let worktreePathA: string | null = null;
   let worktreePathB: string | null = null;
-  let workerA: Worker | null = null;
-  let workerB: Worker | null = null;
+  // 並列実行用の worker ペア群（各ペア = A/B の bridge worker）。
+  // ゲームはターン制で実質1コアしか使わないため、ペアを複数組にして同時対局し
+  // 遊休コアを活用する（worktree の wasm は read-only なので複数 worker から共有可）。
+  const pairs: { a: Worker; b: Worker }[] = [];
 
   // クリーンアップ関数
   const cleanup = (): void => {
-    if (workerA) {
-      workerA.terminate();
-      workerA = null;
+    for (const pair of pairs) {
+      pair.a.terminate();
+      pair.b.terminate();
     }
-    if (workerB) {
-      workerB.terminate();
-      workerB = null;
-    }
+    pairs.length = 0;
     if (worktreePathA) {
       removeWorktree(worktreePathA);
       worktreePathA = null;
@@ -550,20 +558,26 @@ async function main(): Promise<void> {
     worktreePathA = createWorktree(commitA.sha, "A");
     worktreePathB = createWorktree(commitB.sha, "B");
 
-    // bridge workerを起動
-    console.log("Bridge workerを初期化中...");
-    [workerA, workerB] = await Promise.all([
-      createBridgeWorker(
-        worktreePathA,
-        options.difficulty,
-        options.randomFactor,
-      ),
-      createBridgeWorker(
-        worktreePathB,
-        options.difficulty,
-        options.randomFactor,
-      ),
-    ]);
+    // bridge workerを起動（--jobs 組のペアを並列初期化）
+    console.log(`Bridge workerを初期化中... (${options.jobs}並列)`);
+    const createdPairs = await Promise.all(
+      Array.from({ length: options.jobs }, async () => {
+        const [a, b] = await Promise.all([
+          createBridgeWorker(
+            worktreePathA!,
+            options.difficulty,
+            options.randomFactor,
+          ),
+          createBridgeWorker(
+            worktreePathB!,
+            options.difficulty,
+            options.randomFactor,
+          ),
+        ]);
+        return { a, b };
+      }),
+    );
+    pairs.push(...createdPairs);
     console.log("Bridge worker初期化完了\n");
 
     // 珠型タスクリスト生成（フラット化）
@@ -596,121 +610,140 @@ async function main(): Promise<void> {
       B: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
     };
 
-    // 珠型セット制で逐次実行（同じworkerを使い回すため意図的な順次実行）
-    for (const { jushuName, positions, isABlack } of jushuTasks) {
-      const result = await runCommitGame(workerA, workerB, isABlack, {
-        verbose: options.verbose,
-        moveTimeoutMs: 30000,
-        openingMoves: positions,
-      });
-
-      // WDL更新（commitA = playerA 視点）
-      if (result.winner === "draw") {
-        wdl.draws++;
-      } else if (result.winner === "A") {
-        wdl.wins++;
-      } else {
-        wdl.losses++;
-      }
-
-      games.push({ ...result, jushuName });
-
-      completedGames++;
-
-      // 初回ゲーム後のサニティチェック
-      if (completedGames === 1) {
-        const avgTime =
-          result.moveHistory.reduce(
-            (s: number, m: { time: number }) => s + m.time,
-            0,
-          ) / result.moveHistory.length;
-        const maxTime = Math.max(
-          ...result.moveHistory.map((m: { time: number }) => m.time),
-        );
-        console.log(`\n[サニティチェック] 初回ゲーム完了`);
-        console.log(
-          `  手数: ${result.moves} | 勝者: ${result.winner} | 理由: ${result.reason}`,
-        );
-        console.log(
-          `  平均思考時間: ${Math.round(avgTime)}ms | 最大: ${Math.round(maxTime)}ms`,
-        );
-        console.log(`  duration: ${Math.round(result.duration)}ms`);
-        if (avgTime < 1) {
-          console.warn(
-            "  ⚠ 平均思考時間が1ms未満 — エンジンが正しくロードされていない可能性",
-          );
-        }
-      }
-
-      // この局のA/B統計を集計し、累積にも加算
-      const gameAcc = {
-        A: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
-        B: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
-      };
-      for (let i = 0; i < result.moveHistory.length; i++) {
-        const move = result.moveHistory[i]!;
-        if (move.isOpening) {
-          continue;
-        }
-        const isBlackMove = i % 2 === 0;
-        const player =
-          (isBlackMove && isABlack) || (!isBlackMove && !isABlack) ? "A" : "B";
-        const ga = gameAcc[player];
-        const ca = cumAcc[player];
-        if (move.depth !== undefined) {
-          ga.depthSum += move.depth;
-          ga.maxDepth = Math.max(ga.maxDepth, move.depth);
-          ca.depthSum += move.depth;
-          ca.maxDepth = Math.max(ca.maxDepth, move.depth);
-        }
-        ga.timeSum += move.time;
-        ga.count++;
-        ca.timeSum += move.time;
-        ca.count++;
-      }
-
-      // ステータス表示
-      const elapsed = ((performance.now() - startTime) / 1000).toFixed(0);
-      const elo = estimateEloDiff(wdl);
-      let statusMsg = `[${elapsed}s] ${completedGames}/${totalGames} ${jushuName} ${isABlack ? "A黒" : "A白"} +${wdl.wins}=${wdl.draws}-${wdl.losses} Elo:${elo.eloDiff > 0 ? "+" : ""}${elo.eloDiff}`;
-
-      if (sprtConfig) {
-        const sprt = updateSPRT(wdl, sprtConfig);
-        statusMsg += ` LLR:${sprt.llr.toFixed(2)}`;
-        if (sprt.decision !== "continue") {
-          writeStatus(statusMsg);
-          clearStatus();
-          console.log(
-            `SPRT判定: ${sprt.decision} (${completedGames}局目で停止)`,
-          );
+    // 珠型タスクを --jobs 組の worker ペアで並列消化する。
+    // ゲームはターン制で実質1コアしか使わないため、複数ペア同時対局で遊休コアを活用。
+    // 結果処理（WDL/統計/ステータス/SPRT）は await を挟まず同期実行されるため競合しない。
+    let nextTask = 0;
+    let stop = false;
+    const runPair = async (pair: { a: Worker; b: Worker }): Promise<void> => {
+      while (!stop) {
+        const taskIdx = nextTask;
+        nextTask += 1;
+        if (taskIdx >= jushuTasks.length) {
           break;
         }
+        const { jushuName, positions, isABlack } = jushuTasks[taskIdx]!;
+        const result = await runCommitGame(pair.a, pair.b, isABlack, {
+          verbose: options.verbose,
+          moveTimeoutMs: 30000,
+          openingMoves: positions,
+        });
+        if (stop) {
+          break;
+        }
+
+        // WDL更新（commitA = playerA 視点）
+        if (result.winner === "draw") {
+          wdl.draws++;
+        } else if (result.winner === "A") {
+          wdl.wins++;
+        } else {
+          wdl.losses++;
+        }
+
+        games.push({ ...result, jushuName });
+
+        completedGames++;
+
+        // 初回ゲーム後のサニティチェック
+        if (completedGames === 1) {
+          const avgTime =
+            result.moveHistory.reduce(
+              (s: number, m: { time: number }) => s + m.time,
+              0,
+            ) / result.moveHistory.length;
+          const maxTime = Math.max(
+            ...result.moveHistory.map((m: { time: number }) => m.time),
+          );
+          console.log(`\n[サニティチェック] 初回ゲーム完了`);
+          console.log(
+            `  手数: ${result.moves} | 勝者: ${result.winner} | 理由: ${result.reason}`,
+          );
+          console.log(
+            `  平均思考時間: ${Math.round(avgTime)}ms | 最大: ${Math.round(maxTime)}ms`,
+          );
+          console.log(`  duration: ${Math.round(result.duration)}ms`);
+          if (avgTime < 1) {
+            console.warn(
+              "  ⚠ 平均思考時間が1ms未満 — エンジンが正しくロードされていない可能性",
+            );
+          }
+        }
+
+        // この局のA/B統計を集計し、累積にも加算
+        const gameAcc = {
+          A: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
+          B: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
+        };
+        for (let i = 0; i < result.moveHistory.length; i++) {
+          const move = result.moveHistory[i]!;
+          if (move.isOpening) {
+            continue;
+          }
+          const isBlackMove = i % 2 === 0;
+          const player =
+            (isBlackMove && isABlack) || (!isBlackMove && !isABlack)
+              ? "A"
+              : "B";
+          const ga = gameAcc[player];
+          const ca = cumAcc[player];
+          if (move.depth !== undefined) {
+            ga.depthSum += move.depth;
+            ga.maxDepth = Math.max(ga.maxDepth, move.depth);
+            ca.depthSum += move.depth;
+            ca.maxDepth = Math.max(ca.maxDepth, move.depth);
+          }
+          ga.timeSum += move.time;
+          ga.count++;
+          ca.timeSum += move.time;
+          ca.count++;
+        }
+
+        // ステータス表示
+        const elapsed = ((performance.now() - startTime) / 1000).toFixed(0);
+        const elo = estimateEloDiff(wdl);
+        let statusMsg = `[${elapsed}s] ${completedGames}/${totalGames} ${jushuName} ${isABlack ? "A黒" : "A白"} +${wdl.wins}=${wdl.draws}-${wdl.losses} Elo:${elo.eloDiff > 0 ? "+" : ""}${elo.eloDiff}`;
+
+        if (sprtConfig) {
+          const sprt = updateSPRT(wdl, sprtConfig);
+          statusMsg += ` LLR:${sprt.llr.toFixed(2)}`;
+          if (sprt.decision !== "continue") {
+            writeStatus(statusMsg);
+            clearStatus();
+            console.log(
+              `SPRT判定: ${sprt.decision} (${completedGames}局目で停止)`,
+            );
+            stop = true;
+          }
+        }
+
+        writeStatus(statusMsg);
+
+        // 1局ごとの性能統計（改行で表示）
+        const fmtDepth = (a: {
+          depthSum: number;
+          timeSum: number;
+          count: number;
+        }): string =>
+          a.count > 0
+            ? `d=${(a.depthSum / a.count).toFixed(1)} t=${Math.round(a.timeSum / a.count)}ms`
+            : "n/a";
+        const fmtCum = (a: {
+          depthSum: number;
+          count: number;
+          maxDepth: number;
+          timeSum: number;
+        }): string =>
+          a.count > 0
+            ? `d=${(a.depthSum / a.count).toFixed(2)} max=${a.maxDepth} t=${Math.round(a.timeSum / a.count)}ms`
+            : "n/a";
+        console.log(
+          `\n  局: A[${fmtDepth(gameAcc.A)}] B[${fmtDepth(gameAcc.B)}] | 累計: A[${fmtCum(cumAcc.A)}] B[${fmtCum(cumAcc.B)}]`,
+        );
       }
+    };
 
-      writeStatus(statusMsg);
-
-      // 1局ごとの性能統計（改行で表示）
-      const fmtDepth = (a: {
-        depthSum: number;
-        timeSum: number;
-        count: number;
-      }): string =>
-        a.count > 0
-          ? `d=${(a.depthSum / a.count).toFixed(1)} t=${Math.round(a.timeSum / a.count)}ms`
-          : "n/a";
-      const fmtCum = (a: {
-        depthSum: number;
-        count: number;
-        maxDepth: number;
-        timeSum: number;
-      }): string =>
-        a.count > 0
-          ? `d=${(a.depthSum / a.count).toFixed(2)} max=${a.maxDepth} t=${Math.round(a.timeSum / a.count)}ms`
-          : "n/a";
-      console.log(
-        `\n  局: A[${fmtDepth(gameAcc.A)}] B[${fmtDepth(gameAcc.B)}] | 累計: A[${fmtCum(cumAcc.A)}] B[${fmtCum(cumAcc.B)}]`,
-      );
-    }
+    await Promise.all(pairs.map((p) => runPair(p)));
 
     clearStatus();
 

--- a/src/logic/cpu/review/forcedLossCheck.ts
+++ b/src/logic/cpu/review/forcedLossCheck.ts
@@ -16,11 +16,13 @@ import type {
 } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { detectWhiteWinningPattern } from "../evaluation/winningPatterns";
 import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
-// #37 P3 PR4: 脅威検出を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
-import { detectOpponentThreats } from "../wasm/threatAdapter";
+// #37 P3 PR4/PR5b: 脅威検出・両ミセ手を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import {
+  detectOpponentThreats,
+  findDoubleMiseMoves,
+} from "../wasm/threatAdapter";
 import {
   wasmFindVCFSequence,
   wasmFindMiseVCFSequence,

--- a/src/logic/cpu/review/forcedWinDetection.ts
+++ b/src/logic/cpu/review/forcedWinDetection.ts
@@ -10,11 +10,10 @@ import type { ForcedWinNode, ForcedWinType } from "@/types/review";
 import type { VCTSearchOptions, VCTSequenceResult } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { findThreatMoves } from "../search/vctHelpers";
 import { validateVCTSequence } from "../search/vctValidation";
-// #37 P3 PR5: 四三判定を Zig 単一ソース(evaluate.createsFourThree)経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
-import { createsFourThree } from "../wasm/threatAdapter";
+// #37 P3 PR5/PR5b: 四三判定・両ミセ手を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { createsFourThree, findDoubleMiseMoves } from "../wasm/threatAdapter";
 import {
   filterByCounterThreats,
   REVIEW_MISE_VCF_OPTIONS,

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -30,12 +30,12 @@ import {
   evaluateBoardWithBreakdown,
   PATTERN_SCORES,
 } from "../evaluation";
-import { findMiseTargets } from "../evaluation/miseTactics";
 import { colorToWasm } from "../wasm/boardAdapter";
 import { linearTreeFromSequence } from "../wasm/forcedWinTreeWire";
-// #37 P3 PR4: 脅威検出を Zig 単一ソース(threats.detectOpponentThreats)経由に。
-// 合法局面で TS と一致（threatAdapter.test 検証済）。未ロード時は TS フォールバック。
-import { detectOpponentThreats } from "../wasm/threatAdapter";
+// #37 P3 PR4/PR5b: 脅威検出・ミセターゲットを Zig 単一ソース経由に。
+// 合法局面で TS と一致（threatAdapter.test / findMiseTargetsParity.test 検証済）。
+// 未ロード時は TS フォールバック。
+import { detectOpponentThreats, findMiseTargets } from "../wasm/threatAdapter";
 import {
   verifyCandidates,
   findSafeBest,

--- a/src/logic/cpu/wasm/createsFourThreeParity.test.ts
+++ b/src/logic/cpu/wasm/createsFourThreeParity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * createsFourThree の Zig⇄TS パリティ（#37 P3 / bug#1・#2 回帰防止）
+ *
+ * 全空き点に総当たりでミセ石を置く方式は、実戦で到達しない非合法盤（多重四・黒長連・
+ * 盤端の不能配置）を生成し、未定義領域で Zig/TS が分岐するため不適。代わりに
+ * **決定的なランダム合法自己対局**（黒の禁手を尊重・五で終局・近傍着手）で生成した
+ * 全局面・全空き点・両色を照合する faithful な等価テストとする。
+ *
+ * 過去に発見・修正した2バグの回帰をこのテストが捕捉する:
+ *  - bug#1: 跳び三を跳び四と同方向でも活三計上（白で四三を過剰検出）
+ *  - bug#2: 黒 count==4 の長連端補正欠落（伸ばすと6連になる四を過剰検出）
+ * いずれも合法局面（自己対局）で再現し、本テストが緑であることが review/CPU 双方の
+ * createsFourThree 単一ソース性を担保する。
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import { createsFourThree, preloadThreatWasm } from "./threatAdapter";
+
+/** 決定的 PRNG（mulberry32、外部依存なし） */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** (r,c) が既存石の距離2以内か */
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** ランダム合法自己対局を1局打ち、各手後の局面スナップショットを返す */
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c]) {
+          continue;
+        }
+        if (!nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break; // 勝負あり
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+await preloadThreatWasm();
+
+describe("createsFourThree parity (#37 P3)", () => {
+  it("ランダム合法自己対局の全局面・全空き点・両色で Zig==TS", () => {
+    const COLORS: StoneColor[] = ["black", "white"];
+    const GAMES = 80;
+    let seed = 0xc0ffee01;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 50);
+
+      for (const board of snaps) {
+        for (let r = 0; r < 15; r++) {
+          const boardRow = board[r];
+          if (!boardRow) {
+            continue;
+          }
+          for (let c = 0; c < 15; c++) {
+            if (boardRow[c]) {
+              continue;
+            }
+            for (const color of COLORS) {
+              const w = createsFourThree(board, r, c, color);
+              const t = createsFourThreeTs(board, r, c, color);
+              if (w !== t && mismatches.length < 20) {
+                mismatches.push(
+                  `g=${g} (${r},${c},${color}) wasm=${w} ts=${t}`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 30000);
+});

--- a/src/logic/cpu/wasm/findDoubleMiseMovesParity.test.ts
+++ b/src/logic/cpu/wasm/findDoubleMiseMovesParity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * findDoubleMiseMoves の Zig⇄TS パリティ（#37 P3 PR5b）
+ *
+ * 決定的なランダム合法自己対局で生成した各局面・両色で、Zig `evaluate.findDoubleMiseMoves`
+ * と TS `findDoubleMiseMoves` が同じ両ミセ手集合を返すことを照合する faithful な等価テスト。
+ * 列挙順は座標ソートで正規化して比較する。
+ *
+ * createsFourThree / findMiseTargets のパリティが前提（両ミセ判定はこれらに依存）。
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import { findDoubleMiseMoves as findDoubleMiseMovesTs } from "@/logic/cpu/evaluation/miseTactics";
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import { findDoubleMiseMoves, preloadThreatWasm } from "./threatAdapter";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c] || !nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break;
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+const sortPos = (a: Position, b: Position): number =>
+  a.row - b.row || a.col - b.col;
+const norm = (ps: Position[]): string =>
+  [...ps]
+    .sort(sortPos)
+    .map((p) => `${p.row},${p.col}`)
+    .join("|");
+
+await preloadThreatWasm();
+
+describe("findDoubleMiseMoves parity (#37 P3 PR5b)", () => {
+  it("合法自己対局の各局面・両色で Zig==TS", () => {
+    const COLORS: StoneColor[] = ["black", "white"];
+    const GAMES = 40;
+    let seed = 0xd00d1e42;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 45);
+
+      for (const board of snaps) {
+        for (const color of COLORS) {
+          const w = norm(findDoubleMiseMoves(board, color));
+          const t = norm(findDoubleMiseMovesTs(board, color));
+          if (w !== t && mismatches.length < 20) {
+            mismatches.push(`g=${g} ${color} wasm=[${w}] ts=[${t}]`);
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 60000);
+});

--- a/src/logic/cpu/wasm/findMiseTargetsParity.test.ts
+++ b/src/logic/cpu/wasm/findMiseTargetsParity.test.ts
@@ -1,0 +1,130 @@
+/**
+ * findMiseTargets の Zig⇄TS パリティ（#37 P3 PR5b）
+ *
+ * 決定的なランダム合法自己対局で生成した局面の、各空き点にミセ手を仮置きし、
+ * Zig `evaluate.findMiseTargets` と TS `findMiseTargets` が同じ四三ターゲット集合を
+ * 返すことを照合する faithful な等価テスト。列挙順は座標ソートで正規化して比較する。
+ *
+ * createsFourThree のパリティ（[[createsFourThreeParity.test.ts]] 相当）が前提。
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import { findMiseTargets as findMiseTargetsTs } from "@/logic/cpu/evaluation/miseTactics";
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import { findMiseTargets, preloadThreatWasm } from "./threatAdapter";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c] || !nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break;
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+const sortPos = (a: Position, b: Position): number =>
+  a.row - b.row || a.col - b.col;
+const norm = (ps: Position[]): string =>
+  [...ps]
+    .sort(sortPos)
+    .map((p) => `${p.row},${p.col}`)
+    .join("|");
+
+await preloadThreatWasm();
+
+describe("findMiseTargets parity (#37 P3 PR5b)", () => {
+  it("合法自己対局の各局面・近傍空き点にミセ手を仮置きして Zig==TS", () => {
+    const COLORS: StoneColor[] = ["black", "white"];
+    const GAMES = 12;
+    let seed = 0xa11ce777;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 45);
+
+      for (const board of snaps) {
+        for (let r = 0; r < 15; r++) {
+          const boardRow = board[r];
+          if (!boardRow) {
+            continue;
+          }
+          for (let c = 0; c < 15; c++) {
+            if (boardRow[c] || !nearStone(board, r, c)) {
+              continue;
+            }
+            for (const color of COLORS) {
+              // ミセ手を仮置きして契約（石を置いた状態）を満たす
+              boardRow[c] = color;
+              const w = norm(findMiseTargets(board, r, c, color));
+              const t = norm(findMiseTargetsTs(board, r, c, color));
+              boardRow[c] = null;
+              if (w !== t && mismatches.length < 20) {
+                mismatches.push(
+                  `g=${g} (${r},${c},${color}) wasm=[${w}] ts=[${t}]`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 60000);
+});

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -23,6 +23,7 @@ import {
   detectOpponentThreats as detectOpponentThreatsTs,
   type ThreatInfo,
 } from "@/logic/cpu/evaluation";
+import { findMiseTargets as findMiseTargetsTs } from "@/logic/cpu/evaluation/miseTactics";
 import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
@@ -192,4 +193,29 @@ export function detectOpponentThreats(
   }
   // フォールバック（wasm 未ロード時）
   return detectOpponentThreatsTs(board, opponentColor);
+}
+
+/**
+ * (row,col) に color のミセ手を**配置済み**の盤面で、四三ターゲット点（空き）を列挙する（#37 P3 PR5b）。
+ * wasm 経由は Zig `evaluate.findMiseTargets`。未ロード時は TS にフォールバック。
+ * 契約は TS `findMiseTargets` と同じく石を置いた状態で渡す。
+ */
+export function findMiseTargets(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): Position[] {
+  if (wasm) {
+    syncBoard(wasm, board);
+    wasm.findMiseTargetsWasm(
+      row,
+      col,
+      color === "black" ? CELL.BLACK : CELL.WHITE,
+    );
+    const mem = new Uint8Array(wasm.memory.buffer);
+    const { positions } = readPositionList(mem, wasm.getMiseBuffer());
+    return positions;
+  }
+  return findMiseTargetsTs(board, row, col, color);
 }

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -23,7 +23,10 @@ import {
   detectOpponentThreats as detectOpponentThreatsTs,
   type ThreatInfo,
 } from "@/logic/cpu/evaluation";
-import { findMiseTargets as findMiseTargetsTs } from "@/logic/cpu/evaluation/miseTactics";
+import {
+  findDoubleMiseMoves as findDoubleMiseMovesTs,
+  findMiseTargets as findMiseTargetsTs,
+} from "@/logic/cpu/evaluation/miseTactics";
 import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
@@ -218,4 +221,22 @@ export function findMiseTargets(
     return positions;
   }
   return findMiseTargetsTs(board, row, col, color);
+}
+
+/**
+ * color の両ミセ手（どの防御でも別の四三が残る手）を盤面全体から列挙する（#37 P3 PR5b）。
+ * wasm 経由は Zig `evaluate.findDoubleMiseMoves`。未ロード時は TS にフォールバック。
+ */
+export function findDoubleMiseMoves(
+  board: BoardState,
+  color: "black" | "white",
+): Position[] {
+  if (wasm) {
+    syncBoard(wasm, board);
+    wasm.findDoubleMiseMovesWasm(color === "black" ? CELL.BLACK : CELL.WHITE);
+    const mem = new Uint8Array(wasm.memory.buffer);
+    const { positions } = readPositionList(mem, wasm.getDoubleMiseBuffer());
+    return positions;
+  }
+  return findDoubleMiseMovesTs(board, color);
 }

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -21,6 +21,10 @@ export interface ThreatWasmContext {
   findMiseTargetsWasm: (row: number, col: number, color: number) => void;
   /** ミセターゲットバッファの先頭オフセット（memory 内）を返す。 */
   getMiseBuffer: () => number;
+  /** color の両ミセ手を列挙しバッファに書く（#37 P3 PR5b）。 */
+  findDoubleMiseMovesWasm: (color: number) => void;
+  /** 両ミセ手バッファの先頭オフセット（memory 内）を返す。 */
+  getDoubleMiseBuffer: () => number;
   /** wasm 線形メモリ（バッファ読み取り用）。 */
   memory: WebAssembly.Memory;
 }

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -17,6 +17,10 @@ export interface ThreatWasmContext {
   detectOpponentThreatsWasm: (opponentColor: number) => void;
   /** ThreatInfo シリアライズバッファの先頭オフセット（memory 内）を返す。 */
   getThreatInfoBuffer: () => number;
+  /** (row,col) にミセ手配置済みの盤面で四三ターゲットを検出しバッファに書く（#37 P3 PR5b）。 */
+  findMiseTargetsWasm: (row: number, col: number, color: number) => void;
+  /** ミセターゲットバッファの先頭オフセット（memory 内）を返す。 */
+  getMiseBuffer: () => number;
   /** wasm 線形メモリ（バッファ読み取り用）。 */
   memory: WebAssembly.Memory;
 }

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -74,6 +74,18 @@ fn hasFourThreePotential(cells: []const Cell, row: u8, col: u8, color: Cell) boo
     return false;
 }
 
+/// 黒の四の長連補正: empty 端の「gap の1つ先」(中心から run+2 マス先) が黒なら、
+/// その端へ伸ばすと6連(長連)になり五を作れないため塞がり扱いとする。
+/// TS analyzeDirection（directionAnalysis.ts）の count==4 オーバーライン補正に一致。
+fn blackOverlineEnd(cells: []const Cell, row: u8, col: u8, dr: i8, dc: i8, run: u8) bool {
+    const steps: i16 = @as(i16, run) + 2;
+    const r: i16 = @as(i16, row) + dr * steps;
+    const c: i16 = @as(i16, col) + dc * steps;
+    if (!board_mod.isValid(r, c)) return false;
+    const idx: u16 = @intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)));
+    return cells[idx] == .black;
+}
+
 /// createsFourThree: 仮置きして四と活三が同時にできるかチェック（跳びパターン含む）
 /// TS版 analyzeJumpPatterns の hasFour && hasValidOpenThree に対応
 /// 呼び出し側で bitboard が cells と同期している前提。
@@ -111,9 +123,25 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
         const end1 = lutEnd(lut.end1);
         const end2 = lutEnd(lut.end2);
 
-        // 連続四（片端以上が空き）
-        if (lut.count == 4 and (end1 == .empty or end2 == .empty)) {
-            has_four = true;
+        // 連続四（片端以上が空き）。端はセル走査で求め、黒は長連補正を適用する
+        // （TS analyzeDirection と一致。LUT 端は黒長連補正を持たないため使わない）。
+        if (lut.count == 4) {
+            const dir = board_mod.DIRECTIONS[i];
+            const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
+            const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
+            var e1 = pos.end_state;
+            var e2 = neg.end_state;
+            if (color == .black) {
+                if (e1 == .empty and blackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
+                    e1 = .opponent;
+                }
+                if (e2 == .empty and blackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
+                    e2 = .opponent;
+                }
+            }
+            if (e1 == .empty or e2 == .empty) {
+                has_four = true;
+            }
         }
 
         // 連続三の有効性チェック（跳び四方向でなければ）
@@ -130,8 +158,10 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
             has_four = true;
         }
 
-        // 跳び三 (LUT版: 連続三がない場合のみ)
-        if (lut.count != 3 and lut.has_jump_three) {
+        // 跳び三 (LUT版: 連続三がなく、跳び四もない場合のみ)
+        // 跳び四と同方向の跳び三は同一スジの四と三であり、四三を構成しない。
+        // TS analyzeJumpPatterns の `!jumpFourDirections.has(i)` ガードに対応。
+        if (lut.count != 3 and !jump_four_dirs[i] and lut.has_jump_three) {
             if (patterns.isValidJumpThree(cells, row, col, dir_index, color)) {
                 has_valid_open_three = true;
             }
@@ -356,6 +386,31 @@ test "hasFourThreePotential basic" {
     cells[8 * BOARD_SIZE + 7] = .black;
 
     try std.testing.expect(hasFourThreePotential(&cells, 7, 7, .black));
+}
+
+// bug#2 回帰: 黒の四が長連方向に伸びる（伸ばすと6連）場合は四として数えない。
+// 縦 col7: (5,7)黒, (6,7)空, [cand(7,7)], (8,7)(9,7)(10,7)黒, (11,7)白。
+//   → 7-10 の連続四だが、下端(11,7)は白で塞がり、上端(6,7)空の先(5,7)が黒＝伸ばすと
+//      5-10 の6連(長連)。よって黒では「四」にならない（TS analyzeDirection 補正と一致）。
+// 横 row7: (7,5)(7,6)黒, [cand(7,7)], (7,8)空, (7,4)空 → 活三。
+// 四が成立しないので四三は false でなければならない。
+test "createsFourThree: 黒の長連方向の四は四三にしない (bug#2)" {
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[5 * BOARD_SIZE + 7] = .black;
+    cells[8 * BOARD_SIZE + 7] = .black;
+    cells[9 * BOARD_SIZE + 7] = .black;
+    cells[10 * BOARD_SIZE + 7] = .black;
+    cells[11 * BOARD_SIZE + 7] = .white;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    bitboard.initFromCells(&cells);
+    try std.testing.expect(!createsFourThree(&cells, 7, 7, .black));
+
+    // 対照: 上端の長連石(5,7)を白にすると、(6,7)を埋めて 6-10 の五が作れる真の四
+    //       → 四三が成立し true。
+    cells[5 * BOARD_SIZE + 7] = .white;
+    bitboard.initFromCells(&cells);
+    try std.testing.expect(createsFourThree(&cells, 7, 7, .black));
 }
 
 // board_mod.isValid を公開するためにこのモジュール内で再宣言は不要。

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -247,6 +247,87 @@ pub fn findMiseTargets(cells: []Cell, row: u8, col: u8, color: Cell) threats.Pos
     return result;
 }
 
+/// ミセターゲットが存在しうるか安価に判定（プリフィルタ）。
+/// TS miseTactics.ts hasPotentialMiseTarget に対応（analyzeDirection の黒長連補正込み）。
+fn hasPotentialMiseTarget(cells: []const Cell, row: u8, col: u8, color: Cell) bool {
+    for (DIRECTIONS) |dir| {
+        const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
+        const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
+        const count = @as(u16, pos.count) + neg.count + 1;
+        if (count < 2) continue;
+        var e1 = pos.end_state;
+        var e2 = neg.end_state;
+        if (color == .black and count == 4) {
+            if (e1 == .empty and blackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
+                e1 = .opponent;
+            }
+            if (e2 == .empty and blackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
+                e2 = .opponent;
+            }
+        }
+        if (e1 == .empty or e2 == .empty) return true;
+    }
+    return false;
+}
+
+/// 両ミセ判定（近似）。TS miseTactics.ts isDoubleMise に対応。
+/// 各ターゲット T_i に相手石を仮置きし、残りターゲットのいずれかで四三が残るかを検証する。
+/// どの T_i を防いでも別ターゲットで四三が残る（=全防御を生き残る）なら両ミセ。
+/// targets は (row,col) にミセ手配置済みで得た四三点。cells/bitboard は同期済み前提。
+fn isDoubleMise(cells: []Cell, targets: *const threats.PositionList, color: Cell) bool {
+    if (targets.len < 2) return false;
+    const opponent = color.opposite();
+    for (0..targets.len) |i| {
+        const ti = targets.items[i];
+        const ti_idx = @as(u16, ti.row) * BOARD_SIZE + ti.col;
+        // T_i に相手石を仮配置（cells + bitboard）
+        cells[ti_idx] = opponent;
+        bitboard.placeStone(ti.row, ti.col, opponent);
+        var survived = false;
+        for (0..targets.len) |j| {
+            if (i == j) continue;
+            const tj = targets.items[j];
+            if (createsFourThree(cells, tj.row, tj.col, color)) {
+                survived = true;
+                break;
+            }
+        }
+        cells[ti_idx] = .empty;
+        bitboard.removeStone(ti.row, ti.col);
+        // いずれかの防御で全ターゲットが潰れる → 両ミセでない
+        if (!survived) return false;
+    }
+    return true;
+}
+
+/// 盤面上の全空きセルから両ミセ手を列挙する。TS miseTactics.ts findDoubleMiseMoves に対応。
+/// 各空きセルに color を仮置きし、hasPotentialMiseTarget → findMiseTargets(>=2) → isDoubleMise を満たす点を返す。
+/// 呼び出し前に bitboard を cells と同期しておくこと。
+pub fn findDoubleMiseMoves(cells: []Cell, color: Cell) threats.PositionList {
+    var result = threats.PositionList.init();
+    for (0..BOARD_SIZE) |r_usize| {
+        const r: u8 = @intCast(r_usize);
+        for (0..BOARD_SIZE) |c_usize| {
+            const c: u8 = @intCast(c_usize);
+            const idx = @as(u16, r) * BOARD_SIZE + c;
+            if (cells[idx] != .empty) continue;
+            // 仮置き（cells + bitboard）
+            cells[idx] = color;
+            bitboard.placeStone(r, c, color);
+            if (hasPotentialMiseTarget(cells, r, c, color)) {
+                const targets = findMiseTargets(cells, r, c, color);
+                if (targets.len >= 2 and isDoubleMise(cells, &targets, color)) {
+                    result.push(.{ .row = r, .col = c });
+                }
+            }
+            // 復元
+            cells[idx] = .empty;
+            bitboard.removeStone(r, c);
+        }
+    }
+    return result;
+}
+
 /// 四三脅威スキャン
 pub fn scanFourThreeThreat(cells: []Cell, color: Cell, stone_count: u16) bool {
     if (stone_count < 5) return false;

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -172,6 +172,81 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
     return false;
 }
 
+/// ミセターゲット（四三点）を1点追加（空き・未追加・黒禁手除外・createsFourThree 検証）。
+/// TS miseTactics.ts findMiseTargets の tryAdd に対応。
+fn miseTryAdd(cells: []Cell, result: *threats.PositionList, seen: []bool, r: i16, c: i16, color: Cell) void {
+    if (!board_mod.isValid(r, c)) return;
+    const ur: u8 = @intCast(r);
+    const uc: u8 = @intCast(c);
+    const key: u16 = @as(u16, ur) * BOARD_SIZE + uc;
+    if (seen[key]) return;
+    if (cells[key] != .empty) return;
+    if (color == .black and forbidden.checkForbiddenMove(cells, ur, uc) != .none) return;
+    if (createsFourThree(cells, ur, uc, color)) {
+        seen[key] = true;
+        result.push(.{ .row = ur, .col = uc });
+    }
+}
+
+/// ミセターゲット（四三点）を検出（TS miseTactics.ts findMiseTargets full に対応）。
+/// (row,col) は color のミセ手を**配置済み**前提。各方向のライン延長点（飛び四 gap+1 含む）と
+/// ±2 近傍をスキャンする。呼び出し前に bitboard を cells と同期しておくこと。
+pub fn findMiseTargets(cells: []Cell, row: u8, col: u8, color: Cell) threats.PositionList {
+    var result = threats.PositionList.init();
+    var seen = [_]bool{false} ** CELL_COUNT;
+
+    // 1. 各方向のライン延長点（距離制限なし）
+    for (DIRECTIONS, 0..) |dir, di| {
+        const lut = ll.queryPatternByCell(row, col, di, color);
+        if (lut.count < 2) continue; // 2石未満 → 四三不可能
+
+        // 正方向の端
+        var r: i16 = @as(i16, row) + dir.dr;
+        var c: i16 = @as(i16, col) + dir.dc;
+        while (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == color)
+        {
+            r += dir.dr;
+            c += dir.dc;
+        }
+        if (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == .empty)
+        {
+            miseTryAdd(cells, &result, &seen, r, c, color);
+            // 飛び四ターゲット: ギャップの1つ先（miseTryAdd が空き判定）
+            miseTryAdd(cells, &result, &seen, r + dir.dr, c + dir.dc, color);
+        }
+
+        // 負方向の端
+        r = @as(i16, row) - dir.dr;
+        c = @as(i16, col) - dir.dc;
+        while (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == color)
+        {
+            r -= dir.dr;
+            c -= dir.dc;
+        }
+        if (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == .empty)
+        {
+            miseTryAdd(cells, &result, &seen, r, c, color);
+            miseTryAdd(cells, &result, &seen, r - dir.dr, c - dir.dc, color);
+        }
+    }
+
+    // 2. ±2 近傍スキャン（ライン外の四三点も検出）
+    var dr: i16 = -2;
+    while (dr <= 2) : (dr += 1) {
+        var dc: i16 = -2;
+        while (dc <= 2) : (dc += 1) {
+            if (dr == 0 and dc == 0) continue;
+            miseTryAdd(cells, &result, &seen, @as(i16, row) + dr, @as(i16, col) + dc, color);
+        }
+    }
+
+    return result;
+}
+
 /// 四三脅威スキャン
 pub fn scanFourThreeThreat(cells: []Cell, color: Cell, stone_count: u16) bool {
     if (stone_count < 5) return false;

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -110,3 +110,25 @@ export fn findMiseTargetsWasm(row: u8, col: u8, color: u8) void {
         o += 2;
     }
 }
+
+// === findDoubleMiseMoves（#37 P3 PR5b）===
+//
+// 盤面全空きセルから両ミセ手を列挙し [u8 count][count*(u8 row,u8 col)] をバッファに書く。
+var double_mise_buffer: [160]u8 = undefined;
+
+export fn getDoubleMiseBuffer() [*]u8 {
+    return &double_mise_buffer;
+}
+
+/// color の両ミセ手を列挙しバッファに書く。事前に boardSet/syncBitboard で同期しておくこと。
+export fn findDoubleMiseMovesWasm(color: u8) void {
+    const c: board.Cell = @enumFromInt(color);
+    const list = evaluate.findDoubleMiseMoves(&board.board_cells, c);
+    double_mise_buffer[0] = list.len;
+    var o: usize = 1;
+    for (0..list.len) |i| {
+        double_mise_buffer[o] = list.items[i].row;
+        double_mise_buffer[o + 1] = list.items[i].col;
+        o += 2;
+    }
+}

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -86,3 +86,27 @@ export fn detectOpponentThreatsWasm(opponent_color: u8) void {
     o = writeList(o, &info.mises);
     o = writeList(o, &info.double_threes);
 }
+
+// === findMiseTargets（#37 P3 PR5b）===
+//
+// (row,col) に color のミセ手を配置済みの盤面で、四三ターゲット点（空き）を列挙する。
+// [u8 count][count*(u8 row, u8 col)] を mise_buffer にシリアライズ（最大 1+64*2=129B）。
+var mise_buffer: [160]u8 = undefined;
+
+export fn getMiseBuffer() [*]u8 {
+    return &mise_buffer;
+}
+
+/// (row,col) にミセ手を配置済みの盤面で四三ターゲットを検出しバッファに書く。
+/// 事前に boardSet で cells（ミセ手含む）、syncBitboard で bitboard を同期しておくこと。
+export fn findMiseTargetsWasm(row: u8, col: u8, color: u8) void {
+    const c: board.Cell = @enumFromInt(color);
+    const list = evaluate.findMiseTargets(&board.board_cells, row, col, c);
+    mise_buffer[0] = list.len;
+    var o: usize = 1;
+    for (0..list.len) |i| {
+        mise_buffer[o] = list.items[i].row;
+        mise_buffer[o + 1] = list.items[i].col;
+        o += 2;
+    }
+}

--- a/zig/src/threats.zig
+++ b/zig/src/threats.zig
@@ -899,3 +899,66 @@ test "countThreatDirections basic" {
     const count = countThreatDirections(&cells, 7, 7, .white);
     try std.testing.expect(count >= 1);
 }
+
+// === bitboard 不変性のリグレッション（#37 P3 PR5b 調査）===
+//
+// detectOpponentThreats は空き点ループ内で createsFourThree / createsDoubleThree を
+// 繰り返し呼ぶ。これらは候補を仮置き（cells + bitboard.placeStone）し defer で復元するが、
+// removeStone が黒白**両ビット**をクリアするため、候補が**空き点**である限り
+// （置く前のビットは 0 → 置いて消すと 0 に戻る）global_bb は完全復元される。
+// detectOpponentThreats は `cells[idx] != .empty` で空き点に限定しているので蓄積ドリフトは
+// 起きない。本テストはその不変性を凍結する（占有セルに createsFourThree を呼ぶ契約違反を
+// 別実装が犯すとここが落ちて気付ける）。
+fn bbEqual(a: bitboard.Bitboard, b: bitboard.Bitboard) bool {
+    for (0..bitboard.LINE_COUNT) |i| {
+        if (a.black[i] != b.black[i]) return false;
+        if (a.white[i] != b.white[i]) return false;
+    }
+    return true;
+}
+
+test "detectOpponentThreats: global_bb を不変に保つ（蓄積ドリフトなし）" {
+    // ミセ手（四三）と三三脅威が複数生じる多石の合法寄り局面
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    const whites = [_][2]u8{
+        .{ 7, 5 }, .{ 7, 6 }, .{ 8, 7 }, .{ 9, 7 },
+        .{ 6, 8 }, .{ 8, 9 }, .{ 9, 6 }, .{ 5, 5 },
+    };
+    const blacks = [_][2]u8{
+        .{ 7, 7 }, .{ 8, 8 }, .{ 9, 9 }, .{ 6, 6 },
+        .{ 10, 7 }, .{ 7, 10 }, .{ 6, 7 },
+    };
+    for (whites) |p| cells[@as(u16, p[0]) * BOARD_SIZE + p[1]] = .white;
+    for (blacks) |p| cells[@as(u16, p[0]) * BOARD_SIZE + p[1]] = .black;
+    bitboard.initFromCells(&cells);
+
+    const snapshot = bitboard.global_bb;
+    _ = detectOpponentThreats(&cells, .white);
+    try std.testing.expect(bbEqual(snapshot, bitboard.global_bb));
+    _ = detectOpponentThreats(&cells, .black);
+    try std.testing.expect(bbEqual(snapshot, bitboard.global_bb));
+
+    // cells 自体も不変（仮置きが全て復元されている）
+    var fresh = [_]Cell{.empty} ** CELL_COUNT;
+    for (whites) |p| fresh[@as(u16, p[0]) * BOARD_SIZE + p[1]] = .white;
+    for (blacks) |p| fresh[@as(u16, p[0]) * BOARD_SIZE + p[1]] = .black;
+    try std.testing.expect(std.mem.eql(Cell, &cells, &fresh));
+}
+
+test "createsFourThree: 空き候補なら global_bb 不変・占有候補なら破壊（契約の確認）" {
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 7] = .black;
+    cells[7 * BOARD_SIZE + 8] = .black;
+    cells[8 * BOARD_SIZE + 8] = .white;
+    bitboard.initFromCells(&cells);
+    const snapshot = bitboard.global_bb;
+
+    // 空き候補: 仮置き→defer 復元で global_bb は完全復元
+    _ = evaluate.createsFourThree(&cells, 9, 9, .black);
+    try std.testing.expect(bbEqual(snapshot, bitboard.global_bb));
+
+    // 占有セルに呼ぶと removeStone が既存石のビットを消し drift する（＝契約違反の証跡）。
+    // 呼び出し側は必ず空き点を渡すこと（detectOpponentThreats はガード済み）。
+    _ = evaluate.createsFourThree(&cells, 7, 7, .white);
+    try std.testing.expect(!bbEqual(snapshot, bitboard.global_bb));
+}


### PR DESCRIPTION
## 概要（本体 PR）

#37 P3「review 戦術を Zig 単一ソース化」のミセ戦術編。review（振り返り）が使うミセ系の戦術計算を TS から **Zig 単一ソース**へ移行し、TS⇄Zig 二重実装のドリフトを解消する。北極星「戦術＝Zig、TS＝プレゼン」に沿う。

すべて sub PR で内容ごとに積み、本体（このブランチ）へマージ済み。**本体 → main はボスの動作確認後にマージ**。

## サブ PR（すべて feature にマージ済み）

| PR | 内容 |
|---|---|
| #62 | `test(threats)`: bitboard 不変性のリグレッション（調査の安全網） |
| #64 | `fix(zig)`: createsFourThree の四三**過剰検出2バグ**を修正 |
| #65 | `perf(bench)`: commit-bench に `--jobs` 並列対局を追加（強度検証用） |
| #66 | `feat(cpu)`: `findMiseTargets` を Zig 委譲（fullEval 利用点） |
| #67 | `feat(cpu)`: `findDoubleMiseMoves` を Zig 委譲（forcedLoss/forcedWin 利用点） |

## 主要成果

### createsFourThree の実バグ2件を発見・修正（#64）
当初「createsFourThree の分岐は非現実盤限定」と見ていたが、ランダム**合法**自己対局での総当たり照合で**合法局面でも分岐する実バグ**と判明:
- **bug#1**: 跳び三を跳び四と同方向でも活三計上（白で四三過剰検出）。TS `analyzeJumpPatterns` の `!jumpFourDirections.has(i)` ガードに合わせて修正。
- **bug#2**: 黒の連続四で空き端の先が黒（伸ばすと6連=長連）の場合に四計上。TS `analyzeDirection` の count==4 オーバーライン補正が Zig LUT に無いのが原因。四の端をセル走査で求め黒長連補正を適用。

`evaluate.createsFourThree` は review と CPU 探索エンジンが共有するため、両者の単一ソース性が向上。**CPU 強度はベンチ(r0.02, 175局)で弱体化なし（Elo +4）を確認**。

### ミセ戦術の Zig 化（#66, #67）
- `findMiseTargets`（ライン延長点 + 飛び四 gap+1 + ±2 近傍）
- `findDoubleMiseMoves` + `isDoubleMise` + `hasPotentialMiseTarget`（全空きセル走査 + 防御シミュレーション）

これで review のミセ系戦術（`detectOpponentThreats` / `createsFourThree` / `findMiseTargets` / `findDoubleMiseMoves`）が Zig 単一ソースに。

## 検証

- 各関数に **faithful パリティテスト**（決定的ランダム合法自己対局で Zig==TS、座標ソート正規化）:
  `createsFourThreeParity` / `findMiseTargetsParity` / `findDoubleMiseMovesParity`
- `reviewSnapshot`（detectOpponentThreats / findDoubleMiseMoves 等を凍結）含む全テスト緑
- bitboard 不変性リグレッション（#62）で createsFourThree ループの bitboard 復元を凍結

## 残作業（別 PR）

- `hasFourThreeAvailable` / `hasOpenThree` / `findThreatMoves`（vctHelpers）の Zig 化
- TS 側ミセ戦術コードの削除棚卸し（P4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)