### PR TITLE
fix(scenario): #80 練習問題でやり直すと前問に戻るバグを修正

### DIFF
--- a/src/components/scenarios/ScenarioPlayer/ScenarioPlayer.vue
+++ b/src/components/scenarios/ScenarioPlayer/ScenarioPlayer.vue
@@ -146,6 +146,11 @@ watch(
       return;
     }
 
+    // 問題が切り替わったらVCFの進行状態を破棄する。
+    // これをしないと前問の基準盤面が残り、新しい問題で「やり直す」を押すと
+    // 前問に戻ってしまう（#80）。盤面自体は下のセクションロードが再構築する。
+    questionRouter.resetForSectionChange();
+
     const sections = scenarioNav.scenario.value?.sections;
     if (!sections) {
       return;

--- a/src/components/scenarios/ScenarioPlayer/composables/useQuestionRouter.ts
+++ b/src/components/scenarios/ScenarioPlayer/composables/useQuestionRouter.ts
@@ -37,6 +37,7 @@ export const useQuestionRouter = (
     isSectionCompleted: boolean,
   ) => void;
   resetPuzzle: (questionSection: QuestionSection) => void;
+  resetForSectionChange: () => void;
   isResetAvailable: ComputedRef<boolean>;
   isVctUnsupported: (section: QuestionSection) => boolean;
 } => {
@@ -108,6 +109,16 @@ export const useQuestionRouter = (
     }
   }
 
+  /**
+   * セクション（問題）切り替え時に VCF の進行状態を破棄する。
+   * vcfActive（router 側）と hasMoves（solver 側）はどちらも「VCFで着手が始まったか」を
+   * 表す状態のため、セクションをまたぐ際は両方をまとめてリセットする（#80）。
+   */
+  function resetForSectionChange(): void {
+    vcfSolver.resetSectionState();
+    vcfActive.value = false;
+  }
+
   function isVctUnsupported(section: QuestionSection): boolean {
     return hasVctCondition(section);
   }
@@ -116,6 +127,7 @@ export const useQuestionRouter = (
     handlePlaceStone,
     submitAnswer,
     resetPuzzle,
+    resetForSectionChange,
     isResetAvailable,
     isVctUnsupported,
   };

--- a/src/components/scenarios/ScenarioPlayer/composables/useVcfSolver.test.ts
+++ b/src/components/scenarios/ScenarioPlayer/composables/useVcfSolver.test.ts
@@ -435,4 +435,56 @@ describe("useVcfSolver", () => {
       expect(isResetAvailable.value).toBe(false);
     });
   });
+
+  describe("resetSectionState", () => {
+    it("セクション切り替え後はリセット不可（着手前状態）に戻る", async () => {
+      mockValidateAttackMove.mockReturnValue({ valid: true, type: "four" });
+      mockGetDefenseResponse.mockReturnValue({
+        type: "blocked",
+        position: { row: 7, col: 8 },
+      });
+
+      const { handleVcfPlaceStone, resetSectionState, isResetAvailable } =
+        useVcfSolver("scenario-1", onSectionComplete);
+      const section = createVcfQuestionSection();
+
+      await handleVcfPlaceStone({ row: 7, col: 7 }, section, false);
+      expect(isResetAvailable.value).toBe(true);
+
+      resetSectionState();
+      expect(isResetAvailable.value).toBe(false);
+    });
+
+    it("セクション切り替え後は次のセクションの盤面を基準として取り直す", async () => {
+      mockValidateAttackMove.mockReturnValue({ valid: true, type: "four" });
+      mockGetDefenseResponse.mockReturnValue({
+        type: "blocked",
+        position: { row: 7, col: 8 },
+      });
+
+      const { handleVcfPlaceStone, resetSectionState, resetVcf } = useVcfSolver(
+        "scenario-1",
+        onSectionComplete,
+      );
+      const sectionA = createVcfQuestionSection({ id: "q-a" });
+
+      // セクションA で着手 → セクションA の盤面が基準としてキャプチャされる
+      await handleVcfPlaceStone({ row: 7, col: 7 }, sectionA, false);
+
+      // セクション切り替え: ナビゲーションが盤面を別物に差し替えたとみなす
+      mockBoard[0][0] = "white";
+      resetSectionState();
+
+      // セクションB で着手 → セクションB の盤面が新たな基準になる
+      const sectionB = createVcfQuestionSection({ id: "q-b" });
+      await handleVcfPlaceStone({ row: 7, col: 7 }, sectionB, false);
+
+      mockSetBoard.mockClear();
+      resetVcf();
+
+      // 「やり直す」で復元される盤面は セクションB の基準（marker あり）であること
+      const restored = mockSetBoard.mock.calls[0]?.[0] as BoardState;
+      expect(restored[0]?.[0]).toBe("white");
+    });
+  });
 });

--- a/src/components/scenarios/ScenarioPlayer/composables/useVcfSolver.ts
+++ b/src/components/scenarios/ScenarioPlayer/composables/useVcfSolver.ts
@@ -303,15 +303,20 @@ export const useVcfSolver = (
 
   // ===== リセット =====
 
+  /** VCF進行状態（着手フラグ・石IDカウンタ・保留中の勝ち手）を初期化する。 */
+  function clearProgressState(): void {
+    hasMoves.value = false;
+    vcfMoveCounter = 0;
+    pendingCounterFive = null;
+  }
+
   function resetVcf(): void {
     if (vcfBaseBoard) {
       boardStore.setBoard(cloneBoard(vcfBaseBoard), "question");
     }
     boardStore.clearMarks();
     boardStore.clearLines();
-    hasMoves.value = false;
-    vcfMoveCounter = 0;
-    pendingCounterFive = null;
+    clearProgressState();
   }
 
   /**
@@ -324,9 +329,7 @@ export const useVcfSolver = (
    */
   function resetSectionState(): void {
     vcfBaseBoard = null;
-    hasMoves.value = false;
-    vcfMoveCounter = 0;
-    pendingCounterFive = null;
+    clearProgressState();
   }
 
   return {

--- a/src/components/scenarios/ScenarioPlayer/composables/useVcfSolver.ts
+++ b/src/components/scenarios/ScenarioPlayer/composables/useVcfSolver.ts
@@ -57,6 +57,7 @@ export const useVcfSolver = (
     isSectionCompleted: boolean,
   ) => Promise<void>;
   resetVcf: () => void;
+  resetSectionState: () => void;
   isResetAvailable: ComputedRef<boolean>;
 } => {
   const boardStore = useBoardStore();
@@ -313,9 +314,25 @@ export const useVcfSolver = (
     pendingCounterFive = null;
   }
 
+  /**
+   * セクション（問題）切り替え時に内部状態を破棄する。
+   *
+   * `vcfBaseBoard` は初回着手時にのみキャプチャされるため、これをクリアしないと
+   * 別の問題に移っても前問の基準盤面が残り、「やり直す」で前問へ戻ってしまう（#80）。
+   * 盤面自体は useScenarioNavigation がセクションロード時に再構築するため、
+   * resetVcf（ユーザーの「やり直す」）と違い、ここでは盤面・マークには触れない。
+   */
+  function resetSectionState(): void {
+    vcfBaseBoard = null;
+    hasMoves.value = false;
+    vcfMoveCounter = 0;
+    pendingCounterFive = null;
+  }
+
   return {
     handleVcfPlaceStone,
     resetVcf,
+    resetSectionState,
     isResetAvailable,
   };
 };


### PR DESCRIPTION
## 概要
issue #80 の修正。「禁手に嵌める練習問題」の **2問目** で「やり直す」を押すと現在の問題ではなく **1問目に戻ってしまう** バグを修正する。

Closes #80

## 根本原因
`useVcfSolver` は ScenarioPlayer 全体で1インスタンス共有され、可変状態 `vcfBaseBoard` / `hasMoves` / `vcfMoveCounter` / `pendingCounterFive` が問題セクションをまたいで保持される。

- `vcfBaseBoard`（やり直し用の基準盤面）は `if (!vcfBaseBoard)` で **シナリオ中の最初の着手時に1回だけ** キャプチャされ、セクション切り替えでクリアされない。
- そのため2問目（section_4, 初期15石）で「やり直す」を押すと、1問目（section_3, 初期35石）の盤面が復元される。
- 加えて `hasMoves` / `vcfActive` も残存し、2問目入場直後（着手前）から「やり直す」ボタンが表示されていた。

### 再現の裏付け（ブラウザ実測）
2問目で「やり直す」を押すと盤面が **15石 → 35石** に変化。section_3 の初期盤面が35石であることをシナリオJSONで確認済み。

## 修正方針
セクション（問題）切り替え時に VCF の進行状態を破棄する処理を、既存の `currentSectionIndex` watch に組み込む。

1. `useVcfSolver.ts`: `resetSectionState()` を追加（`vcfBaseBoard` / `hasMoves` / `vcfMoveCounter` / `pendingCounterFive` を破棄。盤面はナビゲーションが再構築するため触らない）。
2. `useQuestionRouter.ts`: `resetForSectionChange()` を追加（`vcfSolver.resetSectionState()` + `vcfActive=false`）。
3. `ScenarioPlayer.vue`: 既存 watch の「セクション遷移なしスキップ」ガード後に `questionRouter.resetForSectionChange()` を呼ぶ（実セクション遷移時のみ／新規 watch は作らない）。

### 設計上の判断
レビューで「`resetVcf` を `initialBoard` から都度再構築する」案も検討したが、ナビゲーションは問題開始局面を `initialBoard` + ダイアログの `boardActions` で構築するため、`initialBoard` 単独の再構築は将来 boardActions を持つVCF問題で表示と不一致になる潜在バグを生む。lazy-capture は「初手直前の実際の表示盤面」を捉えるため常に正しい。バグの本質は「キャプチャ漏れ」ではなく「セクションをまたいでクリアし忘れる」ことなので、クリアの追加が最小かつ正確な修正と判断した。

## テスト
`useVcfSolver.test.ts` に `resetSectionState` の2ケースを追加（TDD: red→green を確認）。
- セクション切り替え後はリセット不可（着手前状態）に戻る
- セクション切り替え後は次のセクションの盤面を基準に取り直す

`pnpm check-fix` 通過、pre-commit で全テスト 1510件 + zig-test 緑。

## 動作確認
- 2問目で「やり直す」→ 2問目の初期局面（15石）のまま留まることをブラウザで確認。
- 着手前は「やり直す」ボタンが非表示になることを確認。
- 同一問題内での「やり直す」（`currentSectionIndex` 不変）は従来どおり動作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
