### PR TITLE
fix(zig): createsFourThree の四三過剰検出2件を修正（#37 P3）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -63,7 +63,11 @@
       }
     },
     {
-      "files": ["**/renjuParity.test.ts", "**/threatAdapter.test.ts"],
+      "files": [
+        "**/renjuParity.test.ts",
+        "**/threatAdapter.test.ts",
+        "**/createsFourThreeParity.test.ts"
+      ],
       "rules": {
         "no-bitwise": "off"
       }

--- a/src/logic/cpu/wasm/createsFourThreeParity.test.ts
+++ b/src/logic/cpu/wasm/createsFourThreeParity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * createsFourThree の Zig⇄TS パリティ（#37 P3 / bug#1・#2 回帰防止）
+ *
+ * 全空き点に総当たりでミセ石を置く方式は、実戦で到達しない非合法盤（多重四・黒長連・
+ * 盤端の不能配置）を生成し、未定義領域で Zig/TS が分岐するため不適。代わりに
+ * **決定的なランダム合法自己対局**（黒の禁手を尊重・五で終局・近傍着手）で生成した
+ * 全局面・全空き点・両色を照合する faithful な等価テストとする。
+ *
+ * 過去に発見・修正した2バグの回帰をこのテストが捕捉する:
+ *  - bug#1: 跳び三を跳び四と同方向でも活三計上（白で四三を過剰検出）
+ *  - bug#2: 黒 count==4 の長連端補正欠落（伸ばすと6連になる四を過剰検出）
+ * いずれも合法局面（自己対局）で再現し、本テストが緑であることが review/CPU 双方の
+ * createsFourThree 単一ソース性を担保する。
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import { createsFourThree, preloadThreatWasm } from "./threatAdapter";
+
+/** 決定的 PRNG（mulberry32、外部依存なし） */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** (r,c) が既存石の距離2以内か */
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** ランダム合法自己対局を1局打ち、各手後の局面スナップショットを返す */
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c]) {
+          continue;
+        }
+        if (!nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break; // 勝負あり
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+await preloadThreatWasm();
+
+describe("createsFourThree parity (#37 P3)", () => {
+  it("ランダム合法自己対局の全局面・全空き点・両色で Zig==TS", () => {
+    const COLORS: StoneColor[] = ["black", "white"];
+    const GAMES = 80;
+    let seed = 0xc0ffee01;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 50);
+
+      for (const board of snaps) {
+        for (let r = 0; r < 15; r++) {
+          const boardRow = board[r];
+          if (!boardRow) {
+            continue;
+          }
+          for (let c = 0; c < 15; c++) {
+            if (boardRow[c]) {
+              continue;
+            }
+            for (const color of COLORS) {
+              const w = createsFourThree(board, r, c, color);
+              const t = createsFourThreeTs(board, r, c, color);
+              if (w !== t && mismatches.length < 20) {
+                mismatches.push(
+                  `g=${g} (${r},${c},${color}) wasm=${w} ts=${t}`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 30000);
+});

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -74,6 +74,18 @@ fn hasFourThreePotential(cells: []const Cell, row: u8, col: u8, color: Cell) boo
     return false;
 }
 
+/// 黒の四の長連補正: empty 端の「gap の1つ先」(中心から run+2 マス先) が黒なら、
+/// その端へ伸ばすと6連(長連)になり五を作れないため塞がり扱いとする。
+/// TS analyzeDirection（directionAnalysis.ts）の count==4 オーバーライン補正に一致。
+fn blackOverlineEnd(cells: []const Cell, row: u8, col: u8, dr: i8, dc: i8, run: u8) bool {
+    const steps: i16 = @as(i16, run) + 2;
+    const r: i16 = @as(i16, row) + dr * steps;
+    const c: i16 = @as(i16, col) + dc * steps;
+    if (!board_mod.isValid(r, c)) return false;
+    const idx: u16 = @intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)));
+    return cells[idx] == .black;
+}
+
 /// createsFourThree: 仮置きして四と活三が同時にできるかチェック（跳びパターン含む）
 /// TS版 analyzeJumpPatterns の hasFour && hasValidOpenThree に対応
 /// 呼び出し側で bitboard が cells と同期している前提。
@@ -111,9 +123,25 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
         const end1 = lutEnd(lut.end1);
         const end2 = lutEnd(lut.end2);
 
-        // 連続四（片端以上が空き）
-        if (lut.count == 4 and (end1 == .empty or end2 == .empty)) {
-            has_four = true;
+        // 連続四（片端以上が空き）。端はセル走査で求め、黒は長連補正を適用する
+        // （TS analyzeDirection と一致。LUT 端は黒長連補正を持たないため使わない）。
+        if (lut.count == 4) {
+            const dir = board_mod.DIRECTIONS[i];
+            const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
+            const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
+            var e1 = pos.end_state;
+            var e2 = neg.end_state;
+            if (color == .black) {
+                if (e1 == .empty and blackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
+                    e1 = .opponent;
+                }
+                if (e2 == .empty and blackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
+                    e2 = .opponent;
+                }
+            }
+            if (e1 == .empty or e2 == .empty) {
+                has_four = true;
+            }
         }
 
         // 連続三の有効性チェック（跳び四方向でなければ）
@@ -130,8 +158,10 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
             has_four = true;
         }
 
-        // 跳び三 (LUT版: 連続三がない場合のみ)
-        if (lut.count != 3 and lut.has_jump_three) {
+        // 跳び三 (LUT版: 連続三がなく、跳び四もない場合のみ)
+        // 跳び四と同方向の跳び三は同一スジの四と三であり、四三を構成しない。
+        // TS analyzeJumpPatterns の `!jumpFourDirections.has(i)` ガードに対応。
+        if (lut.count != 3 and !jump_four_dirs[i] and lut.has_jump_three) {
             if (patterns.isValidJumpThree(cells, row, col, dir_index, color)) {
                 has_valid_open_three = true;
             }
@@ -356,6 +386,31 @@ test "hasFourThreePotential basic" {
     cells[8 * BOARD_SIZE + 7] = .black;
 
     try std.testing.expect(hasFourThreePotential(&cells, 7, 7, .black));
+}
+
+// bug#2 回帰: 黒の四が長連方向に伸びる（伸ばすと6連）場合は四として数えない。
+// 縦 col7: (5,7)黒, (6,7)空, [cand(7,7)], (8,7)(9,7)(10,7)黒, (11,7)白。
+//   → 7-10 の連続四だが、下端(11,7)は白で塞がり、上端(6,7)空の先(5,7)が黒＝伸ばすと
+//      5-10 の6連(長連)。よって黒では「四」にならない（TS analyzeDirection 補正と一致）。
+// 横 row7: (7,5)(7,6)黒, [cand(7,7)], (7,8)空, (7,4)空 → 活三。
+// 四が成立しないので四三は false でなければならない。
+test "createsFourThree: 黒の長連方向の四は四三にしない (bug#2)" {
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[5 * BOARD_SIZE + 7] = .black;
+    cells[8 * BOARD_SIZE + 7] = .black;
+    cells[9 * BOARD_SIZE + 7] = .black;
+    cells[10 * BOARD_SIZE + 7] = .black;
+    cells[11 * BOARD_SIZE + 7] = .white;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    bitboard.initFromCells(&cells);
+    try std.testing.expect(!createsFourThree(&cells, 7, 7, .black));
+
+    // 対照: 上端の長連石(5,7)を白にすると、(6,7)を埋めて 6-10 の五が作れる真の四
+    //       → 四三が成立し true。
+    cells[5 * BOARD_SIZE + 7] = .white;
+    bitboard.initFromCells(&cells);
+    try std.testing.expect(createsFourThree(&cells, 7, 7, .black));
 }
 
 // board_mod.isValid を公開するためにこのモジュール内で再宣言は不要。


### PR DESCRIPTION
## 概要

`evaluate.createsFourThree`（review と CPU 探索エンジンが**共有**する Zig 関数）に、**合法局面でも** Zig⇄TS が分岐するパリティバグが 2 件あった。ランダム合法自己対局での総当たり照合で発見（既存の LEGAL_RECORDS 3 件は偶然どちらも踏まず緑だった）。

「createsFourThree の分岐は非現実盤限定か？」の調査（#62 の続き）の結論: **No。合法局面で発生する実バグ**だった。

## bug#1: 跳び三の四方向除外漏れ（白で過剰検出）

同一方向に跳び四と跳び三が両立するとき、Zig は跳び三を活三として計上し四三と誤検出していた。四三は**異なる方向**の四＋三で構成されるため、同方向の三は数えないのが正しい（TS `analyzeJumpPatterns` は `!jumpFourDirections.has(i)` で除外）。Zig は連続三には `!jump_four_dirs[i]` ガードがあったが跳び三に欠けていた。

## bug#2: 黒の長連端補正欠落（黒で過剰検出）

黒の連続四で、空き端の1つ先が黒石（埋めると6連=長連で五にならない）の場合に四として数えていた。TS `analyzeDirection` の `count==4` オーバーライン補正（空き端の先が黒なら塞がり扱い）が Zig の LUT `queryPatternByCell` に無いのが原因。四の端をセル走査で求め、黒のみ長連補正を適用して TS と一致させた。

## 影響範囲

`evaluate.createsFourThree` は以下が共有:
- review: `detectOpponentThreats`（ミセ） / `createsFourThree`
- CPU 探索: `scanFourThreeThreat` / `vct` / `mise_vcf` / `position_eval`

→ 両者の Zig 単一ソース性が向上。**CPU 着手への影響はベンチ（r0.02/8セット）で別途検証**する（純粋な過剰検出の除去なので弱体化はしない見込み）。

## 検証

- 合法自己対局 150局 / 2.87M 点・両色で Zig==TS（修正前 **49 不一致 → 0**）
- faithful パリティテスト `createsFourThreeParity.test.ts`（決定的合法自己対局 80局）を追加
- bug#2 の Zig 単体回帰テストを `evaluate.zig` に追加
- 全テスト緑（Zig 82 / TS 1806）

🤖 Generated with [Claude Code](https://claude.com/claude-code)