### PR TITLE
feat(cpu): review の findDoubleMiseMoves を Zig 委譲（#37 P3）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -67,7 +67,8 @@
         "**/renjuParity.test.ts",
         "**/threatAdapter.test.ts",
         "**/createsFourThreeParity.test.ts",
-        "**/findMiseTargetsParity.test.ts"
+        "**/findMiseTargetsParity.test.ts",
+        "**/findDoubleMiseMovesParity.test.ts"
       ],
       "rules": {
         "no-bitwise": "off"

--- a/src/logic/cpu/review/forcedLossCheck.ts
+++ b/src/logic/cpu/review/forcedLossCheck.ts
@@ -16,11 +16,13 @@ import type {
 } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { detectWhiteWinningPattern } from "../evaluation/winningPatterns";
 import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
-// #37 P3 PR4: 脅威検出を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
-import { detectOpponentThreats } from "../wasm/threatAdapter";
+// #37 P3 PR4/PR5b: 脅威検出・両ミセ手を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import {
+  detectOpponentThreats,
+  findDoubleMiseMoves,
+} from "../wasm/threatAdapter";
 import {
   wasmFindVCFSequence,
   wasmFindMiseVCFSequence,

--- a/src/logic/cpu/review/forcedWinDetection.ts
+++ b/src/logic/cpu/review/forcedWinDetection.ts
@@ -10,11 +10,10 @@ import type { ForcedWinNode, ForcedWinType } from "@/types/review";
 import type { VCTSearchOptions, VCTSequenceResult } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { findDoubleMiseMoves } from "../evaluation/tactics";
 import { findThreatMoves } from "../search/vctHelpers";
 import { validateVCTSequence } from "../search/vctValidation";
-// #37 P3 PR5: 四三判定を Zig 単一ソース(evaluate.createsFourThree)経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
-import { createsFourThree } from "../wasm/threatAdapter";
+// #37 P3 PR5/PR5b: 四三判定・両ミセ手を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { createsFourThree, findDoubleMiseMoves } from "../wasm/threatAdapter";
 import {
   filterByCounterThreats,
   REVIEW_MISE_VCF_OPTIONS,

--- a/src/logic/cpu/wasm/findDoubleMiseMovesParity.test.ts
+++ b/src/logic/cpu/wasm/findDoubleMiseMovesParity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * findDoubleMiseMoves の Zig⇄TS パリティ（#37 P3 PR5b）
+ *
+ * 決定的なランダム合法自己対局で生成した各局面・両色で、Zig `evaluate.findDoubleMiseMoves`
+ * と TS `findDoubleMiseMoves` が同じ両ミセ手集合を返すことを照合する faithful な等価テスト。
+ * 列挙順は座標ソートで正規化して比較する。
+ *
+ * createsFourThree / findMiseTargets のパリティが前提（両ミセ判定はこれらに依存）。
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import { findDoubleMiseMoves as findDoubleMiseMovesTs } from "@/logic/cpu/evaluation/miseTactics";
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import { findDoubleMiseMoves, preloadThreatWasm } from "./threatAdapter";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c] || !nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break;
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+const sortPos = (a: Position, b: Position): number =>
+  a.row - b.row || a.col - b.col;
+const norm = (ps: Position[]): string =>
+  [...ps]
+    .sort(sortPos)
+    .map((p) => `${p.row},${p.col}`)
+    .join("|");
+
+await preloadThreatWasm();
+
+describe("findDoubleMiseMoves parity (#37 P3 PR5b)", () => {
+  it("合法自己対局の各局面・両色で Zig==TS", () => {
+    const COLORS: StoneColor[] = ["black", "white"];
+    const GAMES = 40;
+    let seed = 0xd00d1e42;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 45);
+
+      for (const board of snaps) {
+        for (const color of COLORS) {
+          const w = norm(findDoubleMiseMoves(board, color));
+          const t = norm(findDoubleMiseMovesTs(board, color));
+          if (w !== t && mismatches.length < 20) {
+            mismatches.push(`g=${g} ${color} wasm=[${w}] ts=[${t}]`);
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 60000);
+});

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -23,7 +23,10 @@ import {
   detectOpponentThreats as detectOpponentThreatsTs,
   type ThreatInfo,
 } from "@/logic/cpu/evaluation";
-import { findMiseTargets as findMiseTargetsTs } from "@/logic/cpu/evaluation/miseTactics";
+import {
+  findDoubleMiseMoves as findDoubleMiseMovesTs,
+  findMiseTargets as findMiseTargetsTs,
+} from "@/logic/cpu/evaluation/miseTactics";
 import { createsFourThree as createsFourThreeTs } from "@/logic/cpu/evaluation/winningPatterns";
 import {
   createsFour as createsFourTs,
@@ -218,4 +221,22 @@ export function findMiseTargets(
     return positions;
   }
   return findMiseTargetsTs(board, row, col, color);
+}
+
+/**
+ * color の両ミセ手（どの防御でも別の四三が残る手）を盤面全体から列挙する（#37 P3 PR5b）。
+ * wasm 経由は Zig `evaluate.findDoubleMiseMoves`。未ロード時は TS にフォールバック。
+ */
+export function findDoubleMiseMoves(
+  board: BoardState,
+  color: "black" | "white",
+): Position[] {
+  if (wasm) {
+    syncBoard(wasm, board);
+    wasm.findDoubleMiseMovesWasm(color === "black" ? CELL.BLACK : CELL.WHITE);
+    const mem = new Uint8Array(wasm.memory.buffer);
+    const { positions } = readPositionList(mem, wasm.getDoubleMiseBuffer());
+    return positions;
+  }
+  return findDoubleMiseMovesTs(board, color);
 }

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -21,6 +21,10 @@ export interface ThreatWasmContext {
   findMiseTargetsWasm: (row: number, col: number, color: number) => void;
   /** ミセターゲットバッファの先頭オフセット（memory 内）を返す。 */
   getMiseBuffer: () => number;
+  /** color の両ミセ手を列挙しバッファに書く（#37 P3 PR5b）。 */
+  findDoubleMiseMovesWasm: (color: number) => void;
+  /** 両ミセ手バッファの先頭オフセット（memory 内）を返す。 */
+  getDoubleMiseBuffer: () => number;
   /** wasm 線形メモリ（バッファ読み取り用）。 */
   memory: WebAssembly.Memory;
 }

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -247,6 +247,87 @@ pub fn findMiseTargets(cells: []Cell, row: u8, col: u8, color: Cell) threats.Pos
     return result;
 }
 
+/// ミセターゲットが存在しうるか安価に判定（プリフィルタ）。
+/// TS miseTactics.ts hasPotentialMiseTarget に対応（analyzeDirection の黒長連補正込み）。
+fn hasPotentialMiseTarget(cells: []const Cell, row: u8, col: u8, color: Cell) bool {
+    for (DIRECTIONS) |dir| {
+        const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
+        const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
+        const count = @as(u16, pos.count) + neg.count + 1;
+        if (count < 2) continue;
+        var e1 = pos.end_state;
+        var e2 = neg.end_state;
+        if (color == .black and count == 4) {
+            if (e1 == .empty and blackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
+                e1 = .opponent;
+            }
+            if (e2 == .empty and blackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
+                e2 = .opponent;
+            }
+        }
+        if (e1 == .empty or e2 == .empty) return true;
+    }
+    return false;
+}
+
+/// 両ミセ判定（近似）。TS miseTactics.ts isDoubleMise に対応。
+/// 各ターゲット T_i に相手石を仮置きし、残りターゲットのいずれかで四三が残るかを検証する。
+/// どの T_i を防いでも別ターゲットで四三が残る（=全防御を生き残る）なら両ミセ。
+/// targets は (row,col) にミセ手配置済みで得た四三点。cells/bitboard は同期済み前提。
+fn isDoubleMise(cells: []Cell, targets: *const threats.PositionList, color: Cell) bool {
+    if (targets.len < 2) return false;
+    const opponent = color.opposite();
+    for (0..targets.len) |i| {
+        const ti = targets.items[i];
+        const ti_idx = @as(u16, ti.row) * BOARD_SIZE + ti.col;
+        // T_i に相手石を仮配置（cells + bitboard）
+        cells[ti_idx] = opponent;
+        bitboard.placeStone(ti.row, ti.col, opponent);
+        var survived = false;
+        for (0..targets.len) |j| {
+            if (i == j) continue;
+            const tj = targets.items[j];
+            if (createsFourThree(cells, tj.row, tj.col, color)) {
+                survived = true;
+                break;
+            }
+        }
+        cells[ti_idx] = .empty;
+        bitboard.removeStone(ti.row, ti.col);
+        // いずれかの防御で全ターゲットが潰れる → 両ミセでない
+        if (!survived) return false;
+    }
+    return true;
+}
+
+/// 盤面上の全空きセルから両ミセ手を列挙する。TS miseTactics.ts findDoubleMiseMoves に対応。
+/// 各空きセルに color を仮置きし、hasPotentialMiseTarget → findMiseTargets(>=2) → isDoubleMise を満たす点を返す。
+/// 呼び出し前に bitboard を cells と同期しておくこと。
+pub fn findDoubleMiseMoves(cells: []Cell, color: Cell) threats.PositionList {
+    var result = threats.PositionList.init();
+    for (0..BOARD_SIZE) |r_usize| {
+        const r: u8 = @intCast(r_usize);
+        for (0..BOARD_SIZE) |c_usize| {
+            const c: u8 = @intCast(c_usize);
+            const idx = @as(u16, r) * BOARD_SIZE + c;
+            if (cells[idx] != .empty) continue;
+            // 仮置き（cells + bitboard）
+            cells[idx] = color;
+            bitboard.placeStone(r, c, color);
+            if (hasPotentialMiseTarget(cells, r, c, color)) {
+                const targets = findMiseTargets(cells, r, c, color);
+                if (targets.len >= 2 and isDoubleMise(cells, &targets, color)) {
+                    result.push(.{ .row = r, .col = c });
+                }
+            }
+            // 復元
+            cells[idx] = .empty;
+            bitboard.removeStone(r, c);
+        }
+    }
+    return result;
+}
+
 /// 四三脅威スキャン
 pub fn scanFourThreeThreat(cells: []Cell, color: Cell, stone_count: u16) bool {
     if (stone_count < 5) return false;

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -110,3 +110,25 @@ export fn findMiseTargetsWasm(row: u8, col: u8, color: u8) void {
         o += 2;
     }
 }
+
+// === findDoubleMiseMoves（#37 P3 PR5b）===
+//
+// 盤面全空きセルから両ミセ手を列挙し [u8 count][count*(u8 row,u8 col)] をバッファに書く。
+var double_mise_buffer: [160]u8 = undefined;
+
+export fn getDoubleMiseBuffer() [*]u8 {
+    return &double_mise_buffer;
+}
+
+/// color の両ミセ手を列挙しバッファに書く。事前に boardSet/syncBitboard で同期しておくこと。
+export fn findDoubleMiseMovesWasm(color: u8) void {
+    const c: board.Cell = @enumFromInt(color);
+    const list = evaluate.findDoubleMiseMoves(&board.board_cells, c);
+    double_mise_buffer[0] = list.len;
+    var o: usize = 1;
+    for (0..list.len) |i| {
+        double_mise_buffer[o] = list.items[i].row;
+        double_mise_buffer[o + 1] = list.items[i].col;
+        o += 2;
+    }
+}


### PR DESCRIPTION
## 概要

review（forcedLossCheck / forcedWinDetection）の**両ミセ手列挙** `findDoubleMiseMoves` を TS から Zig 単一ソースへ移行。PR5b のミセ戦術の最後のピース。

## 変更

- **evaluate.zig**: `findDoubleMiseMoves` + `isDoubleMise` + `hasPotentialMiseTarget` を新規実装（TS `miseTactics.ts` 相当）。全空きセルに color を仮置きし `hasPotentialMiseTarget` → `findMiseTargets`(>=2) → `isDoubleMise`（各ターゲットを相手が防いでも別ターゲットで四三が残るか）を満たす点を返す。TS `computeMiseBonus` の DOUBLE_MISE 判定と同一ロジック。
- **threat_wasm.zig**: `findDoubleMiseMovesWasm` + `getDoubleMiseBuffer` を export。
- **threatAdapter.ts**: `findDoubleMiseMoves` 追加（wasm 経由 / 未ロード時 TS フォールバック）。
- **forcedLossCheck.ts / forcedWinDetection.ts**: `threatAdapter.findDoubleMiseMoves` 経由に張り替え。

## 検証

- faithful パリティテスト `findDoubleMiseMovesParity.test.ts`: 決定的合法自己対局40局の各局面・両色で Zig==TS（座標ソート正規化）
- **reviewSnapshot**（findDoubleMiseMoves を凍結）含む全関連テスト緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)