### PR TITLE
refactor(cpu): #43 PR-2 review breakdown 表示の廃止

### DIFF
--- a/src/components/cpu/CpuDebugInfo.vue
+++ b/src/components/cpu/CpuDebugInfo.vue
@@ -14,12 +14,7 @@ import type {
   SearchStats,
 } from "@/types/cpu";
 import { useBoardStore } from "@/stores/boardStore";
-import {
-  getNonZeroBreakdown as getNonZeroBreakdownFromBreakdown,
-  formatScore,
-  formatPatternScore,
-  getLeafBreakdownItems,
-} from "@/logic/cpu/evaluation/breakdownUtils";
+import { formatScore } from "@/logic/cpu/evaluation/breakdownUtils";
 
 const props = defineProps<{
   /** 最後のCPUレスポンス */
@@ -59,18 +54,6 @@ function formatPV(
   return pv.map(
     (pos, idx) => `${idx + 1}. ${formatPosition(pos.row, pos.col)}`,
   );
-}
-
-/**
- * CandidateMove用のgetNonZeroBreakdownラッパー
- */
-function getNonZeroBreakdown(
-  candidate: CandidateMove,
-): ReturnType<typeof getNonZeroBreakdownFromBreakdown> {
-  if (!candidate.breakdown) {
-    return { patterns: [], defense: [], bonuses: [] };
-  }
-  return getNonZeroBreakdownFromBreakdown(candidate.breakdown);
 }
 
 /**
@@ -264,66 +247,6 @@ function isDepthChanged(index: number): boolean {
                 探索: {{ formatScore(candidate.searchScore) }}
               </span>
             </div>
-            <div class="popover-eval-score">
-              即時評価: {{ formatScore(candidate.score) }}
-            </div>
-
-            <!-- スコア内訳 -->
-            <div
-              v-if="candidate.breakdown"
-              class="popover-breakdown"
-            >
-              <!-- 攻撃パターン内訳 -->
-              <template
-                v-if="getNonZeroBreakdown(candidate).patterns.length > 0"
-              >
-                <div class="popover-section-label">攻撃</div>
-                <div
-                  v-for="item in getNonZeroBreakdown(candidate).patterns"
-                  :key="`attack-${item.key}`"
-                  class="popover-row"
-                >
-                  <span class="popover-label">{{ item.label }}:</span>
-                  <span class="popover-value">
-                    {{ formatPatternScore(item.detail) }}
-                  </span>
-                </div>
-              </template>
-
-              <!-- 防御パターン内訳 -->
-              <template
-                v-if="getNonZeroBreakdown(candidate).defense.length > 0"
-              >
-                <div class="popover-section-label">防御</div>
-                <div
-                  v-for="item in getNonZeroBreakdown(candidate).defense"
-                  :key="`defense-${item.key}`"
-                  class="popover-row"
-                >
-                  <span class="popover-label">{{ item.label }}:</span>
-                  <span class="popover-value">
-                    {{ formatPatternScore(item.detail) }}
-                  </span>
-                </div>
-              </template>
-
-              <!-- ボーナス内訳 -->
-              <template
-                v-if="getNonZeroBreakdown(candidate).bonuses.length > 0"
-              >
-                <div class="popover-section-label">ボーナス</div>
-                <div
-                  v-for="item in getNonZeroBreakdown(candidate).bonuses"
-                  :key="`bonus-${item.key}`"
-                  class="popover-row"
-                >
-                  <span class="popover-label">{{ item.label }}:</span>
-                  <span class="popover-value">
-                    {{ formatScore(item.value) }}
-                  </span>
-                </div>
-              </template>
-            </div>
 
             <!-- 予想手順 (PV) -->
             <div
@@ -346,71 +269,6 @@ function isDepthChanged(index: number): boolean {
                 >
                   {{ move }}
                 </span>
-              </div>
-            </div>
-
-            <!-- 探索末端の評価 -->
-            <div
-              v-if="candidate.leafEvaluation"
-              class="popover-leaf"
-            >
-              <div class="popover-section-label">末端評価</div>
-              <div class="leaf-summary">
-                <span class="leaf-total">
-                  {{ formatScore(candidate.leafEvaluation.total) }}
-                </span>
-                <span class="leaf-calc">
-                  (自{{ formatScore(candidate.leafEvaluation.myScore) }} - 相{{
-                    formatScore(candidate.leafEvaluation.opponentScore)
-                  }})
-                </span>
-              </div>
-
-              <!-- 自分の内訳 -->
-              <div
-                v-if="
-                  getLeafBreakdownItems(candidate.leafEvaluation.myBreakdown)
-                    .length > 0
-                "
-                class="leaf-breakdown-section"
-              >
-                <div class="leaf-breakdown-header">自分</div>
-                <div
-                  v-for="item in getLeafBreakdownItems(
-                    candidate.leafEvaluation.myBreakdown,
-                  )"
-                  :key="`my-${item.key}`"
-                  class="leaf-breakdown-row"
-                >
-                  <span class="leaf-breakdown-label">{{ item.label }}:</span>
-                  <span class="leaf-breakdown-value">
-                    {{ formatScore(item.score) }}
-                  </span>
-                </div>
-              </div>
-
-              <!-- 相手の内訳 -->
-              <div
-                v-if="
-                  getLeafBreakdownItems(
-                    candidate.leafEvaluation.opponentBreakdown,
-                  ).length > 0
-                "
-                class="leaf-breakdown-section"
-              >
-                <div class="leaf-breakdown-header">相手</div>
-                <div
-                  v-for="item in getLeafBreakdownItems(
-                    candidate.leafEvaluation.opponentBreakdown,
-                  )"
-                  :key="`opp-${item.key}`"
-                  class="leaf-breakdown-row"
-                >
-                  <span class="leaf-breakdown-label">{{ item.label }}:</span>
-                  <span class="leaf-breakdown-value">
-                    {{ formatScore(item.score) }}
-                  </span>
-                </div>
               </div>
             </div>
 

--- a/src/components/cpu/composables/progressionModel.test.ts
+++ b/src/components/cpu/composables/progressionModel.test.ts
@@ -31,7 +31,6 @@ const pos = (row: number, col: number): Position => ({ row, col });
 function candidate(overrides: Partial<ReviewCandidate>): ReviewCandidate {
   return {
     position: pos(7, 7),
-    score: 0,
     searchScore: 0,
     ...overrides,
   };

--- a/src/components/cpu/composables/useReviewProgression.test.ts
+++ b/src/components/cpu/composables/useReviewProgression.test.ts
@@ -20,7 +20,7 @@ import { useReviewProgression } from "./useReviewProgression";
 const pos = (row: number, col: number): Position => ({ row, col });
 
 function candidate(overrides: Partial<ReviewCandidate>): ReviewCandidate {
-  return { position: pos(7, 7), score: 0, searchScore: 0, ...overrides };
+  return { position: pos(7, 7), searchScore: 0, ...overrides };
 }
 
 /** best と played の両タブが出る最小の EvaluatedMove */

--- a/src/logic/cpu/review/forcedLossPropagation.test.ts
+++ b/src/logic/cpu/review/forcedLossPropagation.test.ts
@@ -113,13 +113,11 @@ describe("propagateForcedLossBackward", () => {
       candidates: [
         {
           position: { row: 0, col: 0 },
-          score: 100,
           searchScore: 100,
           opponentForcedWin: "vct",
         },
         {
           position: { row: 1, col: 0 },
-          score: 90,
           searchScore: 90,
           opponentForcedWin: "vcf",
         },
@@ -140,13 +138,11 @@ describe("propagateForcedLossBackward", () => {
       candidates: [
         {
           position: { row: 0, col: 0 },
-          score: 100,
           searchScore: 100,
           opponentForcedWin: "vct",
         },
         {
           position: { row: 1, col: 0 },
-          score: 90,
           searchScore: 90,
           // opponentForcedWin なし = 生存候補
         },
@@ -181,7 +177,6 @@ describe("propagateForcedLossBackward", () => {
       candidates: [
         {
           position: { row: 0, col: 0 },
-          score: 100,
           searchScore: 100,
           opponentForcedWin: "vct",
         },
@@ -202,7 +197,6 @@ describe("propagateForcedLossToCandidates", () => {
     const moves = ["H8", "I9", "F7", "G8", "I7"];
     const candidate: ReviewCandidate = {
       position: { row: 8, col: 8 }, // I7
-      score: 100,
       searchScore: 100,
     };
     const result = fullEval(4, {
@@ -221,7 +215,6 @@ describe("propagateForcedLossToCandidates", () => {
     const moves = ["H8", "I9", "F7", "G8", "I7"];
     const candidate = {
       position: { row: 8, col: 8 },
-      score: 100,
       searchScore: 100,
       opponentForcedWin: "vcf" as const,
     };
@@ -247,7 +240,6 @@ describe("propagateForcedLossToCandidates", () => {
     const moves = ["H8", "I9", "F7", "G8", "I7"];
     const candidate: ReviewCandidate = {
       position: { row: 8, col: 8 },
-      score: 100,
       searchScore: 100,
     };
     const result = fullEval(4, { candidates: [candidate] });

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -5,7 +5,6 @@
  * vctCheckOnly / lightEval は Worker 側に残す（シンプルなため抽出不要）。
  */
 
-import type { ScoreBreakdown } from "@/types/cpu";
 import type { BoardState, Position } from "@/types/game";
 import type {
   ForcedLossType,
@@ -25,11 +24,9 @@ import type {
 import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { countStones } from "../core/boardUtils";
-import {
-  evaluatePositionWithBreakdown,
-  evaluateBoardWithBreakdown,
-  PATTERN_SCORES,
-} from "../evaluation";
+// #43 PR-2: 表示内訳(breakdown)を廃止。評価内訳クラスタ(evaluation barrel)への依存を断ち、
+// 定数のみを patternScores から直 import する（barrel 経由の結合を残さない）。
+import { PATTERN_SCORES } from "../evaluation/patternScores";
 import { colorToWasm } from "../wasm/boardAdapter";
 import { linearTreeFromSequence } from "../wasm/forcedWinTreeWire";
 // #37 P3 PR4/PR5b: 脅威検出・ミセターゲットを Zig 単一ソース経由に。
@@ -178,10 +175,8 @@ export interface FullEvalResultWithTimings extends FullEvalResult {
 
 /** VCF初手を候補リストの先頭に追加/更新する */
 function promoteVcfCandidate(
-  board: BoardState,
   candidates: ReviewCandidate[],
   reVcf: VCFSequenceResult,
-  color: "black" | "white",
 ): void {
   const vcfIdx = candidates.findIndex(
     (c) =>
@@ -197,18 +192,9 @@ function promoteVcfCandidate(
       return;
     }
   }
-  const { score, breakdown } = evaluatePositionWithBreakdown(
-    board,
-    reVcf.firstMove.row,
-    reVcf.firstMove.col,
-    color,
-    REVIEW_SEARCH_PARAMS.evaluationOptions,
-  );
   candidates.unshift({
     position: reVcf.firstMove,
-    score: Math.round(score),
     searchScore: PATTERN_SCORES.FIVE,
-    breakdown: breakdown as ScoreBreakdown,
     principalVariation: reVcf.sequence,
   });
 }
@@ -259,7 +245,7 @@ function handleDemotion(ctx: DemotionContext): {
   }
 
   if (reVcf) {
-    promoteVcfCandidate(ctx.board, ctx.candidates, reVcf, ctx.color);
+    promoteVcfCandidate(ctx.candidates, reVcf);
     return {
       forcedWinType: "vcf",
       finalBestMove: reVcf.firstMove,
@@ -472,30 +458,12 @@ export function executeFullEval(
   }
   timings.vctRetry = performance.now() - t0;
 
-  // 候補手エントリから内訳付きデータを構築するヘルパー
-  const buildCandidate = (entry: MoveScoreEntry): ReviewCandidate => {
-    const { score: breakdownScore, breakdown } = evaluatePositionWithBreakdown(
-      board,
-      entry.move.row,
-      entry.move.col,
-      color,
-      REVIEW_SEARCH_PARAMS.evaluationOptions,
-    );
-
-    const leafEvaluation =
-      entry.pvLeafBoard && entry.pvLeafColor
-        ? evaluateBoardWithBreakdown(entry.pvLeafBoard, color)
-        : undefined;
-
-    return {
-      position: entry.move,
-      score: Math.round(breakdownScore),
-      searchScore: entry.score,
-      breakdown: breakdown as ScoreBreakdown,
-      principalVariation: entry.pv,
-      leafEvaluation,
-    };
-  };
+  // 候補手エントリから ReviewCandidate を構築するヘルパー
+  const buildCandidate = (entry: MoveScoreEntry): ReviewCandidate => ({
+    position: entry.move,
+    searchScore: entry.score,
+    principalVariation: entry.pv,
+  });
 
   // 実際の手の座標を解析
   const playedMoveStr = moves[moveIndex];
@@ -657,16 +625,6 @@ function buildForcedWinResult(
   // 候補手リスト構築
   const candidates: ReviewCandidate[] = [];
 
-  // 追い詰め開始手をFIVEスコアで追加
-  const { score: fwBreakdownScore, breakdown: fwBreakdown } =
-    evaluatePositionWithBreakdown(
-      board,
-      bestMove.row,
-      bestMove.col,
-      color,
-      REVIEW_SEARCH_PARAMS.evaluationOptions,
-    );
-
   // 両ミセ: targets から読み筋を構築
   let bestPV: Position[] = forcedWin.sequence;
   if (
@@ -681,9 +639,7 @@ function buildForcedWinResult(
 
   candidates.push({
     position: bestMove,
-    score: Math.round(fwBreakdownScore),
     searchScore: PATTERN_SCORES.FIVE,
-    breakdown: fwBreakdown as ScoreBreakdown,
     principalVariation: bestPV,
   });
 
@@ -708,19 +664,9 @@ function buildForcedWinResult(
         searchScore: PATTERN_SCORES.FIVE,
       };
     } else {
-      const { score: pScore, breakdown: pBreakdown } =
-        evaluatePositionWithBreakdown(
-          board,
-          playedRow,
-          playedCol,
-          color,
-          REVIEW_SEARCH_PARAMS.evaluationOptions,
-        );
       candidates.push({
         position: { row: playedRow, col: playedCol },
-        score: Math.round(pScore),
         searchScore: PATTERN_SCORES.FIVE,
-        breakdown: pBreakdown as ScoreBreakdown,
         principalVariation: playedForcedWinSequence,
       });
     }
@@ -743,19 +689,9 @@ function buildForcedWinResult(
         color,
         colorToWasm(color),
       );
-      const { score: pScore, breakdown: pBreakdown } =
-        evaluatePositionWithBreakdown(
-          board,
-          playedRow,
-          playedCol,
-          color,
-          REVIEW_SEARCH_PARAMS.evaluationOptions,
-        );
       candidates.push({
         position: { row: playedRow, col: playedCol },
-        score: Math.round(pScore),
         searchScore: playedScore,
-        breakdown: pBreakdown as ScoreBreakdown,
         principalVariation: pv.length > 1 ? pv : undefined,
       });
     }
@@ -1001,19 +937,9 @@ function buildNormalResult(
         color,
         colorToWasm(color),
       );
-      const { score: pScore, breakdown: pBreakdown } =
-        evaluatePositionWithBreakdown(
-          board,
-          playedRow,
-          playedCol,
-          color,
-          REVIEW_SEARCH_PARAMS.evaluationOptions,
-        );
       candidates.push({
         position: { row: playedRow, col: playedCol },
-        score: Math.round(pScore),
         searchScore: playedScore,
-        breakdown: pBreakdown as ScoreBreakdown,
         principalVariation: pv.length > 1 ? pv : undefined,
       });
     }

--- a/src/logic/cpu/review/reviewSnapshot.test.ts
+++ b/src/logic/cpu/review/reviewSnapshot.test.ts
@@ -285,7 +285,7 @@ describe("review 戦術プリミティブ出力スナップショット (#37 P3 
       board,
       moves,
       moveCount,
-    ).map((position) => ({ position, score: 0, searchScore: 0 }));
+    ).map((position) => ({ position, searchScore: 0 }));
     // timeLimit=Infinity を注入して node-bound 決定化
     annotateFukumiMoves(candidates, board, nextColor, engine, {
       ...REVIEW_VCF_OPTIONS,

--- a/src/types/cpu.ts
+++ b/src/types/cpu.ts
@@ -193,39 +193,17 @@ export interface CpuRequest {
 }
 
 /**
- * 探索末端の評価内訳（デバッグ表示用）
- */
-export interface LeafEvaluation {
-  /** 自分のパターンスコア合計 */
-  myScore: number;
-  /** 相手のパターンスコア合計 */
-  opponentScore: number;
-  /** 最終スコア（myScore - opponentScore） */
-  total: number;
-  /** 自分のパターンスコア内訳 */
-  myBreakdown: LeafPatternScores;
-  /** 相手のパターンスコア内訳 */
-  opponentBreakdown: LeafPatternScores;
-}
-
-/**
  * 候補手情報（デバッグ表示用）
  */
 export interface CandidateMove {
   /** 着手位置 */
   position: Position;
-  /** 即時評価スコア（内訳の合計） */
-  score: number;
   /** 探索スコア（複数手先読みの結果、順位の根拠） */
   searchScore: number;
   /** 順位（1始まり、探索スコア順） */
   rank: number;
-  /** 即時評価の内訳 */
-  breakdown?: ScoreBreakdown;
   /** Principal Variation（探索で予想される手順） */
   principalVariation?: Position[];
-  /** 探索末端での評価内訳 */
-  leafEvaluation?: LeafEvaluation;
 }
 
 /**

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -2,7 +2,7 @@
  * 振り返り（棋譜評価）関連の型定義
  */
 
-import type { CpuBattleRecord, LeafEvaluation, ScoreBreakdown } from "./cpu";
+import type { CpuBattleRecord } from "./cpu";
 import type { Position } from "./game";
 
 /**
@@ -83,16 +83,10 @@ export interface ForcedWinDefense {
  */
 export interface ReviewCandidate {
   position: Position;
-  /** 即時評価スコア */
-  score: number;
   /** 探索スコア（順位の根拠） */
   searchScore: number;
-  /** 即時評価の内訳 */
-  breakdown?: ScoreBreakdown;
   /** 予想手順 */
   principalVariation?: Position[];
-  /** 探索末端の評価内訳 */
-  leafEvaluation?: LeafEvaluation;
   /** この手を打つと相手に強制勝ちを許す場合のタイプ */
   opponentForcedWin?: ForcedLossType;
   /** 相手の強制勝ち手順（Phase 3 深掘りチェックで取得） */


### PR DESCRIPTION
## 概要
#43 stacked PR その3（base = PR-1）。表示専用の **breakdown / leafEvaluation / 即時評価 score** を review から廃止（ボス決定: 内訳パネル簡素化/廃止）。これにより評価内訳クラスタ(a)（positionEvaluation/boardEvaluation 等）の入口が消え、PR-4 で死蔵削除可能になる。

## 変更
- `fullEval.ts`: `evaluatePositionWithBreakdown`/`evaluateBoardWithBreakdown` 呼び出しを全除去。`ReviewCandidate` を `{position,searchScore,principalVariation}` に縮約。**評価 barrel への import を断ち** `PATTERN_SCORES` を `patternScores` から直 import（SOLID レビュー反映）。
- `types/review.ts`/`types/cpu.ts`: `ReviewCandidate`/`CandidateMove` から `score`/`breakdown`/`leafEvaluation` 削除、`LeafEvaluation` 型削除。
- `CpuDebugInfo.vue`: 内訳/末端評価/即時評価の描画と breakdownUtils ヘルパー利用を除去（`formatScore` のみ残す）。
- テストモックの型追従。

## 動作影響
**なし**。判定・並び順・採点は全て Zig 由来 `searchScore`/`playedScore`/`bestScore`。reviewSnapshot **不変**（スナップショット更新ゼロ）。変わるのは消えたデバッグ表示の数字のみ。

## 検証
check-fix / 全 1767 テスト / zig-test / check:circular 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)