### PR TITLE
chore(cpu): #43 PR-5 patternScores の内訳型トリミング

### DIFF
--- a/src/logic/cpu/evaluation.ts
+++ b/src/logic/cpu/evaluation.ts
@@ -6,16 +6,12 @@
  */
 
 export {
-  type BoardEvaluationBreakdown,
   DEFAULT_EVAL_OPTIONS,
   detectOpponentThreats,
   type EvaluationOptions,
   FULL_EVAL_OPTIONS,
   type LeafEvaluationOptions,
-  type LeafPatternScores,
-  type PatternBreakdown,
   PATTERN_SCORES,
   type PatternScoreDetail,
-  type ScoreBreakdown,
   type ThreatInfo,
 } from "./evaluation/index";

--- a/src/logic/cpu/evaluation/index.ts
+++ b/src/logic/cpu/evaluation/index.ts
@@ -10,16 +10,12 @@
 
 // Re-export: patternScores（型・定数）
 export {
-  type BoardEvaluationBreakdown,
   DEFAULT_EVAL_OPTIONS,
   type EvaluationOptions,
   FULL_EVAL_OPTIONS,
   type LeafEvaluationOptions,
-  type LeafPatternScores,
-  type PatternBreakdown,
   PATTERN_SCORES,
   type PatternScoreDetail,
-  type ScoreBreakdown,
   type ThreatInfo,
 } from "./patternScores";
 

--- a/src/logic/cpu/evaluation/patternScores.ts
+++ b/src/logic/cpu/evaluation/patternScores.ts
@@ -324,49 +324,6 @@ export interface PatternScoreDetail {
 }
 
 /**
- * パターン内訳
- */
-export interface PatternBreakdown {
-  five: PatternScoreDetail;
-  openFour: PatternScoreDetail;
-  four: PatternScoreDetail;
-  openThree: PatternScoreDetail;
-  three: PatternScoreDetail;
-  openTwo: PatternScoreDetail;
-  two: PatternScoreDetail;
-}
-
-/**
- * スコア内訳（デバッグ表示用）
- */
-export interface ScoreBreakdown {
-  /** 攻撃パターン内訳 */
-  pattern: PatternBreakdown;
-  /** 防御パターン内訳（相手のパターンを阻止） */
-  defense: PatternBreakdown;
-  /** 四三ボーナス */
-  fourThree: number;
-  /** フクミ手ボーナス */
-  fukumi: number;
-  /** ミセ手ボーナス */
-  mise: number;
-  /** ミセ手の種類（表示ラベル解決用） */
-  miseType: MiseType;
-  /** 中央ボーナス */
-  center: number;
-  /** 複数方向脅威ボーナス */
-  multiThreat: number;
-  /** 防御交差点ボーナス（相手が2方向以上の脅威を作る位置の防御価値） */
-  defenseMultiThreat: number;
-  /** 単発四ペナルティ（減点） */
-  singleFourPenalty: number;
-  /** 禁手追い込みボーナス（白番のみ） */
-  forbiddenTrap: number;
-  /** 禁手脆弱性ペナルティ（黒番のみ、減点） */
-  forbiddenVulnerability: number;
-}
-
-/**
  * 末端評価オプション
  */
 export interface LeafEvaluationOptions {
@@ -381,41 +338,6 @@ export interface LeafEvaluationOptions {
 }
 
 /**
- * ミセ手の種類
- */
-export type MiseType = "none" | "mise" | "double-mise";
-
-/**
- * パターンスコア内訳（探索末端用）
- */
-export interface LeafPatternScores {
-  five: number;
-  openFour: number;
-  four: number;
-  openThree: number;
-  three: number;
-  openTwo: number;
-  two: number;
-  total: number;
-}
-
-/**
- * 盤面評価の内訳（探索末端用）
- */
-export interface BoardEvaluationBreakdown {
-  /** 自分のパターンスコア合計 */
-  myScore: number;
-  /** 相手のパターンスコア合計 */
-  opponentScore: number;
-  /** 最終スコア（myScore - opponentScore） */
-  total: number;
-  /** 自分のパターンスコア内訳 */
-  myBreakdown: LeafPatternScores;
-  /** 相手のパターンスコア内訳 */
-  opponentBreakdown: LeafPatternScores;
-}
-
-/**
  * パターンタイプ
  */
 export type PatternType =
@@ -427,41 +349,3 @@ export type PatternType =
   | "openTwo"
   | "two"
   | null;
-
-/**
- * 空のパターンスコア詳細を作成
- */
-export function emptyScoreDetail(): PatternScoreDetail {
-  return { base: 0, diagonalBonus: 0, final: 0 };
-}
-
-/**
- * 空のパターンスコア内訳を作成
- */
-export function emptyLeafPatternScores(): LeafPatternScores {
-  return {
-    five: 0,
-    openFour: 0,
-    four: 0,
-    openThree: 0,
-    three: 0,
-    openTwo: 0,
-    two: 0,
-    total: 0,
-  };
-}
-
-/**
- * 空のパターン内訳を作成
- */
-export function emptyPatternBreakdown(): PatternBreakdown {
-  return {
-    five: emptyScoreDetail(),
-    openFour: emptyScoreDetail(),
-    four: emptyScoreDetail(),
-    openThree: emptyScoreDetail(),
-    three: emptyScoreDetail(),
-    openTwo: emptyScoreDetail(),
-    two: emptyScoreDetail(),
-  };
-}

--- a/src/types/cpu.ts
+++ b/src/types/cpu.ts
@@ -3,22 +3,12 @@
  */
 
 import type { EvaluationOptions } from "@/logic/cpu/evaluation";
-import type {
-  LeafPatternScores,
-  PatternBreakdown,
-  PatternScoreDetail,
-  ScoreBreakdown,
-} from "@/logic/cpu/evaluation/patternScores";
+import type { PatternScoreDetail } from "@/logic/cpu/evaluation/patternScores";
 
 import type { BoardState, Position, StoneColor } from "./game";
 
 // SSoT: patternScores.ts に定義された型を re-export
-export type {
-  LeafPatternScores,
-  PatternBreakdown,
-  PatternScoreDetail,
-  ScoreBreakdown,
-};
+export type { PatternScoreDetail };
 
 /**
  * CPU難易度


### PR DESCRIPTION
## 概要
#43 stacked PR その6（base = PR-4）。PR-2/4 で消費者が消えた内訳専用型を patternScores から削除。

## 削除（消費者ゼロを type-check で確認）
ScoreBreakdown / PatternBreakdown / LeafPatternScores / BoardEvaluationBreakdown / MiseType / empty{ScoreDetail,LeafPatternScores,PatternBreakdown}

## 存続
PATTERN_SCORES 定数 / EvaluationOptions / DEFAULT・FULL_EVAL_OPTIONS / LeafEvaluationOptions / スコア注入系 / PatternScoreDetail(directionAnalysis 参照) / JumpPatternResult / PatternType / ThreatInfo / DirectionPattern。barrel(evaluation/index.ts, evaluation.ts, types/cpu.ts) 同期。

## 動作影響
なし。reviewSnapshot 不変。check-fix / 全1669テスト / zig-test / check:circular 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)