### PR TITLE
feat(cpu): vctHelpers 3関数を Zig 単一ソース化（#37 P3 PR6）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -68,7 +68,8 @@
         "**/threatAdapter.test.ts",
         "**/createsFourThreeParity.test.ts",
         "**/findMiseTargetsParity.test.ts",
-        "**/findDoubleMiseMovesParity.test.ts"
+        "**/findDoubleMiseMovesParity.test.ts",
+        "**/vctHelpersParity.test.ts"
       ],
       "rules": {
         "no-bitwise": "off"

--- a/src/logic/cpu/review/forcedLossCheck.ts
+++ b/src/logic/cpu/review/forcedLossCheck.ts
@@ -17,11 +17,12 @@ import type {
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { detectWhiteWinningPattern } from "../evaluation/winningPatterns";
-import { hasFourThreeAvailable, hasOpenThree } from "../search/vctHelpers";
-// #37 P3 PR4/PR5b: 脅威検出・両ミセ手を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+// #37 P3 PR4/PR5b/PR6: 脅威検出・両ミセ手・VCT検証ヘルパーを Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
 import {
   detectOpponentThreats,
   findDoubleMiseMoves,
+  hasFourThreeAvailable,
+  hasOpenThree,
 } from "../wasm/threatAdapter";
 import {
   wasmFindVCFSequence,

--- a/src/logic/cpu/review/forcedWinDetection.ts
+++ b/src/logic/cpu/review/forcedWinDetection.ts
@@ -10,10 +10,13 @@ import type { ForcedWinNode, ForcedWinType } from "@/types/review";
 import type { VCTSearchOptions, VCTSequenceResult } from "../search/types";
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
-import { findThreatMoves } from "../search/vctHelpers";
 import { validateVCTSequence } from "../search/vctValidation";
-// #37 P3 PR5/PR5b: 四三判定・両ミセ手を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
-import { createsFourThree, findDoubleMiseMoves } from "../wasm/threatAdapter";
+// #37 P3 PR5/PR5b/PR6: 四三判定・両ミセ手・脅威手列挙を Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import {
+  createsFourThree,
+  findDoubleMiseMoves,
+  findThreatMoves,
+} from "../wasm/threatAdapter";
 import {
   filterByCounterThreats,
   REVIEW_MISE_VCF_OPTIONS,

--- a/src/logic/cpu/search/vctValidation.ts
+++ b/src/logic/cpu/search/vctValidation.ts
@@ -9,13 +9,14 @@ import type { BoardState, Position } from "@/types/game";
 
 import { checkFive } from "@/logic/renjuRules";
 
+// #37 P3 PR6: VCT検証ヘルパーを Zig 単一ソース経由に（合法局面で TS と一致、未ロード時 TS フォールバック）。
+import { hasFourThreeAvailable, hasOpenThree } from "../wasm/threatAdapter";
 import { createsFour } from "./threatMoves";
 import {
   checkDefenseCounterThreat,
   findFourMoves,
   getFourDefensePosition,
 } from "./threatPatterns";
-import { hasFourThreeAvailable, hasOpenThree } from "./vctHelpers";
 
 /**
  * VCT手順の事後検証

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -32,6 +32,11 @@ import {
   createsFour as createsFourTs,
   createsOpenThree as createsOpenThreeTs,
 } from "@/logic/cpu/search/threatMoves";
+import {
+  findThreatMoves as findThreatMovesTs,
+  hasFourThreeAvailable as hasFourThreeAvailableTs,
+  hasOpenThree as hasOpenThreeTs,
+} from "@/logic/cpu/search/vctHelpers";
 
 import { loadThreatWasm, type ThreatWasmContext } from "./threatLoader";
 import { CELL } from "./types";
@@ -239,4 +244,60 @@ export function findDoubleMiseMoves(
     return positions;
   }
   return findDoubleMiseMovesTs(board, color);
+}
+
+/**
+ * color が活三（連続三で両端空き／跳び三）を盤面上に持つか（#37 P3 PR6）。
+ * wasm 経由は Zig `vct.hasOpenThree`。未ロード時は TS にフォールバック。
+ * review 利用点（VCT 検証）は lineTable なしの全盤走査パスで呼ぶため、本アダプタも
+ * lineTable を受けない（Zig 版も全盤走査）。
+ */
+export function hasOpenThree(
+  board: BoardState,
+  color: "black" | "white",
+): boolean {
+  if (wasm) {
+    syncBoard(wasm, board);
+    return (
+      wasm.hasOpenThreeWasm(color === "black" ? CELL.BLACK : CELL.WHITE) !== 0
+    );
+  }
+  return hasOpenThreeTs(board, color);
+}
+
+/**
+ * color がミセ手（1手で四三を作れる手）を盤面上に持つか（#37 P3 PR6）。
+ * wasm 経由は Zig `vct.hasFourThreeAvailable`（黒は禁手考慮）。未ロード時は TS にフォールバック。
+ */
+export function hasFourThreeAvailable(
+  board: BoardState,
+  color: "black" | "white",
+): boolean {
+  if (wasm) {
+    syncBoard(wasm, board);
+    return (
+      wasm.hasFourThreeAvailableWasm(
+        color === "black" ? CELL.BLACK : CELL.WHITE,
+      ) !== 0
+    );
+  }
+  return hasFourThreeAvailableTs(board, color);
+}
+
+/**
+ * color の脅威手（四・活三を作れる空き点、四優先・row-major）を列挙する（#37 P3 PR6）。
+ * wasm 経由は Zig `vct.findThreatMoves`。未ロード時は TS にフォールバック。
+ */
+export function findThreatMoves(
+  board: BoardState,
+  color: "black" | "white",
+): Position[] {
+  if (wasm) {
+    syncBoard(wasm, board);
+    wasm.findThreatMovesWasm(color === "black" ? CELL.BLACK : CELL.WHITE);
+    const mem = new Uint8Array(wasm.memory.buffer);
+    const { positions } = readPositionList(mem, wasm.getThreatMovesBuffer());
+    return positions;
+  }
+  return findThreatMovesTs(board, color);
 }

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -25,6 +25,14 @@ export interface ThreatWasmContext {
   findDoubleMiseMovesWasm: (color: number) => void;
   /** 両ミセ手バッファの先頭オフセット（memory 内）を返す。 */
   getDoubleMiseBuffer: () => number;
+  /** color が活三を持つか（1/0）。盤面全走査（#37 P3 PR6）。 */
+  hasOpenThreeWasm: (color: number) => number;
+  /** color がミセ手（1手で四三）を持つか（1/0）。盤面全走査（#37 P3 PR6）。 */
+  hasFourThreeAvailableWasm: (color: number) => number;
+  /** color の脅威手（四・活三、四優先）を列挙しバッファに書く（#37 P3 PR6）。 */
+  findThreatMovesWasm: (color: number) => void;
+  /** 脅威手バッファの先頭オフセット（memory 内）を返す。 */
+  getThreatMovesBuffer: () => number;
   /** wasm 線形メモリ（バッファ読み取り用）。 */
   memory: WebAssembly.Memory;
 }

--- a/src/logic/cpu/wasm/vctHelpersParity.test.ts
+++ b/src/logic/cpu/wasm/vctHelpersParity.test.ts
@@ -1,0 +1,152 @@
+/**
+ * vctHelpers 3関数の Zig⇄TS パリティ（#37 P3 PR6）
+ *
+ * hasOpenThree / hasFourThreeAvailable / findThreatMoves を Zig 単一ソース化するにあたり、
+ * WASM 委譲版（threatAdapter）と TS 実装（vctHelpers）が合法局面で完全一致することを保証する。
+ *
+ * createsFourThreeParity.test.ts と同じ方針: 全空き点総当たりの非合法盤は未定義領域で分岐するため、
+ * **決定的なランダム合法自己対局**（黒の禁手を尊重・五で終局・近傍着手）で生成した全局面・両色を照合する。
+ *
+ * - hasOpenThree / hasFourThreeAvailable: 各局面・両色で bool 一致
+ * - findThreatMoves: 各局面・両色で **順序付き配列**（row-major・four優先）まで一致
+ *   （TS・Zig とも同一走査順なので、順序差が出れば実バグとして検出する）
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import {
+  findThreatMoves as findThreatMovesTs,
+  hasFourThreeAvailable as hasFourThreeAvailableTs,
+  hasOpenThree as hasOpenThreeTs,
+} from "@/logic/cpu/search/vctHelpers";
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+
+import {
+  findThreatMoves,
+  hasFourThreeAvailable,
+  hasOpenThree,
+  preloadThreatWasm,
+} from "./threatAdapter";
+
+/** 決定的 PRNG（mulberry32、外部依存なし） */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** (r,c) が既存石の距離2以内か */
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** ランダム合法自己対局を1局打ち、各手後の局面スナップショットを返す */
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c]) {
+          continue;
+        }
+        if (!nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break; // 勝負あり
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+/** Position[] を順序保持で文字列化（findThreatMoves の厳密比較用） */
+function serialize(positions: Position[]): string {
+  return positions.map((p) => `${p.row},${p.col}`).join("|");
+}
+
+await preloadThreatWasm();
+
+describe("vctHelpers parity (#37 P3 PR6)", () => {
+  it("ランダム合法自己対局の全局面・両色で Zig==TS", () => {
+    const COLORS: StoneColor[] = ["black", "white"];
+    const GAMES = 80;
+    let seed = 0xc0ffee01;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 50);
+
+      for (const board of snaps) {
+        for (const color of COLORS) {
+          // hasOpenThree
+          const wOpen = hasOpenThree(board, color);
+          const tOpen = hasOpenThreeTs(board, color);
+          if (wOpen !== tOpen && mismatches.length < 20) {
+            mismatches.push(
+              `g=${g} hasOpenThree(${color}) wasm=${wOpen} ts=${tOpen}`,
+            );
+          }
+
+          // hasFourThreeAvailable
+          const wFt = hasFourThreeAvailable(board, color);
+          const tFt = hasFourThreeAvailableTs(board, color);
+          if (wFt !== tFt && mismatches.length < 20) {
+            mismatches.push(
+              `g=${g} hasFourThreeAvailable(${color}) wasm=${wFt} ts=${tFt}`,
+            );
+          }
+
+          // findThreatMoves（順序込み）
+          const wMoves = serialize(findThreatMoves(board, color));
+          const tMoves = serialize(findThreatMovesTs(board, color));
+          if (wMoves !== tMoves && mismatches.length < 20) {
+            mismatches.push(
+              `g=${g} findThreatMoves(${color}) wasm=[${wMoves}] ts=[${tMoves}]`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 30000);
+});

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -132,3 +132,44 @@ export fn findDoubleMiseMovesWasm(color: u8) void {
         o += 2;
     }
 }
+
+// === vctHelpers（#37 P3 PR6）===
+//
+// VCT 検証ヘルパー3関数（review 専用パス: validateVCTSequence / filterByCounterThreats /
+// findVCTByFirstMoveIteration）を Zig 単一ソース経由にする橋。実体は vct.zig の既存関数。
+// いずれも盤面全走査を内包するバッチ API なので、1 回の sync で 1 回呼ぶ（点ごと再同期は不要）。
+// 事前に boardSet で cells、syncBitboard で bitboard を同期しておくこと。
+
+/// color が活三を持つか（1/0）。
+export fn hasOpenThreeWasm(color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    return if (vct.hasOpenThree(&board.board_cells, c)) 1 else 0;
+}
+
+/// color がミセ手（1手で四三）を持つか（1/0）。内部で空き点を仮置き・復元する。
+export fn hasFourThreeAvailableWasm(color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    return if (vct.hasFourThreeAvailable(&board.board_cells, c)) 1 else 0;
+}
+
+// 四・活三を作れる手（四優先・row-major）を [u8 count][count*(row,col)] でシリアライズ。
+// 最大 225 手なので 1 + 225*2 = 451 バイト。
+var threat_moves_buffer: [512]u8 = undefined;
+
+export fn getThreatMovesBuffer() [*]u8 {
+    return &threat_moves_buffer;
+}
+
+/// color の脅威手を列挙しバッファに書く。内部で各空き点を仮置き・復元する。
+export fn findThreatMovesWasm(color: u8) void {
+    const c: board.Cell = @enumFromInt(color);
+    var buf: [225]threats.Position = undefined;
+    const n = vct.findThreatMoves(&board.board_cells, c, &buf);
+    threat_moves_buffer[0] = @intCast(n);
+    var o: usize = 1;
+    for (0..n) |i| {
+        threat_moves_buffer[o] = buf[i].row;
+        threat_moves_buffer[o + 1] = buf[i].col;
+        o += 2;
+    }
+}


### PR DESCRIPTION
## 概要

#37 P3（review 戦術の Zig 単一ソース化）の続き。VCT 検証ヘルパー3関数を Zig/WASM へ委譲する。ミセ戦術（PR5b, #63）に続く PR6。

対象3関数（`src/logic/cpu/search/vctHelpers.ts`）:
- `hasOpenThree` — 指定色が活三を持つか
- `hasFourThreeAvailable` — 指定色がミセ手（1手で四三）を持つか
- `findThreatMoves` — 四・活三を作れる手を列挙（四優先）

**前提**: これら3関数は Zig 側に実装済み（`zig/src/vct.zig:196-313`、`hasVCT`/`findVCTSequence` から既に使用）。本 PR は **threat.wasm へのエクスポート敷設 + アダプタ配線 + faithful パリティ + 利用点の import 切替**のみ（新規アルゴリズム実装なし）。

## 変更

1. **Zig エクスポート**（`threat_wasm.zig`）: `hasOpenThreeWasm` / `hasFourThreeAvailableWasm` / `findThreatMovesWasm` + バッファ。実体は vct.zig の既存関数。
2. **アダプタ配線**（`threatLoader.ts` / `threatAdapter.ts`）: 既存 PR2/PR4/PR5b と同一パターン。WASM 委譲 + TS フォールバック。
3. **faithful パリティテスト**（`vctHelpersParity.test.ts`）: 決定的ランダム合法自己対局80局の全局面・両色で Zig==TS を照合（findThreatMoves は順序付き配列で厳密比較）。
4. **利用点の import 切替**: `vctValidation.ts` / `forcedLossCheck.ts` / `forcedWinDetection.ts` を threatAdapter へ統合。TS 実装はフォールバック兼テスト用に残置（P4 で削除棚卸し）。

いずれも review 専用パス（VCT 検証）であり、対局 CPU 強度には非影響。

## 検証

- ✅ `vctHelpersParity.test.ts` 緑（faithful 等価）
- ✅ `pnpm test` 1809件緑
- ✅ `zig build test` 緑
- ✅ `pnpm check-fix` 緑
- ✅ サブエージェント `/review`（SOLID・パフォーマンス・イシュー）全 LGTM

## 補足

- threat.wasm サイズ: 124KB → 133KB（+9KB、`hasVCF`/`findVCFSequence` の引き込みによる）
- パフォーマンス: WASM 委譲は1呼び出しごとに syncBoard(O(225)) が走るが review 背景タスクで許容。将来 `filterByCounterThreats` のバッチ化余地あり（本 PR scope 外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
