### PR TITLE
docs(cpu): CPU強化ロードマップ・評価重みプラン(凍結)・必須防御案(棄却)

### DIFF
--- a/docs/plans/cpu-strength-roadmap-2026-06-10.md
+++ b/docs/plans/cpu-strength-roadmap-2026-06-10.md
@@ -1,0 +1,118 @@
+# 連珠CPU強化ロードマップ（機械学習なし）
+
+> 生成: 2026-06-10。Rapfi（世界最強格エンジン）を解析オラクルに使い、自己対局を採点して
+> 抽出した **検証済み blunder 46件** と、Zig/WASM 実装（探索/評価/VCF/VCT/quiescence/着手順序）の
+> コード精読を、多エージェント・ワークフロー（理解→分類→診断→敵対的検証→統合）で統合した結果。
+> ツール: `scripts/rapfi/`（`rapfiClient.ts` / `mineBlunders.ts` / `forbiddenParity.ts` / `strengthWorkflow.mjs`）。
+
+## blunder 分類（検証済み46件 / verifiedDrop 614–3069）
+
+| カテゴリ                            | 件数 | 備考                                                               |
+| ----------------------------------- | ---- | ------------------------------------------------------------------ |
+| eval-misjudgment（位置評価誤り）    | 30   | 最多。ただし新評価軸は Phase B(`line_potential`)と共線で相殺リスク |
+| allowed-opponent-threat（受け落ち） | 8    | 二重活三の受け落ち                                                 |
+| missed-tactical-win（攻め見落とし） | 6    | 四三絡みのテンポ割引が原因                                         |
+| horizon-quiescence（水平線/TT汚染） | 1    | 件数は少ないが**探索全域を汚染する上流バグ**                       |
+| hallucinated-win（幻勝ち）          | 1    | TT汚染の症状。単体修正は reject                                    |
+
+## 大原則（過去の失敗を踏まえる）
+
+- **1コミット1施策**。`1fa2668`（PVS+Counter-move+Threat Extension+Score Verification の4機能混在）が main 比 **Elo +44.5 弱体化**の犯人で、個別原因の切り分けを不能にした轍を踏まない。
+- **評価軸の追加は最後**。`project_eval_axis_redundancy.md` の通り、新評価軸は Phase B(`line_potential`)と情報重複して相殺・悪化する。上位施策は**評価軸を増やさず、既存の探索バグ・マスクバグを正す**ものを優先。
+- **検証は `commit-bench` r0.02 × 8セット(416局)**。対局CPU直結の変更は必ず Elo 測定。r0.05/単一データ点は不可。
+- **VERIFY_INCREMENTAL parity**（`incremental_eval.zig:338` の bulk vs incremental 完全一致 Debug assert）を評価系変更の安全網にする。
+
+## 優先度付き施策リスト（影響 × 労力）
+
+| #     | 施策                                                             | 影響   | 労力   | 独立性 | 回帰    | verdict       | 順位根拠                                                        |
+| ----- | ---------------------------------------------------------------- | ------ | ------ | ------ | ------- | ------------- | --------------------------------------------------------------- |
+| **1** | **TT の perspective/ply 汚染修正**                               | high   | medium | OK     | medium  | revise→再設計 | 探索全域を汚染。幻勝ちの上流。評価軸非依存                      |
+| **2** | **VCT 受け点の過少列挙修正（夏止め欠落）**                       | high   | low    | OK     | low-med | severity:high | 幻勝ちVCTを`FIVE-20`で即指し＝自滅手の直接原因。1関数統一       |
+| **3** | **必須防御マスクの「全活線カバー」化（再設計）**                 | high   | medium | OK     | high    | revise        | 二重活三の受け落ち。「両止め強制」は誤り→反撃テンポ許容で再設計 |
+| 4     | テンポ割引の四三絡み免除（`incremental_eval.zig`）               | medium | medium | 要検証 | medium  | revise        | 攻め見落とし。四三ボーナス二重計上の回帰テスト必須              |
+| 5     | VCT カウンターフォー耐性の全分岐検証（PV一本道→AND全分岐）       | high   | high   | OK     | medium  | severity:high | 非PV分岐の幻勝ち。労力高                                        |
+| 6     | VCF の四四を防御不能=勝ち扱い（`getFourDefensePosition`）        | medium | low    | OK     | low     | severity:high | 四四勝ち取りこぼし。安全側                                      |
+| 7     | NMP/Futility を専用フラグに分離（`enable_counter_four`流用解消） | medium | low    | OK     | low     | severity:high | チューニング阻害解消。施策1-4の前提整備                         |
+| 8     | リーフ中央性/接触ブロックペナルティ                              | medium | medium | **NG** | medium  | revise        | 30件と最多だが Phase B と共線。block-penalty 単体のみ条件付き   |
+| 9     | History/Counter/Killer の色区別・ply管理                         | medium | medium | OK     | low     | medium-high   | 着手順序のノイズ。探索効率                                      |
+| 10    | Aspiration の非対称再探索・ルートPVS                             | medium | medium | OK     | low     | medium        | 到達深度改善。効果はベンチ次第                                  |
+
+**除外**: 施策8(1)リーフ中央性移設は独立性NG・Phase B共線で棄却（block-penalty が有意な場合のみ条件付き）。allowed-opponent-threat 元案の `can_win_first` バイパス無効化は連珠的に誤り（反撃テンポを枝刈り）のため撤回。
+
+---
+
+## 上位3施策の詳細
+
+### 施策1: TT の perspective/ply 汚染修正
+
+**対象**: `zig/src/zobrist.zig:5,68-86` / `zig/src/tt.zig:76-120`（probe/store） / `zig/src/minimax.zig:380-389`（probe後 `return entry.score`）, `:417-421`（threat probe の `FIVE-1 .exact` store）, `:365-370`（終端五連 ±FIVE return） / `zig/src/scores.zig`（`MATE_THRESHOLD`/`isMateScore` 追加）
+
+**変更内容**
+
+1. **手番混入の解消（主犯）**: `computeBoardHash`/`updateHash` は石配置のみで side-to-move を含まず、`global_tt` は探索ごとに clear せず `newGeneration()` のみ。→ **side-to-move 用 Zobrist キーを追加し手番で XOR**。「脇手が near-win を継承し ourScore 6292 級に膨張」の整合的機序。
+2. **ply 補正（副犯）**: `scores.zig` に `MATE_THRESHOLD = FIVE-100`/`isMateScore`。`tt.store` に `ply` 引数を足し、保存前に詰みスコアを `±ply` で root基準→ノード基準へ正規化、probe 返却時に逆補正。threat probe の `FIVE-1`・終端 ±FIVE・通常 store/return をすべて補正経路に。
+3. **`.exact` 撒きすぎ対策（別コミット）**: threat probe が `FIVE-1` を常時 `.exact` で撒くのが汚染を増幅。lower/upper-bound 化を検討。
+
+**最初に書く TDD テスト（Red から）**
+
+```
+test "TT round-trip preserves mate distance over ply 0..8"
+test "side-to-move separates TT entries"（同石配置の黒手番 FIVE-1 が白手番 probe でヒットしない）
+test "horizon id=10 reproduction"（白 I7J7K7 × I5I6I7 交差盤で脇手 G6 を near-win で返さない）
+```
+
+**回帰リスクと検証**: medium。`commit-bench` r0.02 × 8セット必須。既存 VCF 詰み局面で**最短手順を選ぶ**回帰テスト併設。手番分離と ply補正は**別コミット・別ベンチ**で切り分ける。
+
+**TS-Zig 二重実装**: 影響なし（探索スコア簿記のみ。`forbidden`/`renjuRules` 非干渉。TS探索はWASM専用化済み）。
+
+### 施策2: VCT 受け点の過少列挙修正（夏止め欠落）
+
+**対象**: `zig/src/vct.zig:365-370`（`getThreatDefensePositions` が活三に `getLineEnds`＝両端2点のみ）→ 統一先 `zig/src/threats.zig:134` `getOpenThreeDefensePositions`（夏止め点を含む。`mise_vcf.zig:141`・`threats.zig:570` は既にこちらを使用）
+
+**変更内容**: VCT の活三受け列挙を `getLineEnds` → `getOpenThreeDefensePositions` に統一。VCT は「全受けが VCT に繋がる(AND)」で勝ち判定するため、**夏止めを見落とすと「全受け→勝ち」を誤成立**させ `search.zig:187` が `FIVE-20` で即指し→自滅。受けを**広げる**＝誤った勝ち証明が減る安全方向。
+
+**最初に書く TDD テスト**
+
+```
+test "VCT defense enumeration includes 夏止め"（getThreatDefensePositions == getOpenThreeDefensePositions）
+test "false-VCT rejected when 夏止め defends"
+```
+
+**回帰リスクと検証**: low-medium。受けを広げるため「成立していた正当な VCT が不成立化」しないか既存 VCT テスト全緑を確認。`commit-bench` r0.02 × 8セットで自滅手減少＝Elo改善を測定。
+
+**TS-Zig 二重実装**: VCT/脅威ヘルパは `renjuParity`（禁手）対象外。TS二重実装なし。
+
+### 施策3: 必須防御マスクの「全活線カバー」化（再設計版）
+
+**対象**: `zig/src/threats.zig:570-577`（防御点を `addUniqueList` で単一 union 合流） / `zig/src/position_eval.zig:339-340`（`contains` union判定） / `zig/src/move_order.zig:236-238`（lazy 経路の `defense_bitmap`）
+
+**変更内容（verdict の再設計を反映）**: 元案「全グループ防御点に含まれなければ -1000000」は**連珠的に誤り**——独立2活三は1手で両止め不能が普通で、正着はしばしば**自分の四による反撃(テンポ)**。枝刈りすると新たな受け落ちを生む。よって:
+
+1. 活三を**グループ単位**で保持（union 温存＋`OpenThreeGroup{defenses}` 配列）。
+2. マスク判定を「候補手が**全グループを止める** OR **同等以上に速い反撃（自分の四/活四/四三）を持つ**」に変更。反撃手は非ペナルティ。
+3. **`can_win_first` バイパスは維持**（元案の無効化は撤回）。
+4. lazy 経路の再計算コストは設計で解決（評価関数内ローカル計算に閉じ込め、bridge エンコードに新フィールドを足さない）。
+
+**最初に書く TDD テスト**
+
+```
+test "二重活三で片方だけ止め＋反撃なしの手は -1000000"
+test "両活三を1手で止める急所は非ペナルティ"
+test "自分の四による反撃手は二重活三下でも非ペナルティ"  ← 元案の欠陥を防ぐ要
+test "id=23/28 再現"（放置手を返さず Rapfi 防御点 F9/I12系 を選ぶ）
+```
+
+**回帰リスクと検証**: **high**（必須防御は対局CPU直結）。`commit-bench` r0.02 × 8セット必須。被覆判定のみを最小単位で入れ、`can_win_first` 速度比較や構造拡張は別フェーズ。
+
+**TS-Zig 二重実装**: 必須防御マスクは `position_eval.zig`(Zig) と `src/logic/cpu/evaluation/patternScores.ts`(TS) の二重実装で評価パリティ領域。被覆判定を**評価関数内ローカル計算に閉じ込め** precomputed_threats の bridge に新フィールドを足さない。パリティテストでランダム盤面の必須防御マスク一致を検証してドリフト防止。
+
+---
+
+## 次の一手（ワークフロー推奨）
+
+**施策2「VCT 受け点の夏止め欠落修正」**。理由: 自滅手の直接原因で影響 high、1関数統一で最低労力、受けを広げる安全方向、評価軸非依存、TS二重実装なしで Zig 片側完結。TDD を Red から始めやすい。施策1（TT汚染）は影響最大だが手番分離＋ply補正の2フェーズで労力medium・回帰mediumのため、施策2のクイックウィン直後に着手。
+
+## 実装者向けの留意（人間レビュー必須）
+
+- **施策1の「Zobrist に手番ビットが無い」汚染**は、盤面の石数パリティで手番が一意に決まるため、通常の局面遷移だけでは同一ハッシュ×異手番は生じない。**null move（NMP のパス）が同一盤面・異手番を作る**のが主トリガと考えられる。修正（手番ビット追加）は標準的に正しいが、**汚染の実トリガを実装時に再現テストで確認**すること（施策7のフラグ分離・NMP 挙動と関連）。
+- mining は medium 相当・Rapfi 700ms 採点。**最強設定(hard)での再マイニング**で blunder 分布が変わる可能性あり。

--- a/docs/plans/mandatory-defense-multiline-2026-06-10.md
+++ b/docs/plans/mandatory-defense-multiline-2026-06-10.md
@@ -1,0 +1,64 @@
+# 必須防御マスクの全活線カバー化 — 第一歩（過小防御の解消）
+
+## 狙い
+
+hard CPU が相手の脅威に「必須防御マスク」（この点に打たねば負ける強制防御点集合）で
+着手を絞る際、**独立した活三が2本以上ある局面で過小防御になる**バグを解消する。
+corpus の blunder 分類 `allowed-opponent-threat=8件` に直結する実バグ。
+
+## 現状の欠陥（調査確定, file:line）
+
+- `ThreatInfo`（zig/src/threats.zig:77-93）は脅威をカテゴリ単位の**フラットunion**で保持
+  （open_threes 等が1リスト・脅威ごとのグループ情報なし）。
+- `detectThreatsCore`（threats.zig:527-584）が全方向の防御点を `addUniqueList` で1リストに混ぜる。
+- 評価枝刈り `position_eval.zig:304-367`（活三は :339-340）が
+  `threat.open_threes.contains(row,col)` 一発で「unionのどれか1点を踏めばOK」と判定。
+- **帰結（過小防御）**: 独立活三A・Bが同時にあると、Aだけ止める手も union に含まれ
+  `contains`=true で生き残る → CPU は「必須防御クリア」と誤認 → B で負ける。
+  ※既存の `can_win_first`（四三/活四の反撃, position_eval.zig:325-326）は除外対象外なので
+  「反撃テンポ」は部分的に考慮済みだが、**グループ別の全止め判定は無い**。
+
+## 必須防御枝刈りは WASM 専用（重要）
+
+- この枝刈りロジックは Zig/WASM のみ。TS には移植されていない
+  （TS `threatDetection.ts`/`patternScores.ts` の ThreatInfo は review/scripts 専用）。
+- パリティ: 実在するのは `src/logic/cpu/wasm/threatAdapter.test.ts`（WASM⇄TS の
+  `detectOpponentThreats` をフラット5カテゴリで照合）。**`renjuParity.test.ts` は実在しない**
+  （CLAUDE.md の記述は不正確）。
+- → **`ThreatInfo` の構造を変えなければ TS同期もパリティ改修も不要**。
+
+## 第一歩 A（最小・パリティ非破壊・除外を緩めるだけ）
+
+`ThreatInfo` 構造は据え置き（フラットunion維持＝threatAdapter パリティ無傷）。
+
+1. `detectThreatsCore` に **独立活三の本数カウンタ** `open_three_group_count: u8` を追加。
+   各方向で新しい活三を検出するたびにインクリメント（止め点リストは従来どおり union に統合）。
+2. `position_eval.zig:339` の活三枝刈りを変更:
+   `open_three_group_count >= 2` のときは、`can_win_first`（既存の四三/活四反撃）でない限り
+   **活三マスクによる除外を発動しない**（＝複数活線時はどの手も安全除外せず探索に委ねる）。
+3. `move_order.zig:217-247` の union 枝刈りは**触らない**（探索手集合を変える最大リスク要因のため後回し）。
+
+### なぜ安全か
+
+- 変更は「除外を緩める」方向のみ。誤って正解手まで切る危険がない。
+- 真に二重活三で受けが無い局面では CPU は元々負け。広げても悪化しない一方、
+  反撃の四がある局面では探索がそれを拾える（過小防御の盲打ちを回避）。
+- 複数活三は稀なので、枝刈り緩和による深度コストは局所的。
+
+## テスト・検証
+
+- Zig: position_eval.zig:779-966 の mandatory-defense テスト群に
+  「独立活三2本＋片止め手は必須防御を満たさない／反撃四は許容」の RED→GREEN を追加。
+- 影響: 静的評価値（≒move順）のみ。move_order の探索手集合は不変。
+- commit-bench r0.02（効率セット数）で Elo 計測。corpus の該当局面（allowed-opponent-threat）で
+  analyze-position による実証も行う。
+
+## 第二歩（効果が出たら・別コミット）
+
+`ThreatInfo` を真のグループ別配列へ拡張し「全グループ止め OR 同等速反撃（createsFourThree/has_four）」
+の正確判定を導入。`move_order.zig` の defense_bitmap も AND 化。このとき TS `threatDetection.ts`＋
+`threatAdapter.test.ts`＋Zig テストを同時更新（パリティ維持）。回帰リスク高のため第一歩の効果確認後。
+
+## 原則
+
+1コミット1施策 / 評価のみ先・探索手集合(move_order)は後 / commit-bench で符号確認 / ボス承認後に着手。

--- a/docs/plans/wasm-eval-weight-injection-2026-06-10.md
+++ b/docs/plans/wasm-eval-weight-injection-2026-06-10.md
@@ -1,0 +1,92 @@
+# WASM 評価重みの実行時注入 → 既存重み SPSA チューニング
+
+## レビュー結果 (2026-06-10): 要修正 → 当面【凍結】・安価ゲート優先に再構成
+
+3観点（SOLID/パフォーマンス/イシュー）全員 **要修正**。フル配線（Zig var化+WASM export+JSブリッジ+SPSA改修＝数日工数）に進む前に、**2つの安価ゲートを通すことを必須化**した。最重要の指摘:
+
+- **`eval-misjudgment` は消去法の残差カテゴリ**（`classifyBlunder.ts` の `classifyMechanism` L148-166：強制勝ち・既敗・戦術受け落ちの**どれでもない手の全部**）。中身は「重みのスケールずれ(SPSA可)／評価関数が表現していない概念(SPSA不可)／読みの差(SPSA不可)」の混合。**「eval 76%」は「重みで直る」を含意しない**。roadmap 自身の結論「残るギャップは no-ML では埋めにくい本質ギャップ」と本プランは矛盾。
+- よって **「レバーが物理的に動くか」を最安手段で先に確かめる**（下記 Gate B）。動かなければ数日の配線を丸ごと回避できる。
+- `tune-params.ts` は依存先 `src/logic/cpu/benchmark/headless.ts` が **TS探索削除で消滅済み＝現状壊れている**。Phase 3 は「worker契約変更」では済まず、WASM駆動自己対局ハーネスの再構築が前提（MEMORY「benchmark/ Phase 5 で再構築予定」と符合）。
+
+## 背景・目的
+
+★4(hard) CPU の Rapfi 比の弱点は機序分類で **eval-misjudgment 76〜94% / タクティクス受け落ち 0%**（[[project_cpu_strength_roadmap]]）。
+ボス体感「詰めは強いが序盤の組み立てが弱い」と一致。残るレバー候補は**位置評価＝盤面の形の採点**＝
+`zig/src/scores.zig` の「形」系重み。**新評価軸の追加は禁止**（Phase B と共線で相殺悪化, [[project_eval_axis_redundancy]]）。
+本プランは**既存重みのチューニングのみ**。ただし上記の通り「重みで動く」こと自体が未証明なので、段階ゲートで検証する。
+
+## 段階ゲート（安価→高価。各ゲート不通過で凍結/破棄）
+
+### Gate A — eval-gap の実在確証（標準開局再mine, 実行中）
+
+`blunders-classified-std.json`（標準26珠型開局）で eval-misjudgment が支配的か。
+**数値しきい値（確認バイアス回避）**:
+
+- 標準開局は先頭3手固定＝CPU初手は ply3〜。「ply≤7 偏在」は**序盤固定手の直後という構造**で説明され得るので、
+  **ply≥10 の局面に限定**しても eval-misjudgment が過半、**かつ** verifiedDrop≥600 の重い blunder でも eval 系が過半、を GO 条件とする。
+- NO-GO（序盤アーティファクト/eval-gap は実在せず）なら本プラン破棄。
+
+### Gate B — 「重みレバーが物理的に動くか」最安テスト ★新設・最重要
+
+フル配線の前に、**既存の commit-bench インフラだけ**でレバーの生死を判定する:
+
+1. `scores.zig` の `CENTER_BONUS`（序盤の組み立て＝ボス体感に直結, 既定5）を**1行だけ**大きく振った
+   ブランチを作る（例 5→0 と 5→20 の2本）。**新規 export も JS ブリッジも不要**。`zig build` のみ。
+2. `commit-bench`（main vs その1行ブランチ, r0.02×数セット）で **Elo が有意に動くか**を見る。
+3. 判定:
+   - **大きく振っても Elo がほぼ動かない** → 「重みでは強さが動かない」の最速の反証。フル SPSA 配線は無駄＝破棄。
+   - **動く** → 重みは生きたレバー。Phase 1〜 のフル配線に進む価値あり。
+
+- これは Gate A（eval が弱い）とは独立の「**レバーが効くか**」の検証。両方通って初めて Phase 1。
+
+## Phase 1〜（Gate A・B 両通過後のみ着手）
+
+### Phase 0.5: 既存 SSoT バグの是正（Phase 1 の前提）
+
+- `patterns.zig:64` の DIAGONAL 倍率 **リテラル直書き `* 105 + 50, 100`** を `scores.DIAGONAL_BONUS_NUM` 参照へ寄せる
+  （`:137` と二重。var 化しても直書き経路だけ古い値が残るため）。
+
+### Phase 1: Zig — 重みを実行時設定可能化
+
+1. `scores.zig` を **単一構造体** `pub var current: EvalParams = DEFAULT;` に集約（散在 var を避け、リセット=`current = DEFAULT`
+   1行、追加削除が1フィールドで済む＝SOLID指摘）。チューニング対象のみフィールド化、**据え置き群は const 据え置き**。
+2. `main.zig` に `export fn setEvalParam(id: u32, value: i32)` ＋ `export fn resetEvalParams()`。
+   id↔名前は **コード生成で SSoT 化**（手動ミラー禁止）。往復パリティテスト（全 EvalParamName が setEvalParam→読戻しで一致）必須。
+3. **比率パラメータの扱いを明記**: `DIAGONAL_BONUS_DEN`/`TEMPO_..._DEN` は**据え置き**、`NUM` のみ可変。
+4. **`CONNECTIVITY_BONUS` は対象から外す**（既に `eval_options_flags` bits16-23 で runtime 注入可、かつ `initFromBoard` で
+   IncrementalEval に init時スナップショット＝`pub var` 書換えが探索ループに伝播しない。二経路化の混乱源）。
+   どうしても入れるなら既存 EvalOptions 経路で。
+5. **E2Eテスト必須**: 単発 `evaluateBoard` だけでなく、**実探索ループ（incremental eval 経由の findBestMove）で重みが反映される**ことを
+   テスト（setEvalParam 後に着手が変わる局面で確認）。これが無いと「効かない重みを SPSA で振る」サイレント失敗が起きる。
+
+### Phase 2: WASM駆動自己対局ハーネスの再生 ★独立フェーズ（旧プランの抜け）
+
+- `benchmark/headless.ts`（削除済み）を **WASM 駆動**で再構築。`game-worker.ts` の TS `applyPatternScoreOverrides` 経路は
+  実機 CPU に無効なので **撤去 or review/TS専用に隔離**（死にフラグ化を防ぐ＝SSoT）。
+- エンジン API `setEvalParams(overrides)` の最後で**必ず `ttClear()`**（運用でなくコードで強制）。
+
+### Phase 3: SPSA を WASM 駆動に・次元を絞る
+
+- **対象次元を3〜4に絞る**（フル9次元は収束しない）。`OPEN_THREE` と `LINE_POTENTIAL_TABLE[3..4]` は
+  **同一形状（発展中の三）で二重発火**するため**片方固定 or 合成して1軸**（相殺は軸追加でなくても正相関重みの同時振りで再現＝Phase B 教訓の本質）。
+  候補: `CENTER_BONUS` / `DIAGONAL_BONUS_NUM` / `LINE_POTENTIAL`（OPEN_THREE は固定）。
+- **randomFactor=0.02 必須**（決定論CPUのままでは SPSA 勾配がノイズに埋もれる/張り付く）。各イテレーション別シード。
+- N/iter は **50〜100**（N=40 は勝率SE±7.9%で勾配がノイズ）。**総対局数は1万〜数万局オーダー**、`--jobs` 並列で wall-clock 数〜十数時間。プランに見積もり明記。
+- 目的関数は θ vs θ± 直接対決（commit-bench 同型, 先後入替あり）。**注意: self-play 最適 ≠ Rapfi 比の真の強さ**（目的関数に Rapfi 整合信号が無い構造的弱点）。リスクとして明記。
+
+### Phase 4: ベイク＆パリティ
+
+- 勝った重みを `scores.zig`(DEFAULT) ＋ `patternScores.ts` PATTERN_SCORES ＋ `lineScan.ts` PACKED_TO_SCORE ＋
+  `params/default-tunables.json` の initial に**全て同期**（SSoT）。`threatAdapter.test.ts` で**スコア数値パリティ**まで確認。
+- commit-bench r0.02×8セット(416局)で vs main の Elo 確定（CI 下限>0 で採用）。
+
+## var化の影響評価（指標）
+
+- 評価重みは**探索最内ループでは参照されない**（`incremental_eval` の集計済み値を読む。重みは `initFromBoard`/`applyMove` の集計時に焼き込み）。
+  ゆえに var 化の影響は軽微だが、根拠は「加算主体」ではなく「重みが集計に焼き込まれ最内では集計済み値を読む」。
+- 指標は **depth 列でなく NPS（固定局面・固定時間の nodes/sec）or 関数別プロファイル**で ±2% 以内を許容基準に。
+
+## 原則
+
+2ゲート（A:eval実在 / B:レバー可動）両通過まで Phase 1 凍結 / 1コミット1施策 / 各段 check-fix・Zigテスト緑 /
+最終 commit-bench r0.02×8セット / ボス承認後に着手・PR はレビュー後マージ。


### PR DESCRIPTION
## 概要

CPU 強化（no-ML）フェーズの設計ドキュメント3本を追加します。**コード変更なし**。

- `cpu-strength-roadmap-2026-06-10.md`: 自己対局を外部オラクルで採点した blunder 分析 + Zig 実装精読から得た強化ロードマップ。決定論的機序分類の結論（測定可能な弱点はほぼ位置評価＝eval-misjudgment 支配、タクティクス受け落ちは頭打ち）。
- `wasm-eval-weight-injection-2026-06-10.md`: 評価重みの実行時注入 → 既存重み SPSA チューニング計画。3観点レビューで要修正 → **凍結**（「eval-misjudgment は消去法の残差で重みで直るとは限らない」「安価ゲートで先にレバーの可動を確認」に再構成）。
- `mandatory-defense-multiline-2026-06-10.md`: 必須防御マスク全活線カバー化案。corpus 実証で 0/46 件しか直さず → **棄却**。

## 位置づけ

`docs/plans/` の設計記録（過去の stacked PR 群に倣う）。実装判断・棄却理由の根拠を残すものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
