### PR TITLE
feat(cpu): patternsAdapter 敷設 + #43削除プラン（#37 P4 PR-A）

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -69,7 +69,8 @@
         "**/createsFourThreeParity.test.ts",
         "**/findMiseTargetsParity.test.ts",
         "**/findDoubleMiseMovesParity.test.ts",
-        "**/vctHelpersParity.test.ts"
+        "**/vctHelpersParity.test.ts",
+        "**/patternsParity.test.ts"
       ],
       "rules": {
         "no-bitwise": "off"

--- a/docs/plans/issue-37-p4-delete-patterns.md
+++ b/docs/plans/issue-37-p4-delete-patterns.md
@@ -1,0 +1,102 @@
+# #37 P4 (#43): patterns.ts / forbiddenMoves.ts 物理削除プラン
+
+> ステータス: **設計のみ**（2026-06-09）。実装は次セッション以降。本ドキュメントは /review 合意形成用。
+
+## Context
+
+#37 の最終目標は、連珠ルール（禁手・図形・パターン判定）の **TS 二重実装 `src/logic/renjuRules/patterns.ts` と `forbiddenMoves.ts` を物理削除**し、ダブルメンテを解消すること（= #43）。Zig 側（`forbidden.zig`/`jump_patterns.zig`/`patterns.zig`）に全関数の実装があり、対局CPU・VCF/VCT worker・禁手判定（forbiddenAdapter）は既に Zig 委譲済み。
+
+### 唯一のブロッカー（調査で判明）
+
+**review 内訳表示の評価スコア計算**が、評価ヘルパー（`forbiddenTactics`/`jumpPatterns`/`miseTactics`/`threatDetection`/`winningPatterns`）と探索ヘルパー（`threatMoves`/`vctHelpers`/`threatPatterns`）を通じて、patterns.ts/forbiddenMoves.ts のプリミティブ（`checkForbiddenMove`/`checkJumpFour`/`checkJumpThree`/`checkStraightFour`/`checkOpenPattern`/`getConsecutiveThreeStraightFourPoints`/`getJumpThreeStraightFourPoints`）を**同期 TS 直呼び**している。さらに `forbiddenMoves.ts` 自身が patterns.ts を使う。
+
+評価関数（`evaluatePositionWithBreakdown` 等）は「#37 対象外＝別issue（ボス合意）」だが、それが patterns.ts を使う限り #43 を塞ぐ、というロードマップ上の矛盾。
+
+## 方針（Option B: ルールプリミティブを Zig 委譲、評価スコア組み立ては TS 温存）
+
+**#37 の真の目的は「連珠ルールの二重実装」解消**であり、評価のしきい値/ボーナス（ヒューリスティック）は「ルール」ではない。よって:
+
+- **ルールプリミティブ**（禁手・図形判定）→ Zig 単一ソース（thin wasm + adapter）に一本化。
+- **評価スコアの組み立て**（evaluatePositionWithBreakdown の内訳合成・スコア定数）→ TS に温存（= 別issue。プレゼン/ヒューリスティック層）。ただし内部のルール判定は adapter 経由 Zig に切替。
+
+これで patterns.ts/forbiddenMoves.ts の TS 消費者がゼロになり物理削除できる。評価関数の全 Zig 化（ScoreBreakdown を Zig が返す Option A）は不要（大規模・UI内訳パリティ риск回避）。
+
+### 既存資産（再利用）
+
+- `forbiddenAdapter.ts`（checkForbiddenMove の Zig 委譲、`forbidden_wasm.zig` の `checkForbiddenPointWasm`）— 既存。
+- `threat_wasm.zig` + `threatAdapter.ts`（classifyThreat/createsFourThree/detect/mise/hasOpenThree 等）— 既存パターン踏襲。
+- `renjuParity.test.ts` — TS==Zig 照合。patterns.ts プリミティブの Zig 同値を既にカバー（`checkJumpFour`/`checkStraightFour`/`getJumpThreeStraightFourPoints` 等）。移行中の安全網。**最終 PR で TS オラクル消失とともに用途終了**。
+- cpu-engine wasm は既に `getJumpThreeStraightFourPointsWasm` 等を export（`wasm/types.ts:28`）。Zig 実装存在の裏付け。
+
+## 消費者マップ（patterns.ts プリミティブ → 移行対象）
+
+| プリミティブ                            | TS 消費者（test除く、forbiddenMoves.ts は共倒れ削除）                                   |
+| --------------------------------------- | --------------------------------------------------------------------------------------- |
+| `checkJumpFour`                         | threatMoves, vctHelpers, threatPatterns, threatDetection, winningPatterns, jumpPatterns |
+| `checkJumpThree`                        | 同上 + forbiddenTactics                                                                 |
+| `checkStraightFour`                     | jumpPatterns                                                                            |
+| `getConsecutiveThreeStraightFourPoints` | forbiddenTactics, jumpPatterns                                                          |
+| `getJumpThreeStraightFourPoints`        | forbiddenTactics, jumpPatterns（+ wasm/types.ts は型のみ）                              |
+| `checkOpenPattern`                      | patternRecognition                                                                      |
+| `checkForbiddenMove`(forbiddenMoves.ts) | 残 TS 直呼び3箇所（miseTactics 等）→ forbiddenAdapter へ                                |
+
+- `patternRecognition.ts`（`recognizePattern`）は **index.ts バレルからのみ参照（実消費者ゼロ＝死蔵）**。PR-C で patternRecognition.ts ごと削除。
+- `forbiddenMoves.ts` の `checkForbiddenMoveWithContext`（グローバルハッシュキャッシュ版）も **index.ts 再エクスポートのみ＝実消費者ゼロ**。forbiddenMoves.ts と共倒れ削除（Zig は単点版なので移行不要）。
+- `core.ts` の `checkFive`/`createEmptyBoard` 等は削除対象外（残存）。
+
+## PR 分解
+
+### PR-A: patternsAdapter 敷設（新規 wasm export + adapter + parity）✅ 実装済み（本PR）
+
+- `threat_wasm.zig` に **5 プリミティブ**を export 追加（実体は jump_patterns.zig の既存関数。cells 直読み=bitboard非依存）:
+  - bool 返し（u8）: `checkJumpFourWasm` / `checkJumpThreeWasm` / `checkStraightFourWasm`（引数: row,col,dir,color。「配置済み」cells 規約）
+  - Position列返し: `getConsecutiveThreeStraightFourPointsWasm`（最大2点）/ `getJumpThreeStraightFourPointsWasm`（最大1点）→ `pattern_points_buffer`（`[u8 count][count*(row,col)]`）+ `getPatternPointsBuffer`
+  - **`checkOpenPattern` は省略**: 生存消費者が patternRecognition と forbiddenMoves のみで両方 PR-C/D で削除されるため adapter 不要。
+- `src/logic/cpu/wasm/patternsAdapter.ts` 新規（5関数。`getThreatWasm` で threatAdapter のインスタンス共用＝二重ロード回避。boardInit/boardSet のみ同期。未ロード時 TS フォールバック）。
+- faithful パリティ `patternsParity.test.ts` 新設（決定的合法自己対局40局、近傍空き点に候補配置、全8方向・両色で raw wasm==TS。点列は座標ソート正規化。+ adapter 配線 smoke）。
+- ゲート: check-fix / 新パリティ緑 / renjuParity 緑 / reviewSnapshot 不変。
+
+### PR-B: CPU/eval 利用点を adapter へ張替
+
+- 上表の CPU 探索/評価ヘルパー（threatMoves/vctHelpers/threatPatterns/threatDetection/winningPatterns/jumpPatterns/forbiddenTactics/miseTactics）の patterns.ts プリミティブ import を `patternsAdapter` へ、残 `checkForbiddenMove` 直呼びを `forbiddenAdapter` へ切替。
+- **同期性**: adapter は wasm ロード後同期。1呼び出しごと syncBoard(O(225))。review/worker パス（非ホットパス、1着手/クリック駆動）なので許容。ループ内多回呼びでボトルネックなら該当箇所のみバッチ export を検討（PR-B 内で判断）。
+- ゲート: reviewSnapshot バイト不変 / renjuParity 緑 / 全テスト緑 / review breakdown 実動作確認。
+- 完了時点で patterns.ts の消費者は forbiddenMoves.ts と patternRecognition.ts と index.ts のみ。
+
+### PR-C: renjuRules 内部の patterns 依存解消
+
+- `patternRecognition.ts`: 実利用なら checkOpenPattern を adapter へ、未使用なら recognizePattern ごと削除。
+- `wasm/types.ts` の型参照整理。
+- forbiddenMoves.ts の patterns 依存は PR-D で共倒れ削除のため触らない。
+
+### PR-D: フォールバック撤去 + 物理削除（capstone, #37 完了）
+
+- **起動ブートゲート追加（フォールバック撤去の前提・3観点レビュー指摘）**: 現状 main.ts の preload は非ブロッキング発火（`.catch`）でレースあり。フォールバック撤去後は未ロード同期呼びが例外になるため、**`app.mount` 前に `await Promise.all([preloadForbiddenWasm(), preloadThreatWasm()])` で完了保証**する init barrier を先に入れる。review.worker.ts は既に `await preloadThreatWasm()` 済み。テストは setup で preload。
+- 前提充足確認: 全同期呼び出し経路が wasm ロード後であることを保証（UI 直呼びは無いことを確認済みだが、forbiddenAdapter 経由の経路も含めて再確認）。
+- `forbiddenAdapter`/`patternsAdapter` の **TS フォールバック分岐を撤去**（wasm 必須化）。順序: ブートゲート merge → フォールバック撤去。
+- **`patterns.ts` / `forbiddenMoves.ts` を `git rm`**。`renjuRules/index.ts` の re-export 除去。
+- `renjuParity.test.ts`: TS オラクル消失 → 削除（Zig unit test が単一ソースの正しさを担保）。または Zig 出力の golden 化に再設計（要判断）。
+- ゲート: check-fix / 全テスト緑 / zig build test 緑 / reviewSnapshot 不変 / review breakdown 実動作 / 対局・パズルで禁手判定が従来通り（E2E）。
+
+## 技術判断・リスク
+
+- **同期 wasm の保証**: フォールバック撤去後、wasm 未ロードで同期呼びが走ると例外。main/worker の preload が**起動時必ず完了**しているか PR-D で厳密検証（非ブロッキング発火のレース確認）。必要なら preload を await するブートゲートを追加。
+- **パリティの維持**: PR-A〜C の間 renjuParity を緑に保ち、Zig プリミティブが TS と同値であることを移行前に保証。最終 PR-D でのみ TS を消す。
+- **非合法盤の扱い**: Zig⇄TS は非合法盤（多重四/長連/盤端不能）で食い違うが合法局面では一致（#37 既知）。パリティは**合法自己対局ベース**。点列 export は座標ソート/順序付きで正規化。
+- **patternRecognition の生死**: PR-A で要確定（index バレル経由の実利用調査）。
+- **評価関数は依然 TS**: 本プランは「評価スコア組み立て」を TS に残す（別issue）。#37 完了後も evaluatePositionWithBreakdown は TS だが、ルール判定は Zig 単一ソース。これがロードマップ「TS=プレゼン、戦術=Zig」の最終形。
+- **性能**: 触る箇所は review/worker（非対局ホットパス）。対局CPU(Zig)は無干渉。実害なし。
+
+## 工数見積り（粗）
+
+- PR-A: 中（wasm export 6 + adapter + パリティ）。点列バッファ2本の設計。
+- PR-B: 中〜大（8ファイルの import 切替 + 同期性検証 + reviewSnapshot ガード）。最大の地味作業。
+- PR-C: 小。
+- PR-D: 中（フォールバック撤去 + preload 保証検証 + 物理削除 + renjuParity 処理 + E2E）。
+- 合計: 複数セッション。各 PR は stacked（本体→main はボス動作確認後）。
+
+## 未解決の確認事項（実装前にボスへ）
+
+1. renjuParity.test.ts は **削除**でよいか（Zig 単一ソース化の帰結）、Zig golden 再設計が要るか。
+2. preload 未完レース対策として**起動ブートゲート（preload await）**を入れてよいか（わずかな初期化遅延）。
+3. patternRecognition.recognizePattern が未使用なら削除してよいか。

--- a/src/logic/cpu/wasm/patternsAdapter.ts
+++ b/src/logic/cpu/wasm/patternsAdapter.ts
@@ -1,0 +1,151 @@
+/**
+ * 図形パターンプリミティブ アダプタ（#37 P4 PR-A）
+ *
+ * 連珠ルールの図形判定（跳び四 / 跳び三 / 達四 / 達四点列挙）を Zig 単一ソース
+ * （jump_patterns.zig、threat_wasm 経由）に委譲する橋。最終的に TS 二重実装
+ * `src/logic/renjuRules/patterns.ts` を物理削除（#43）するための布石。
+ *
+ * - wasm インスタンスは threatAdapter のものを共用（`getThreatWasm`）。二重ロード回避。
+ * - これらの Zig 関数は cells 直読み（bitboard 非依存）なので boardInit/boardSet のみ同期
+ *   （syncBitboard 不要）。
+ * - 契約は TS 版と同じく (row,col) に color を**配置済み**の board を渡す。
+ * - 未ロード時は TS `patterns.ts` にフォールバック（移行期の保険。#43 PR-D で撤去）。
+ */
+import type { BoardState, Position } from "@/types/game";
+
+import {
+  checkJumpFour as checkJumpFourTs,
+  checkJumpThree as checkJumpThreeTs,
+  checkStraightFour as checkStraightFourTs,
+  getConsecutiveThreeStraightFourPoints as getConsecutiveTs,
+  getJumpThreeStraightFourPoints as getJumpThreeTs,
+} from "@/logic/renjuRules/patterns";
+
+import type { ThreatWasmContext } from "./threatLoader";
+
+import { getThreatWasm } from "./threatAdapter";
+import { CELL } from "./types";
+
+/** cells のみ同期（jump_patterns は bitboard を使わないため syncBitboard は不要）。 */
+function syncCells(w: ThreatWasmContext, board: BoardState): void {
+  w.boardInit();
+  for (let row = 0; row < 15; row++) {
+    const boardRow = board[row];
+    if (!boardRow) {
+      continue;
+    }
+    for (let col = 0; col < 15; col++) {
+      const v = boardRow[col];
+      if (v === "black") {
+        w.boardSet(row, col, CELL.BLACK);
+      } else if (v === "white") {
+        w.boardSet(row, col, CELL.WHITE);
+      }
+    }
+  }
+}
+
+function colorEnum(color: "black" | "white"): number {
+  return color === "black" ? CELL.BLACK : CELL.WHITE;
+}
+
+/** pattern points バッファ（[u8 count][count*(row,col)]）を Position[] に読み出す。 */
+function readPatternPoints(w: ThreatWasmContext): Position[] {
+  const mem = new Uint8Array(w.memory.buffer);
+  const off = w.getPatternPointsBuffer();
+  const count = mem[off] ?? 0;
+  const positions: Position[] = [];
+  let o = off + 1;
+  for (let i = 0; i < count; i++) {
+    positions.push({ row: mem[o] ?? 0, col: mem[o + 1] ?? 0 });
+    o += 2;
+  }
+  return positions;
+}
+
+/** (row,col,dir,color) で跳び四が成立するか。配置済み board 規約。 */
+export function checkJumpFour(
+  board: BoardState,
+  row: number,
+  col: number,
+  dirIndex: number,
+  color: "black" | "white",
+): boolean {
+  const w = getThreatWasm();
+  if (w) {
+    syncCells(w, board);
+    return w.checkJumpFourWasm(row, col, dirIndex, colorEnum(color)) !== 0;
+  }
+  return checkJumpFourTs(board, row, col, dirIndex, color);
+}
+
+/** (row,col,dir,color) で跳び三が成立するか。配置済み board 規約。 */
+export function checkJumpThree(
+  board: BoardState,
+  row: number,
+  col: number,
+  dirIndex: number,
+  color: "black" | "white",
+): boolean {
+  const w = getThreatWasm();
+  if (w) {
+    syncCells(w, board);
+    return w.checkJumpThreeWasm(row, col, dirIndex, colorEnum(color)) !== 0;
+  }
+  return checkJumpThreeTs(board, row, col, dirIndex, color);
+}
+
+/** (row,col,dir,color) で達四が成立するか。配置済み board 規約。 */
+export function checkStraightFour(
+  board: BoardState,
+  row: number,
+  col: number,
+  dirIndex: number,
+  color: "black" | "white" = "black",
+): boolean {
+  const w = getThreatWasm();
+  if (w) {
+    syncCells(w, board);
+    return w.checkStraightFourWasm(row, col, dirIndex, colorEnum(color)) !== 0;
+  }
+  return checkStraightFourTs(board, row, col, dirIndex, color);
+}
+
+/** 連続三の達四点（最大2点）を列挙する。配置済み board 規約。 */
+export function getConsecutiveThreeStraightFourPoints(
+  board: BoardState,
+  row: number,
+  col: number,
+  dirIndex: number,
+  color: "black" | "white" = "black",
+): Position[] {
+  const w = getThreatWasm();
+  if (w) {
+    syncCells(w, board);
+    w.getConsecutiveThreeStraightFourPointsWasm(
+      row,
+      col,
+      dirIndex,
+      colorEnum(color),
+    );
+    return readPatternPoints(w);
+  }
+  return getConsecutiveTs(board, row, col, dirIndex, color);
+}
+
+/** 跳び三の達四点（最大1点）を列挙する。配置済み board 規約。 */
+export function getJumpThreeStraightFourPoints(
+  board: BoardState,
+  row: number,
+  col: number,
+  dirIndex: number,
+  color: "black" | "white" = "black",
+): Position[] {
+  const w = getThreatWasm();
+  if (w) {
+    syncCells(w, board);
+    w.getJumpThreeStraightFourPointsWasm(row, col, dirIndex, colorEnum(color));
+    return readPatternPoints(w);
+  }
+  return getJumpThreeTs(board, row, col, dirIndex, color);
+}

--- a/src/logic/cpu/wasm/patternsParity.test.ts
+++ b/src/logic/cpu/wasm/patternsParity.test.ts
@@ -1,0 +1,271 @@
+/**
+ * patterns プリミティブの Zig⇄TS パリティ（#37 P4 PR-A）
+ *
+ * threat_wasm（= jump_patterns.zig）と TS 実装（patterns.ts）が合法局面で完全一致する
+ * ことを保証する。物理削除（#43）前に Zig が TS と同値であることの安全網。
+ *
+ * 性能のため本体パリティは「候補配置ごとに cells を1回同期 → raw wasm を全方向呼ぶ」方式
+ * （adapter は呼び出しごとに再同期するためループ照合に不向き）。adapter の配線（同期・色変換・
+ * バッファ読み出し）は末尾の smoke テストで別途検証する。
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BoardState, Position, StoneColor } from "@/types/game";
+
+import { checkFive, createEmptyBoard } from "@/logic/renjuRules/core";
+import { checkForbiddenMove } from "@/logic/renjuRules/forbiddenMoves";
+import {
+  checkJumpFour as checkJumpFourTs,
+  checkJumpThree as checkJumpThreeTs,
+  checkStraightFour as checkStraightFourTs,
+  getConsecutiveThreeStraightFourPoints as getConsecutiveTs,
+  getJumpThreeStraightFourPoints as getJumpThreeTs,
+} from "@/logic/renjuRules/patterns";
+
+import type { ThreatWasmContext } from "./threatLoader";
+
+import {
+  checkJumpFour,
+  checkJumpThree,
+  checkStraightFour,
+  getConsecutiveThreeStraightFourPoints,
+  getJumpThreeStraightFourPoints,
+} from "./patternsAdapter";
+import { getThreatWasm, preloadThreatWasm } from "./threatAdapter";
+import { CELL } from "./types";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function nearStone(board: BoardState, r: number, c: number): boolean {
+  for (let dr = -2; dr <= 2; dr++) {
+    for (let dc = -2; dc <= 2; dc++) {
+      const rr = r + dr;
+      const cc = c + dc;
+      if (rr < 0 || rr > 14 || cc < 0 || cc > 14) {
+        continue;
+      }
+      if (board[rr]?.[cc]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function playRandomLegalGame(rng: () => number, maxPly: number): BoardState[] {
+  const board = createEmptyBoard();
+  board[7]![7] = "black";
+  const snapshots: BoardState[] = [];
+  let color: StoneColor = "white";
+
+  for (let ply = 1; ply < maxPly; ply++) {
+    const cands: Position[] = [];
+    for (let r = 0; r < 15; r++) {
+      for (let c = 0; c < 15; c++) {
+        if (board[r]?.[c] || !nearStone(board, r, c)) {
+          continue;
+        }
+        if (color === "black" && checkForbiddenMove(board, r, c).isForbidden) {
+          continue;
+        }
+        cands.push({ row: r, col: c });
+      }
+    }
+    if (cands.length === 0) {
+      break;
+    }
+    const pick = cands[Math.floor(rng() * cands.length)]!;
+    board[pick.row]![pick.col] = color;
+    snapshots.push(board.map((row) => [...row]) as BoardState);
+    if (checkFive(board, pick.row, pick.col, color)) {
+      break;
+    }
+    color = color === "black" ? "white" : "black";
+  }
+  return snapshots;
+}
+
+function syncCells(w: ThreatWasmContext, board: BoardState): void {
+  w.boardInit();
+  for (let row = 0; row < 15; row++) {
+    const boardRow = board[row];
+    if (!boardRow) {
+      continue;
+    }
+    for (let col = 0; col < 15; col++) {
+      const v = boardRow[col];
+      if (v === "black") {
+        w.boardSet(row, col, CELL.BLACK);
+      } else if (v === "white") {
+        w.boardSet(row, col, CELL.WHITE);
+      }
+    }
+  }
+}
+
+function readPoints(w: ThreatWasmContext): string {
+  const mem = new Uint8Array(w.memory.buffer);
+  const off = w.getPatternPointsBuffer();
+  const count = mem[off] ?? 0;
+  const pts: string[] = [];
+  let o = off + 1;
+  for (let i = 0; i < count; i++) {
+    pts.push(`${mem[o] ?? 0},${mem[o + 1] ?? 0}`);
+    o += 2;
+  }
+  return pts.sort().join("|");
+}
+
+function normTs(positions: Position[]): string {
+  return positions
+    .map((p) => `${p.row},${p.col}`)
+    .sort()
+    .join("|");
+}
+
+await preloadThreatWasm();
+
+describe("patterns primitives parity (#37 P4 PR-A)", () => {
+  it("raw wasm == TS（全局面・近傍空き点・全8方向・両色）", () => {
+    const w = getThreatWasm()!;
+    const COLORS: ("black" | "white")[] = ["black", "white"];
+    const GAMES = 40;
+    let seed = 0xbeef1234;
+    const mismatches: string[] = [];
+
+    for (let g = 0; g < GAMES && mismatches.length < 20; g++) {
+      const rng = mulberry32(seed);
+      seed = (seed + 0x9e3779b1) | 0;
+      const snaps = playRandomLegalGame(rng, 50);
+
+      for (const board of snaps) {
+        for (let r = 0; r < 15; r++) {
+          const boardRow = board[r];
+          if (!boardRow) {
+            continue;
+          }
+          for (let c = 0; c < 15; c++) {
+            if (boardRow[c] || !nearStone(board, r, c)) {
+              continue;
+            }
+            for (const color of COLORS) {
+              boardRow[c] = color;
+              syncCells(w, board); // 候補配置ごとに1回だけ同期
+              const ce = color === "black" ? CELL.BLACK : CELL.WHITE;
+              for (let dir = 0; dir < 8; dir++) {
+                const pairs: [string, boolean, boolean][] = [
+                  [
+                    "jumpFour",
+                    w.checkJumpFourWasm(r, c, dir, ce) !== 0,
+                    checkJumpFourTs(board, r, c, dir, color),
+                  ],
+                  [
+                    "jumpThree",
+                    w.checkJumpThreeWasm(r, c, dir, ce) !== 0,
+                    checkJumpThreeTs(board, r, c, dir, color),
+                  ],
+                  [
+                    "straightFour",
+                    w.checkStraightFourWasm(r, c, dir, ce) !== 0,
+                    checkStraightFourTs(board, r, c, dir, color),
+                  ],
+                ];
+                for (const [name, wb, tb] of pairs) {
+                  if (wb !== tb && mismatches.length < 20) {
+                    mismatches.push(
+                      `g=${g} (${r},${c},${color},dir=${dir}) ${name} wasm=${wb} ts=${tb}`,
+                    );
+                  }
+                }
+                w.getConsecutiveThreeStraightFourPointsWasm(r, c, dir, ce);
+                const wCons = readPoints(w);
+                const tCons = normTs(getConsecutiveTs(board, r, c, dir, color));
+                if (wCons !== tCons && mismatches.length < 20) {
+                  mismatches.push(
+                    `g=${g} (${r},${c},${color},dir=${dir}) consecutive wasm=[${wCons}] ts=[${tCons}]`,
+                  );
+                }
+                w.getJumpThreeStraightFourPointsWasm(r, c, dir, ce);
+                const wJump = readPoints(w);
+                const tJump = normTs(getJumpThreeTs(board, r, c, dir, color));
+                if (wJump !== tJump && mismatches.length < 20) {
+                  mismatches.push(
+                    `g=${g} (${r},${c},${color},dir=${dir}) jumpThree wasm=[${wJump}] ts=[${tJump}]`,
+                  );
+                }
+              }
+              boardRow[c] = null;
+            }
+          }
+        }
+      }
+    }
+
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  }, 30000);
+
+  it("adapter 配線 == TS（同期・色変換・バッファ読み出し）", () => {
+    // 跳び三 ●_●● を作る局面で adapter 経路を検証
+    const board = createEmptyBoard();
+    board[7]![5] = "black";
+    board[7]![6] = "black";
+    board[7]![8] = "black"; // (7,7) 配置で _●●_●_ 系
+    const mismatches: string[] = [];
+    for (let dir = 0; dir < 8; dir++) {
+      for (const color of ["black", "white"] as const) {
+        board[7]![7] = color;
+        const cases: [string, boolean, boolean][] = [
+          [
+            "jumpFour",
+            checkJumpFour(board, 7, 7, dir, color),
+            checkJumpFourTs(board, 7, 7, dir, color),
+          ],
+          [
+            "jumpThree",
+            checkJumpThree(board, 7, 7, dir, color),
+            checkJumpThreeTs(board, 7, 7, dir, color),
+          ],
+          [
+            "straightFour",
+            checkStraightFour(board, 7, 7, dir, color),
+            checkStraightFourTs(board, 7, 7, dir, color),
+          ],
+        ];
+        for (const [name, w, t] of cases) {
+          if (w !== t) {
+            mismatches.push(`dir=${dir} ${color} ${name} adapter=${w} ts=${t}`);
+          }
+        }
+        const wc = normTs(
+          getConsecutiveThreeStraightFourPoints(board, 7, 7, dir, color),
+        );
+        const tc = normTs(getConsecutiveTs(board, 7, 7, dir, color));
+        if (wc !== tc) {
+          mismatches.push(
+            `dir=${dir} ${color} consecutive adapter=[${wc}] ts=[${tc}]`,
+          );
+        }
+        const wj = normTs(
+          getJumpThreeStraightFourPoints(board, 7, 7, dir, color),
+        );
+        const tj = normTs(getJumpThreeTs(board, 7, 7, dir, color));
+        if (wj !== tj) {
+          mismatches.push(
+            `dir=${dir} ${color} jumpThree adapter=[${wj}] ts=[${tj}]`,
+          );
+        }
+        board[7]![7] = null;
+      }
+    }
+    expect(mismatches, mismatches.join("\n")).toEqual([]);
+  });
+});

--- a/src/logic/cpu/wasm/threatAdapter.ts
+++ b/src/logic/cpu/wasm/threatAdapter.ts
@@ -56,6 +56,14 @@ export function setThreatWasmForTest(w: ThreatWasmContext | undefined): void {
   wasm = w;
 }
 
+/**
+ * ロード済み threat wasm インスタンスを返す（未ロード時 undefined）。
+ * patternsAdapter（#37 P4）が同一インスタンスを共用し threat.wasm の二重ロードを避けるため。
+ */
+export function getThreatWasm(): ThreatWasmContext | undefined {
+  return wasm;
+}
+
 function syncBoard(w: ThreatWasmContext, board: BoardState): void {
   w.boardInit();
   for (let row = 0; row < 15; row++) {

--- a/src/logic/cpu/wasm/threatLoader.ts
+++ b/src/logic/cpu/wasm/threatLoader.ts
@@ -33,6 +33,43 @@ export interface ThreatWasmContext {
   findThreatMovesWasm: (color: number) => void;
   /** 脅威手バッファの先頭オフセット（memory 内）を返す。 */
   getThreatMovesBuffer: () => number;
+  /** (row,col,dir,color) で跳び四が成立するか（1/0）。配置済み cells 規約（#37 P4 PR-A）。 */
+  checkJumpFourWasm: (
+    row: number,
+    col: number,
+    dir: number,
+    color: number,
+  ) => number;
+  /** (row,col,dir,color) で跳び三が成立するか（1/0）。配置済み cells 規約。 */
+  checkJumpThreeWasm: (
+    row: number,
+    col: number,
+    dir: number,
+    color: number,
+  ) => number;
+  /** (row,col,dir,color) で達四が成立するか（1/0）。配置済み cells 規約。 */
+  checkStraightFourWasm: (
+    row: number,
+    col: number,
+    dir: number,
+    color: number,
+  ) => number;
+  /** 連続三の達四点（最大2点）を pattern points バッファに書く。 */
+  getConsecutiveThreeStraightFourPointsWasm: (
+    row: number,
+    col: number,
+    dir: number,
+    color: number,
+  ) => void;
+  /** 跳び三の達四点（最大1点）を pattern points バッファに書く。 */
+  getJumpThreeStraightFourPointsWasm: (
+    row: number,
+    col: number,
+    dir: number,
+    color: number,
+  ) => void;
+  /** pattern points バッファの先頭オフセット（memory 内）を返す。 */
+  getPatternPointsBuffer: () => number;
   /** wasm 線形メモリ（バッファ読み取り用）。 */
   memory: WebAssembly.Memory;
 }

--- a/zig/src/threat_wasm.zig
+++ b/zig/src/threat_wasm.zig
@@ -16,6 +16,7 @@
 const bitboard = @import("bitboard.zig");
 const board = @import("board.zig");
 const evaluate = @import("evaluate.zig");
+const jp = @import("jump_patterns.zig");
 const threats = @import("threats.zig");
 const vct = @import("vct.zig");
 
@@ -171,5 +172,65 @@ export fn findThreatMovesWasm(color: u8) void {
         threat_moves_buffer[o] = buf[i].row;
         threat_moves_buffer[o + 1] = buf[i].col;
         o += 2;
+    }
+}
+
+// === patterns プリミティブ（#37 P4 PR-A）===
+//
+// patterns.ts の図形判定プリミティブを Zig 単一ソース化する橋（patternsAdapter 経由）。
+// 実体は jump_patterns.zig の既存関数。これらは cells を直読みする（bitboard 非依存）ため
+// boardInit/boardSet のみで同期可（syncBitboard 不要）。
+// 規約: (row,col) に color を**配置済み**の cells で評価する（renjuParity と同一規約）。
+// dir_index は 0-7（DIRECTIONS_8。TS の DIRECTIONS と一致）。
+
+/// (row,col,dir,color) で跳び四が成立するか（1/0）。
+export fn checkJumpFourWasm(row: u8, col: u8, dir_index: u8, color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    return if (jp.checkJumpFour(&board.board_cells, row, col, dir_index, c)) 1 else 0;
+}
+
+/// (row,col,dir,color) で跳び三が成立するか（1/0）。
+export fn checkJumpThreeWasm(row: u8, col: u8, dir_index: u8, color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    return if (jp.checkJumpThree(&board.board_cells, row, col, dir_index, c)) 1 else 0;
+}
+
+/// (row,col,dir,color) で達四（連続四で延ばすと五）が成立するか（1/0）。
+export fn checkStraightFourWasm(row: u8, col: u8, dir_index: u8, color: u8) u8 {
+    const c: board.Cell = @enumFromInt(color);
+    return if (jp.checkStraightFour(&board.board_cells, row, col, dir_index, c)) 1 else 0;
+}
+
+// 達四点（getConsecutive…/getJumpThree…）を [u8 count][count*(row,col)] でシリアライズ。
+// 連続三は最大2点なので 1+2*2=5 バイト。
+var pattern_points_buffer: [8]u8 = undefined;
+
+export fn getPatternPointsBuffer() [*]u8 {
+    return &pattern_points_buffer;
+}
+
+/// 連続三の達四点（最大2点）を pattern_points_buffer に書く。
+export fn getConsecutiveThreeStraightFourPointsWasm(row: u8, col: u8, dir_index: u8, color: u8) void {
+    const c: board.Cell = @enumFromInt(color);
+    const r = jp.getConsecutiveThreeStraightFourPoints(&board.board_cells, row, col, dir_index, c);
+    pattern_points_buffer[0] = r.count;
+    var o: usize = 1;
+    for (0..r.count) |i| {
+        pattern_points_buffer[o] = r.points[i].row;
+        pattern_points_buffer[o + 1] = r.points[i].col;
+        o += 2;
+    }
+}
+
+/// 跳び三の達四点（最大1点）を pattern_points_buffer に書く。
+export fn getJumpThreeStraightFourPointsWasm(row: u8, col: u8, dir_index: u8, color: u8) void {
+    const c: board.Cell = @enumFromInt(color);
+    const r = jp.getJumpThreeStraightFourPoints(&board.board_cells, row, col, dir_index, c);
+    if (r.found) {
+        pattern_points_buffer[0] = 1;
+        pattern_points_buffer[1] = r.point.row;
+        pattern_points_buffer[2] = r.point.col;
+    } else {
+        pattern_points_buffer[0] = 0;
     }
 }


### PR DESCRIPTION
## 概要（#37 P4 PR-A / stacked: sub → feature）

#37 本丸 **#43（patterns.ts/forbiddenMoves.ts 物理削除）** の最初の sub-PR。base は feature ブランチ `feat/issue-37-p4-delete-patterns`。

### 内容
1. **削除プラン同梱**: `docs/plans/issue-37-p4-delete-patterns.md`（段階PR分解 A→B→C→D、/review 3観点 LGTM 済）。
2. **patternsAdapter 敷設**: patterns.ts の図形プリミティブ5関数（`checkJumpFour`/`checkJumpThree`/`checkStraightFour`/`getConsecutiveThreeStraightFourPoints`/`getJumpThreeStraightFourPoints`）を Zig 単一ソース（`jump_patterns.zig`、`threat_wasm` 経由）に委譲。
   - `threat_wasm.zig` に5 export + `pattern_points_buffer`/getter 追加（cells 直読み＝bitboard 非依存）
   - `patternsAdapter.ts` 新設。threatAdapter の wasm インスタンスを `getThreatWasm` で共用（二重ロード回避）。未ロード時 TS フォールバック（#43 PR-D で撤去）。
   - `checkOpenPattern` は生存消費者（patternRecognition/forbiddenMoves）が共倒れ削除されるため省略。
3. **faithful パリティ** `patternsParity.test.ts`: 決定的合法自己対局40局・近傍空き点・全8方向・両色で raw wasm==TS（点列は座標ソート正規化）+ adapter 配線 smoke。

**本PRは橋の敷設のみで利用者なし**（PR-B で評価/探索ヘルパーの利用点を張替）。

### 検証
- ✅ `patternsParity.test.ts` 緑（Zig==TS）
- ✅ `pnpm test` 1761件 / `zig build test` / `pnpm check-fix`
- ✅ 既存 `renjuParity` / reviewSnapshot 緑維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)
