### PR TITLE
feat(cpu): review の findMiseTargets を Zig 委譲（#37 P3）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -66,7 +66,8 @@
       "files": [
         "**/renjuParity.test.ts",
         "**/threatAdapter.test.ts",
-        "**/createsFourThreeParity.test.ts"
+        "**/createsFourThreeParity.test.ts",
+        "**/findMiseTargetsParity.test.ts"
       ],
       "rules": {
         "no-bitwise": "off"

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -30,12 +30,12 @@ import {
   evaluateBoardWithBreakdown,
   PATTERN_SCORES,
 } from "../evaluation";
-import { findMiseTargets } from "../evaluation/miseTactics";
 import { colorToWasm } from "../wasm/boardAdapter";
 import { linearTreeFromSequence } from "../wasm/forcedWinTreeWire";
-// #37 P3 PR4: 脅威検出を Zig 単一ソース(threats.detectOpponentThreats)経由に。
-// 合法局面で TS と一致（threatAdapter.test 検証済）。未ロード時は TS フォールバック。
-import { detectOpponentThreats } from "../wasm/threatAdapter";
+// #37 P3 PR4/PR5b: 脅威検出・ミセターゲットを Zig 単一ソース経由に。
+// 合法局面で TS と一致（threatAdapter.test / findMiseTargetsParity.test 検証済）。
+// 未ロード時は TS フォールバック。
+import { detectOpponentThreats, findMiseTargets } from "../wasm/threatAdapter";
 import {
   verifyCandidates,
   findSafeBest,

--- a/src/logic/cpu/wasm/findMiseTargetsParity.test.ts
+++ b/src/logic/cpu/wasm/findMiseTargetsParity.test.ts
@@ -1,0 +1,130 @@
+/**
+ * findMiseTargets の Zig⇄TS パリティ（#37 P3 PR5b）
+ *
+ * 決定的なランダム合法自己対局で生成した局面の、各空き点にミセ手を仮置きし、
+ * Zig `evaluate.findMiseTargets` と TS `findMiseTargets` が同じ四三ターゲット集合を
+ * 返すことを照合する faithful な等価テスト。列挙順は座標ソートで正規化して比較する。
+ *
+ * createsFourThree のパリティ（[[createsFourThreeParity.test.ts]] 相当）が前提。
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import { findMiseTargets as findMiseTargetsTs } from "@/logic/cpu/evaluation/miseTactics";
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import { findMiseTargets, preloadThreatWasm } from "./threatAdapter";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c] || !nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break;
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+const sortPos = (a: Position, b: Position): number =>
+  a.row - b.row || a.col - b.col;
+const norm = (ps: Position[]): string =>
+  [...ps]
+    .sort(sortPos)
+    .map((p) => `${p.row},${p.col}`)
+    .join("|");
+
+await preloadThreatWasm();
+
+describe("findMiseTargets parity (#37 P3 PR5b)", () => {
+  it("合法自己対局の各局面・近傍空き点にミセ手を仮置きして Zig==TS", () => {
+    const COLORS: StoneColor[] = ["black", "white"];
+    const GAMES = 12;
+    let seed = 0xa11ce777;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 45);
+
+      for (const board of snaps) {
+        for (let r = 0; r < 15; r++) {
+          const boardRow = board[r];
+          if (!boardRow) {
+            continue;
+          }
+          for (let c = 0; c < 15; c++) {
+            if (boardRow[c] || !nearStone(board, r, c)) {
+              continue;
+            }
+            for (const color of COLORS) {
+              // ミセ手を仮置きして契約（石を置いた状態）を満たす
+              boardRow[c] = color;
+              const w = norm(findMiseTargets(board, r, c, color));
+              const t = norm(findMiseTargetsTs(board, r, c, color));
+              boardRow[c] = null;
+              if (w !== t && mismatches.length < 20) {
+                mismatches.push(
+                  `g=${g} (${r},${c},${color}) wasm=[${w}] ts=[${t}]`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 60000);
+});

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -23,6 +23,7 @@ import {
   detectOpponentThreats as detectOpponentThreatsTs,
   type ThreatInfo,
 } from "@/logic/cpu/evaluation";
+import { findMiseTargets as findMiseTargetsTs } from "@/logic/cpu/evaluation/miseTactics";
 import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
@@ -192,4 +193,29 @@ export function detectOpponentThreats(
   }
   // フォールバック（wasm 未ロード時）
   return detectOpponentThreatsTs(board, opponentColor);
+}
+
+/**
+ * (row,col) に color のミセ手を**配置済み**の盤面で、四三ターゲット点（空き）を列挙する（#37 P3 PR5b）。
+ * wasm 経由は Zig `evaluate.findMiseTargets`。未ロード時は TS にフォールバック。
+ * 契約は TS `findMiseTargets` と同じく石を置いた状態で渡す。
+ */
+export function findMiseTargets(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: "black" | "white",
+): Position[] {
+  if (wasm) {
+    syncBoard(wasm, board);
+    wasm.findMiseTargetsWasm(
+      row,
+      col,
+      color === "black" ? CELL.BLACK : CELL.WHITE,
+    );
+    const mem = new Uint8Array(wasm.memory.buffer);
+    const { positions } = readPositionList(mem, wasm.getMiseBuffer());
+    return positions;
+  }
+  return findMiseTargetsTs(board, row, col, color);
 }

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -17,6 +17,10 @@ export interface ThreatWasmContext {
   detectOpponentThreatsWasm: (opponentColor: number) => void;
   /** ThreatInfo シリアライズバッファの先頭オフセット（memory 内）を返す。 */
   getThreatInfoBuffer: () => number;
+  /** (row,col) にミセ手配置済みの盤面で四三ターゲットを検出しバッファに書く（#37 P3 PR5b）。 */
+  findMiseTargetsWasm: (row: number, col: number, color: number) => void;
+  /** ミセターゲットバッファの先頭オフセット（memory 内）を返す。 */
+  getMiseBuffer: () => number;
   /** wasm 線形メモリ（バッファ読み取り用）。 */
   memory: WebAssembly.Memory;
 }

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -172,6 +172,81 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
     return false;
 }
 
+/// ミセターゲット（四三点）を1点追加（空き・未追加・黒禁手除外・createsFourThree 検証）。
+/// TS miseTactics.ts findMiseTargets の tryAdd に対応。
+fn miseTryAdd(cells: []Cell, result: *threats.PositionList, seen: []bool, r: i16, c: i16, color: Cell) void {
+    if (!board_mod.isValid(r, c)) return;
+    const ur: u8 = @intCast(r);
+    const uc: u8 = @intCast(c);
+    const key: u16 = @as(u16, ur) * BOARD_SIZE + uc;
+    if (seen[key]) return;
+    if (cells[key] != .empty) return;
+    if (color == .black and forbidden.checkForbiddenMove(cells, ur, uc) != .none) return;
+    if (createsFourThree(cells, ur, uc, color)) {
+        seen[key] = true;
+        result.push(.{ .row = ur, .col = uc });
+    }
+}
+
+/// ミセターゲット（四三点）を検出（TS miseTactics.ts findMiseTargets full に対応）。
+/// (row,col) は color のミセ手を**配置済み**前提。各方向のライン延長点（飛び四 gap+1 含む）と
+/// ±2 近傍をスキャンする。呼び出し前に bitboard を cells と同期しておくこと。
+pub fn findMiseTargets(cells: []Cell, row: u8, col: u8, color: Cell) threats.PositionList {
+    var result = threats.PositionList.init();
+    var seen = [_]bool{false} ** CELL_COUNT;
+
+    // 1. 各方向のライン延長点（距離制限なし）
+    for (DIRECTIONS, 0..) |dir, di| {
+        const lut = ll.queryPatternByCell(row, col, di, color);
+        if (lut.count < 2) continue; // 2石未満 → 四三不可能
+
+        // 正方向の端
+        var r: i16 = @as(i16, row) + dir.dr;
+        var c: i16 = @as(i16, col) + dir.dc;
+        while (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == color)
+        {
+            r += dir.dr;
+            c += dir.dc;
+        }
+        if (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == .empty)
+        {
+            miseTryAdd(cells, &result, &seen, r, c, color);
+            // 飛び四ターゲット: ギャップの1つ先（miseTryAdd が空き判定）
+            miseTryAdd(cells, &result, &seen, r + dir.dr, c + dir.dc, color);
+        }
+
+        // 負方向の端
+        r = @as(i16, row) - dir.dr;
+        c = @as(i16, col) - dir.dc;
+        while (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == color)
+        {
+            r -= dir.dr;
+            c -= dir.dc;
+        }
+        if (board_mod.isValid(r, c) and
+            cells[@intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)))] == .empty)
+        {
+            miseTryAdd(cells, &result, &seen, r, c, color);
+            miseTryAdd(cells, &result, &seen, r - dir.dr, c - dir.dc, color);
+        }
+    }
+
+    // 2. ±2 近傍スキャン（ライン外の四三点も検出）
+    var dr: i16 = -2;
+    while (dr <= 2) : (dr += 1) {
+        var dc: i16 = -2;
+        while (dc <= 2) : (dc += 1) {
+            if (dr == 0 and dc == 0) continue;
+            miseTryAdd(cells, &result, &seen, @as(i16, row) + dr, @as(i16, col) + dc, color);
+        }
+    }
+
+    return result;
+}
+
 /// 四三脅威スキャン
 pub fn scanFourThreeThreat(cells: []Cell, color: Cell, stone_count: u16) bool {
     if (stone_count < 5) return false;

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -86,3 +86,27 @@ export fn detectOpponentThreatsWasm(opponent_color: u8) void {
     o = writeList(o, &info.mises);
     o = writeList(o, &info.double_threes);
 }
+
+// === findMiseTargets（#37 P3 PR5b）===
+//
+// (row,col) に color のミセ手を配置済みの盤面で、四三ターゲット点（空き）を列挙する。
+// [u8 count][count*(u8 row, u8 col)] を mise_buffer にシリアライズ（最大 1+64*2=129B）。
+var mise_buffer: [160]u8 = undefined;
+
+export fn getMiseBuffer() [*]u8 {
+    return &mise_buffer;
+}
+
+/// (row,col) にミセ手を配置済みの盤面で四三ターゲットを検出しバッファに書く。
+/// 事前に boardSet で cells（ミセ手含む）、syncBitboard で bitboard を同期しておくこと。
+export fn findMiseTargetsWasm(row: u8, col: u8, color: u8) void {
+    const c: board.Cell = @enumFromInt(color);
+    const list = evaluate.findMiseTargets(&board.board_cells, row, col, c);
+    mise_buffer[0] = list.len;
+    var o: usize = 1;
+    for (0..list.len) |i| {
+        mise_buffer[o] = list.items[i].row;
+        mise_buffer[o + 1] = list.items[i].col;
+        o += 2;
+    }
+}


### PR DESCRIPTION
## 概要

review（fullEval）の**ミセターゲット列挙** `findMiseTargets` を TS から Zig 単一ソースへ移行。当初 PR5b でブロックしていた箇所を、createsFourThree パリティ修正（#64）後に再開して完了。

## 変更

- **evaluate.zig**: `findMiseTargets` を新規実装。TS `miseTactics.ts` の full 版相当（各方向のライン延長点 + 飛び四 gap+1 ターゲット + ±2 近傍スキャン）。`mise_vcf.zig` の `findMiseTargetsLite` は gap+1/±2 を欠くため再利用せず別実装。黒禁手除外も TS と一致。
- **threat_wasm.zig**: `findMiseTargetsWasm` + `getMiseBuffer` を export（PositionList を `[count][count*(row,col)]` でシリアライズ）。
- **threatAdapter.ts**: `findMiseTargets` を追加（wasm 経由 / 未ロード時 TS フォールバック）。
- **fullEval.ts**: `doubleMiseTargets` 算出を `threatAdapter.findMiseTargets` 経由に張り替え。

## 検証

- faithful パリティテスト `findMiseTargetsParity.test.ts`: 決定的合法自己対局12局の各局面・近傍空き点にミセ手を仮置きし、Zig==TS（座標ソート正規化）
- reviewSnapshot / threatAdapter / tactics 含む全関連テスト緑

## 前提

createsFourThree のパリティ（#64）が前提。findMiseTargets は内部で createsFourThree を多用するため、#64 のバグが残っていると非合法盤同様に分岐していた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)