### PR TITLE
feat(cpu): eval形系重みの実行時注入 (setEvalParam) [stack 1/3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ zig/bench-results/
 .claude/settings.local.json
 .claude/worktrees/
 tools/oracle/
+
+# GPL の外部解析エンジン(Rapfi)クライアント置き場。コミット禁止。
+scripts/rapfi/

--- a/docs/plans/runtime-eval-weight-injection-2026-06-11.md
+++ b/docs/plans/runtime-eval-weight-injection-2026-06-11.md
@@ -1,0 +1,99 @@
+# runtime eval 重み注入 — 実装プラン (2026-06-11)
+
+> **2026-06-11 /review 反映済（SOLID/パフォーマンス/イシュー 3観点・全員 要修正→反映）。** 主要な必須修正: ①注入版≡ベイク版のビット一致テスト ②weight-bench の1局隔離(try/catch+worker再生成, moveTimeoutMs=120000) ③baseline(var) vs main(const) 同強度クロスチェック ④param-id ドリフトを「reset後 getEvalParam=固有既定」で検出 ⑤勝ち重みはベイク再確認してから本採用。
+
+## 背景（なぜ作るか）
+
+- 形系重み（OPEN_TWO 等）は Zig の **comptime 定数**で wasm に焼き込み。実対局探索 `findBestMove` には**ブール9bitのフラグしか渡らない**（`searchEngine.ts:30-46`）。
+- `evaluationOptions.patternScoreOverrides` は **src/logic/cpu に消費者ゼロ＝死んだ引数**。ab-bench の `--score-override` は wasm に届かない。
+- さらに `src/logic/cpu/benchmark/headless.ts` が**存在せず**、`runHeadlessGame` を import する **ab-bench / game-worker / tune-params / bench-ai 等は全て壊れている**（TS削除の巻き添え）。
+- ⟹ **今 eval 重みを A/B 検証できる唯一の手段は commit-bench（重み1行違いコミット×worktreeリビルド）**。
+- commit-bench の重さの主因は **worktree生成 + `pnpm install` + per-commit wasmビルド**（1プロファイルごとに分オーダー）。※ commit-bench 自体は **1プロセス内 `--jobs=N` 並列は可能**（複数プロセス同時起動だけが worktree パス競合で不可）。「並列不可」は誤り。
+- これから重みを「こねくり回す」のに、毎回リビルドは非現実的。**wasm に重みを実行時注入する setter** を入れ、単一ビルド・リビルド不要の高速ループを作る。
+- ⚠️ **Gate0 の move timeout クラッシュ（75sハング）は worktree 機構の脆さではなく探索エンジン側のバグ**（`main.zig:145` の 10s absolute cap が効かない局面が存在）。weight-bench に移行しても消えない ⟹ §ロバスト性の1局隔離が**必須**。
+
+## ゴール / 非ゴール
+
+- ゴール: `--weights=OPEN_TWO:25,OPEN_THREE:600` 形式で**リビルドなしに**重みを振って Elo 比較できる bench を用意する。
+- 非ゴール: TS 評価ミラー（`PACKED_TO_SCORE`）の同期や本採用（ベイク）。**勝ち重みが出てから Phase 4 で対応**。今回は **wasm 専用パス**のみ触る。
+
+## 不変条件（安全性の核）
+
+- **既定値は一切変えない。** `const`→`var` 化しても既定値同一＝挙動同一＝既存テスト（renjuParity 等）全緑。
+- override 未適用時は完全に現状と同一バイナリ挙動。
+
+## 設計
+
+### 1. Zig: scores.zig の var 化 + エクスポート
+
+- 対象（形系・四五未満）を `pub const`→`pub var`（既定値そのまま）:
+  `OPEN_THREE / THREE / OPEN_TWO / TWO / CENTER_BONUS / LINE_POTENTIAL_TABLE`。
+  - `FIVE/OPEN_FOUR/FOUR` は事実上「勝ち」値でevalレバーでない（プラン方針）ため**対象外（const 維持）**。
+  - 脅威/ミセ系ボーナスも今回対象外（後で追加可能な設計に）。
+- 既定値スナップショットを別 const で保持（`OPEN_THREE_DEFAULT` 等）し `resetEvalParams()` で復元。
+- `main.zig` に export 追加:
+  - `setEvalParam(id: u32, value: i32) void` — comptime switch で対象へ代入。
+  - `getEvalParam(id: u32) i32` — 往復テスト用。
+  - `resetEvalParams() void` — 全既定復元。
+- `LINE_POTENTIAL_TABLE` は配列。id はエントリ [1..4] を個別に割当（[0]/[5] は sentinel=0、対象外）。
+- **comptime 使用の検証**: `scores` 定数は `patterns.zig`(PATTERN_TABLE は幾何のみ・スコアは getPatternScore で後段適用)/`position_eval`/`line_potential` 等で**実行時参照**。配列サイズや comptime switch に使われていないことをビルドで確認（grep上は LINE_POTENTIAL_TABLE 宣言以外に comptime 文脈なし）。
+
+### 2. param-id の SSoT（**手動双方向ミラー禁止**）
+
+- id↔名前の正準表を **1ファイルに集約**（`scripts/lib/evalParams.ts`: `export const EVAL_PARAM_IDS = {OPEN_THREE:0, THREE:1, ...}`）。Zig 側 switch はこの並びに対応。
+- **ドリフト検出（強化）**: 単純な set→get 往復は「TS と Zig が同じ方向に id をズラした取り違え」を検知できない。代わりに **`resetEvalParams()` 直後に全 id で `getEvalParam(id)` が*それぞれ固有の既定値*に一致するか**を検証する（既定値は全 id で相異なるので、id↔ターゲットの対応ズレを機械検出できる）。
+- さらに堅くするため `getEvalParamName(id) -> [*:0]const u8` を1本足し、TS の期待名と wasm 返却名を全 id 照合（任意・推奨）。**「コメントで手動ミラー」は禁止事項**として明記。
+
+### 3. cpu-bridge-worker.ts
+
+- `BridgeWorkerData` に `evalWeights?: Record<string, number>` 追加。
+- `WasmModuleExports`（**scripts 側のみ。src の `WasmModuleContext` は触らない**）に `setEvalParam? / getEvalParam? / resetEvalParams?` を**任意**で追加（既存 `getStatsBuffer?` と同じ optional パターン＝古いworktree互換, OCP）。
+- 重み適用を **`applyEvalWeights(wasm, weights): void` の純粋関数に抽出**（main 直書きを避ける, SRP＋テスト容易性）。`createWasmSearchHandler` 生成直後に1回呼ぶ。
+- 適用フロー: export があれば **必ず `resetEvalParams()`（baseline 側=override 空でも呼ぶ→ロード時クリーン既定保証）** → 各 `evalWeights` を `setEvalParam`。無ければ warn してスキップ（commit-bench 後方互換）。
+- **1 worker = 1 サイド = 1 重みプロファイル**を全局使い回し ⟹ 先後混線なし、着手ごとの set 不要。
+- **キャッシュ汚染なし（確認済）**: `search.findBestMoveIterative` は探索冒頭で毎回 `incremental_eval.initFromBoard`(search.zig:343)を呼び、`LINE_POTENTIAL_TABLE` を実行時再参照して eval_state を再構築。重みは起動時 set で探索中不変 ⟹ 注入が初回探索より前である限り、インクリメンタル和キャッシュも常にライブ重みで再計算される。ビット一致テスト(§5)で最終保証。
+
+### 4. 新オーケストレータ weight-bench.ts
+
+- worktree を**作らない**。`worktreePath = リポジトリルート`を両サイドに渡し、**ローカルの `zig/zig-out/bin/cpu-engine.wasm` を両 worker がそれぞれインスタンス化**（別インスタンス＝`var` はインスタンス毎リニアメモリ＝ worker/`--jobs` 間で非共有・重み独立）。wasm インスタンス化時の import `env.getTimestampMsExternal` 提供を忘れない（move timeout 制御が壊れる）。
+- **wasm 鮮度チェック**: ソース mtime > wasm mtime なら1回ビルド。起動ログに wasm のビルド時刻/サイズを出して「古い wasm で測る事故」を防ぐ。
+- side A = baseline（override 空＝reset 後の既定）、side B = `--weights` override。
+- **commit-bench の `main()` 埋没ロジックを先に抽出（前提リファクタ・独立コミット）**: 対局ループ＋ワークスティール並列＋WDL/Elo・CI 集計を `runMatch(makePair, { sets, randomFactor, jobs, moveTimeoutMs, ... })` 相当の純粋関数へ。weight-bench と commit-bench の差は「worker ペアの作り方（worktree vs ローカル wasm）」と「side B の customParams(evalWeights)」だけ ⟹ **ペア生成を引数注入**すればループ本体を完全共有（DIP）。これをやらないと再利用が実質コピペ＝DRY 違反。
+- `runCommitGame`(commit-game-runner.ts) は worktree 非依存の中立コーディネータ ⟹ **そのまま再利用**。
+- CLI: `--weights=K:V,...` `--sets=N` `--randomFactor` `--jobs` `--moveTimeoutMs`。出力 Elo は **A=baseline 視点**（commit-bench の WDL=commitA 視点と一致）。
+
+### 5. テスト（TDD）
+
+- **Zig 単体（`zig build test`）**:
+  - ① **reset 後 getEvalParam=固有既定**（全 id・id 取り違え検出, §2）。
+  - ② setEvalParam→getEvalParam で設定値が読める。
+  - ③ **注入版≡ベイク版ビット一致（必須・最重要）**: ある重みプロファイル（例 OPEN_THREE=600、別途 LINE_POTENTIAL 変種）を**ベイクしてリビルドした wasm** の `evaluateBoard`/`findBestMove` と、**baseline+setEvalParam で同値注入**した出力が**複数局面でビット一致**。LINE_POTENTIAL は**複数手進めたインクリメンタル局面**でも一致を確認（キャッシュ汚染の最終ゲート）。
+  - ④ override 無し（reset のみ）で var化前 const バイナリと**評価値スナップショット一致**（既定不変の担保）。
+- **統合**: ⑤ `applyEvalWeights` が既知局面のスコアを期待通り変える ⑥ weight-bench **null test**: A=B baseline を **randomFactor=0.02** で回し **CI が 0 を含む**（0 厳密一致を期待しない）。
+- **回帰**: 既定不変ゆえ既存スイート（renjuParity 含む）全緑。
+- **nps 回帰**: var 化後に `/profile-cpu` で const ビルド比 **<2%** の劣化に収まることを1回実測（理論見積 <1%）。
+
+## ロバスト性（weight-bench 自身の責務・必須）
+
+- **1局隔離**: `runPair` 内で try/catch。ハングした1局は記録して破棄（or 敗北扱い）し**残りは続行**＝「1局ハングで全体クラッシュ」を構造的に排除（Gate0 の再発防止）。
+- **ハング worker の再生成**: タイムアウトした worker は WASM 同期実行でブロック＝再利用不可 ⟹ `terminate()`→再生成。入れないと実効並列度が落ちる。
+- **`moveTimeoutMs` 既定 = 120000**（commit-bench 同等を継承。30000 ではない＝75sハングを吸収）。
+- 75sハングの**本質修正（10s cap が効かない局面）は別タスク**。weight-bench は隔離で耐える。
+
+## 投資順序・結論汚染リスク（イシュー観点）
+
+- 正レバーがまだ1本も出ていない段階だが、**ツールがあれば Gate0 自体が桁違いに速くなる**（残 openthree/center0 + 減方向 + 今後の掃き方探索）ため先行は妥当。ただし**振る重み空間に正レバーが無ければツールは徒労**である点は自覚する。
+- **「注入で勝った ≠ ベイクで勝つ」**: const→var で最適化パスが変わる可能性は推論で潰せない ⟹ §5③のビット一致テストが一次防衛。さらに**本採用前に勝ち重みをベイク・リビルドして commit-bench で再確認**（最終保険・Phase 4 のゲート）。
+- baseline(var, override 無し) と現行 main(const) の**ゼロ点接続**: §5④の静的ビット一致で担保。不安が残れば 1セット(52局, r0)の baseline-vs-main クロス対局で Elo≈0 を確認。
+
+## 段階コミット
+
+1. Zig var化＋export(set/get/reset/getName)＋Zig単体テスト ①②③④（既定不変・全緑）
+2. commit-bench から `runMatch` 抽出（前提リファクタ・出力同一）
+3. param-id SSoT + `applyEvalWeights` + bridge worker 適用 + 統合テスト⑤
+4. weight-bench.ts + null test⑥ + nps回帰
+5. （検証）Gate0 減方向3本＋増方向を新ループで **r0.02 8セット(416局)** で再測（統計強度を Gate0 と揃える）
+
+## 将来（本採用時・今回非対象）
+
+- 勝ち重み確定後: **ベイク・リビルドして commit-bench 再確認** → TS `PACKED_TO_SCORE` 再構築同期 + scores.zig 既定更新 + `params/` 同期 + renjuParity/E2E。Phase 4。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,9 @@ export default [
       "**/*.d.ts",
       ".oxlint_cache",
       ".eslint_cache",
+      // GPL の外部解析エンジン（Rapfi）置き場。コミット禁止・lint対象外。
+      "scripts/rapfi/**",
+      "tools/oracle/**",
     ],
   },
 

--- a/scripts/lib/evalParams.ts
+++ b/scripts/lib/evalParams.ts
@@ -1,0 +1,64 @@
+/**
+ * eval 重みパラメータ id の正準表（TS 側）。
+ *
+ * 数値は Zig `scores.zig` の `EvalParamId` と一致させる。
+ * **手動の双方向コメント同期は禁止。** ドリフトは
+ * 「resetEvalParams() 後に全 id の getEvalParam が*それぞれ固有の*既定値に
+ * 一致するか」で機械検出する（scores.zig のテスト＋verify-eval-injection）。
+ *
+ * LINE_POTENTIAL_TABLE は素材数 1..4 のエントリを個別 id に割当
+ * （[0]/[5] は sentinel=0 で対象外）。
+ */
+export const EVAL_PARAM_IDS = {
+  OPEN_THREE: 0,
+  THREE: 1,
+  OPEN_TWO: 2,
+  TWO: 3,
+  CENTER_BONUS: 4,
+  LINE_POTENTIAL_1: 5,
+  LINE_POTENTIAL_2: 6,
+  LINE_POTENTIAL_3: 7,
+  LINE_POTENTIAL_4: 8,
+} as const;
+
+export type EvalParamName = keyof typeof EVAL_PARAM_IDS;
+
+/** 各 id の既定値（ドリフト検出用。全 id で相異なる）。scores.zig の *_DEFAULT と一致。 */
+export const EVAL_PARAM_DEFAULTS: Record<EvalParamName, number> = {
+  OPEN_THREE: 1000,
+  THREE: 30,
+  OPEN_TWO: 50,
+  TWO: 10,
+  CENTER_BONUS: 0,
+  LINE_POTENTIAL_1: 3,
+  LINE_POTENTIAL_2: 12,
+  LINE_POTENTIAL_3: 40,
+  LINE_POTENTIAL_4: 60,
+};
+
+/** "OPEN_TWO:25,OPEN_THREE:600" 形式をパースし [id, value][] に。未知キーは例外。 */
+export function parseWeightOverrides(str: string): [number, number][] {
+  const out: [number, number][] = [];
+  for (const pair of str.split(",")) {
+    const trimmed = pair.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const [k, v] = trimmed.split(":");
+    if (!k || v === undefined) {
+      continue;
+    }
+    const id = (EVAL_PARAM_IDS as Record<string, number>)[k.trim()];
+    if (id === undefined) {
+      throw new Error(
+        `不明な eval 重みキー "${k.trim()}"。有効: ${Object.keys(EVAL_PARAM_IDS).join(", ")}`,
+      );
+    }
+    const num = Number(v.trim());
+    if (Number.isNaN(num)) {
+      throw new Error(`"${k.trim()}" の値が数値でない: "${v}"`);
+    }
+    out.push([id, num]);
+  }
+  return out;
+}

--- a/scripts/verify-eval-injection.ts
+++ b/scripts/verify-eval-injection.ts
@@ -1,0 +1,218 @@
+/**
+ * 注入版 ≡ ベイク版 ビット一致検証（runtime eval 重み注入の一次防衛ゲート）
+ *
+ * 同じ重みを (i) scores.zig 既定に焼いてリビルドした wasm（baked）と、
+ * (ii) 既定 wasm に setEvalParam で注入した wasm（inject）で、
+ * 多数局面の evaluateBoard と findBestMove がビット一致するか検証する。
+ *
+ * const→var 化や注入経路が、ベイク版と挙動を変えていないことの最終保証。
+ * 特に LINE_POTENTIAL はインクリメンタル和キャッシュ（incremental_eval.zig）を
+ * 持つため、複数手進めた局面でも一致するかを重点的に見る。
+ *
+ *   node --experimental-strip-types --import ./scripts/register-loader.mjs \
+ *     scripts/verify-eval-injection.ts \
+ *     --baked=/tmp/wasm-baked.wasm --inject=/tmp/wasm-inject.wasm \
+ *     --weights=OPEN_THREE:600,LINE_POTENTIAL_1:2,LINE_POTENTIAL_2:6,LINE_POTENTIAL_3:20,LINE_POTENTIAL_4:30
+ */
+import { readFileSync } from "node:fs";
+
+import { EVAL_PARAM_IDS } from "./lib/evalParams.ts";
+
+interface Engine {
+  boardInit: () => void;
+  boardSet: (r: number, c: number, v: number) => void;
+  evaluateBoard: (perspective: number, optionsFlags: number) => number;
+  findBestMove: (
+    color: number,
+    maxDepth: number,
+    timeLimitMs: number,
+    maxNodes: number,
+    absoluteTimeLimitMs: number,
+    aspirationMode: number,
+    evalOptionsFlags: number,
+  ) => void;
+  getResultBuffer: () => number;
+  resetEvalParams: () => void;
+  setEvalParam: (id: number, value: number) => void;
+  ttClear: () => void;
+  memory: WebAssembly.Memory;
+}
+
+const arg = (k: string): string | undefined =>
+  process.argv
+    .slice(2)
+    .find((s) => s.startsWith(`--${k}=`))
+    ?.slice(k.length + 3);
+
+async function load(path: string): Promise<Engine> {
+  const buf = readFileSync(path);
+  const { instance } = await WebAssembly.instantiate(buf, {
+    env: { getTimestampMsExternal: () => 0 },
+  });
+  return instance.exports as unknown as Engine;
+}
+
+function setStones(e: Engine, stones: [number, number, number][]): void {
+  e.boardInit();
+  for (const [r, c, v] of stones) {
+    e.boardSet(r, c, v);
+  }
+}
+
+/** 決定的な疑似ランダム局面列を生成（中央付近に交互着手）。 */
+function genPositions(): [number, number, number][][] {
+  const out: [number, number, number][][] = [];
+  // Park-Miller 最小標準（決定的・ビット演算なし・safe integer 内）
+  let seed = 12345;
+  const rnd = (): number => {
+    seed = (seed * 16807) % 2147483647;
+    return seed / 2147483647;
+  };
+  for (let g = 0; g < 40; g++) {
+    const used = new Set<number>();
+    const stones: [number, number, number][] = [];
+    const len = 4 + Math.floor(rnd() * 20); // 4..23 手
+    for (let i = 0; i < len; i++) {
+      let r = 0;
+      let c = 0;
+      let idx = 0;
+      let tries = 0;
+      do {
+        r = 4 + Math.floor(rnd() * 7);
+        c = 4 + Math.floor(rnd() * 7);
+        idx = r * 15 + c;
+        tries++;
+      } while (used.has(idx) && tries < 50);
+      if (used.has(idx)) {
+        continue;
+      }
+      used.add(idx);
+      stones.push([r, c, (i % 2) + 1]); // 1=black,2=white 交互
+      out.push(stones.slice()); // 各手数のスナップショット（インクリメンタル経路網羅）
+    }
+  }
+  return out;
+}
+
+function readMove(e: Engine): {
+  row: number;
+  col: number;
+  score: number;
+  depth: number;
+} {
+  const ptr = e.getResultBuffer();
+  const view = new DataView(e.memory.buffer);
+  return {
+    row: view.getUint8(ptr),
+    col: view.getUint8(ptr + 1),
+    score: view.getInt32(ptr + 2, true),
+    depth: view.getUint8(ptr + 6),
+  };
+}
+
+async function main(): Promise<void> {
+  const bakedPath = arg("baked");
+  const injectPath = arg("inject");
+  const weightsStr = arg("weights") ?? "";
+  if (!bakedPath || !injectPath) {
+    console.error("--baked と --inject は必須");
+    process.exit(1);
+  }
+  const overrides: [number, number][] = [];
+  for (const pair of weightsStr.split(",")) {
+    const [k, v] = pair.split(":");
+    if (!k || v === undefined) {
+      continue;
+    }
+    const id = (EVAL_PARAM_IDS as Record<string, number>)[k.trim()];
+    if (id === undefined) {
+      console.error(`不明な重みキー: ${k}`);
+      process.exit(1);
+    }
+    overrides.push([id, Number(v)]);
+  }
+
+  const baked = await load(bakedPath);
+  const inject = await load(injectPath);
+
+  // inject 側に重みを注入（reset → 各 setEvalParam）
+  inject.resetEvalParams();
+  for (const [id, v] of overrides) {
+    inject.setEvalParam(id, v);
+  }
+
+  const positions = genPositions();
+  const optionFlagSets = [0, 511]; // 既定 / hard 全bit
+
+  let evalChecked = 0;
+  let evalMismatch = 0;
+  let moveChecked = 0;
+  let moveMismatch = 0;
+  const samples: string[] = [];
+
+  for (let pi = 0; pi < positions.length; pi++) {
+    const stones = positions[pi]!;
+    setStones(baked, stones);
+    setStones(inject, stones);
+    const perspective = (stones.length % 2) + 1; // 次手番
+    // evaluateBoard は決定的・即時 → 全局面で網羅（重みを読む本体の証明）
+    for (const flags of optionFlagSets) {
+      const sb = baked.evaluateBoard(perspective, flags);
+      const si = inject.evaluateBoard(perspective, flags);
+      evalChecked++;
+      if (sb !== si) {
+        evalMismatch++;
+        if (samples.length < 10) {
+          samples.push(
+            `eval len=${stones.length} flags=${flags}: baked=${sb} inject=${si}`,
+          );
+        }
+      }
+    }
+    // findBestMove は重いので間引き＋小ノード上限で決定的に（move選択の等価性確認）
+    if (pi % 20 === 0) {
+      baked.ttClear();
+      inject.ttClear();
+      baked.findBestMove(perspective, 4, 5000, 3000, 5000, 0, 511);
+      const mb = readMove(baked);
+      inject.findBestMove(perspective, 4, 5000, 3000, 5000, 0, 511);
+      const mi = readMove(inject);
+      moveChecked++;
+      if (mb.row !== mi.row || mb.col !== mi.col || mb.score !== mi.score) {
+        moveMismatch++;
+        if (samples.length < 10) {
+          samples.push(
+            `move len=${stones.length}: baked=(${mb.row},${mb.col},s=${mb.score},d=${mb.depth}) inject=(${mi.row},${mi.col},s=${mi.score},d=${mi.depth})`,
+          );
+        }
+      }
+    }
+  }
+
+  console.log(`\n=== 注入版 ≡ ベイク版 ビット一致検証 ===`);
+  console.log(`重み: ${overrides.map(([id, v]) => `${id}=${v}`).join(", ")}`);
+  console.log(
+    `evaluateBoard: ${evalChecked - evalMismatch}/${evalChecked} 一致`,
+  );
+  console.log(
+    `findBestMove : ${moveChecked - moveMismatch}/${moveChecked} 一致`,
+  );
+  if (samples.length > 0) {
+    console.log(`--- 不一致サンプル ---`);
+    for (const s of samples) {
+      console.log(`  ${s}`);
+    }
+  }
+  const ok = evalMismatch === 0 && moveMismatch === 0;
+  console.log(
+    ok
+      ? "\n✅ 完全一致: 注入経路はベイク版と等価"
+      : "\n❌ 不一致あり: 注入経路に差異",
+  );
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -175,6 +175,13 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    const test_scores = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/scores.zig"),
+            .target = native_target,
+        }),
+    });
+
     const test_bitboard = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/bitboard.zig"),
@@ -228,6 +235,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(test_vcf).step);
     test_step.dependOn(&b.addRunArtifact(test_vct).step);
     test_step.dependOn(&b.addRunArtifact(test_incremental_eval).step);
+    test_step.dependOn(&b.addRunArtifact(test_scores).step);
     test_step.dependOn(&b.addRunArtifact(test_bitboard).step);
     test_step.dependOn(&b.addRunArtifact(test_line_lookup).step);
     test_step.dependOn(&b.addRunArtifact(test_line_potential).step);

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -41,6 +41,20 @@ export fn evaluateDirectionScores(row: u8, col: u8, color: u8) i32 {
 export fn wasmGetPatternScore(count: u8, end1: u8, end2: u8) i32 {
     return patterns.wasmGetPatternScore(count, end1, end2);
 }
+
+// --- eval 重み実行時注入（bench 専用。重みごとリビルド不要にする） ---
+export fn setEvalParam(id: u32, value: i32) void {
+    scores_mod.setEvalParam(id, value);
+}
+export fn getEvalParam(id: u32) i32 {
+    return scores_mod.getEvalParam(id);
+}
+export fn resetEvalParams() void {
+    scores_mod.resetEvalParams();
+}
+export fn getEvalParamName(id: u32) [*:0]const u8 {
+    return scores_mod.getEvalParamName(id);
+}
 export fn wasmGetPatternType(count: u8, end1: u8, end2: u8) u8 {
     return patterns.wasmGetPatternType(count, end1, end2);
 }

--- a/zig/src/scores.zig
+++ b/zig/src/scores.zig
@@ -1,12 +1,20 @@
+const std = @import("std");
+
 /// パターンスコア定数（patternScores.ts の PATTERN_SCORES と同値）
+///
+/// 四五（FIVE/OPEN_FOUR/FOUR）は事実上「勝ち」値で eval レバーにならないため
+/// const 維持（勝ち判定の閾値比較の最適化を保つ）。
+/// 形系（四五未満）の OPEN_THREE 以下と CENTER_BONUS / LINE_POTENTIAL_TABLE は
+/// bench での実行時チューニング対象として `var` 化する（setEvalParam で注入）。
+/// 既定値は不変＝override 未適用時は const 時代と完全同値。
 pub const FIVE: i32 = 100000;
 pub const OPEN_FOUR: i32 = 10000;
 pub const FOUR: i32 = 1500;
-pub const OPEN_THREE: i32 = 1000;
-pub const THREE: i32 = 30;
-pub const OPEN_TWO: i32 = 50;
-pub const TWO: i32 = 10;
-pub const CENTER_BONUS: i32 = 0;
+pub var OPEN_THREE: i32 = 1000;
+pub var THREE: i32 = 30;
+pub var OPEN_TWO: i32 = 50;
+pub var TWO: i32 = 10;
+pub var CENTER_BONUS: i32 = 0;
 
 /// 末端評価定数
 pub const LEAF_FOUR_THREE_THREAT: i32 = 2000;
@@ -64,4 +72,149 @@ pub const INFINITY: i32 = 1000000;
 ///   [3]=40: 素材3個（活二/閉三の素材）OPEN_TWO=50 と同程度
 ///   [4]=60: 素材4個（活三になる手前）OPEN_THREE=1000 と十分差
 ///   [5]=0:  既存パターンが完全に拾うので0（sentinel）
-pub const LINE_POTENTIAL_TABLE = [_]i32{ 0, 3, 12, 40, 60, 0 };
+pub var LINE_POTENTIAL_TABLE = [_]i32{ 0, 3, 12, 40, 60, 0 };
+
+// ============================================================================
+// 実行時 eval 重み注入（bench 専用）
+//
+// 形系重みを `var` 化し、wasm 起動後に setEvalParam で注入できるようにする。
+// これにより重みごとのリビルドなしに A/B Elo を測れる（weight-bench）。
+// 既定値は下記スナップショットで保持し resetEvalParams() で復元する。
+//
+// param-id の正準表はここ（Zig）と `scripts/lib/evalParams.ts`（TS）の2箇所に
+// 現れるが、**手動の双方向コメント同期は禁止**。ドリフトは
+// 「resetEvalParams() 後に全 id の getEvalParam が*それぞれ固有の*既定値に
+// 一致するか」で機械検出する（既定値は全 id で相異なる）。
+// ============================================================================
+
+const OPEN_THREE_DEFAULT: i32 = 1000;
+const THREE_DEFAULT: i32 = 30;
+const OPEN_TWO_DEFAULT: i32 = 50;
+const TWO_DEFAULT: i32 = 10;
+const CENTER_BONUS_DEFAULT: i32 = 0;
+const LINE_POTENTIAL_TABLE_DEFAULT = [_]i32{ 0, 3, 12, 40, 60, 0 };
+
+/// eval 重みパラメータ id（数値は scripts/lib/evalParams.ts と一致させる）。
+/// LINE_POTENTIAL_TABLE は素材数 1..4 のエントリを個別 id に割当
+/// （[0]/[5] は sentinel=0 で対象外）。
+pub const EvalParamId = enum(u32) {
+    open_three = 0,
+    three = 1,
+    open_two = 2,
+    two = 3,
+    center_bonus = 4,
+    line_potential_1 = 5,
+    line_potential_2 = 6,
+    line_potential_3 = 7,
+    line_potential_4 = 8,
+};
+
+/// 不明な id に対する getEvalParam の返却値（テストで検出可能なsentinel）。
+pub const EVAL_PARAM_UNKNOWN: i32 = std.math.minInt(i32);
+
+/// 全形系重みを既定値へ復元する。
+/// wasm ロード直後（baseline 含む）に必ず1回呼び、クリーンな既定から始める。
+pub fn resetEvalParams() void {
+    OPEN_THREE = OPEN_THREE_DEFAULT;
+    THREE = THREE_DEFAULT;
+    OPEN_TWO = OPEN_TWO_DEFAULT;
+    TWO = TWO_DEFAULT;
+    CENTER_BONUS = CENTER_BONUS_DEFAULT;
+    LINE_POTENTIAL_TABLE = LINE_POTENTIAL_TABLE_DEFAULT;
+}
+
+/// id の重みに value を設定する。不明な id は無視。
+pub fn setEvalParam(id: u32, value: i32) void {
+    const pid = std.meta.intToEnum(EvalParamId, id) catch return;
+    switch (pid) {
+        .open_three => OPEN_THREE = value,
+        .three => THREE = value,
+        .open_two => OPEN_TWO = value,
+        .two => TWO = value,
+        .center_bonus => CENTER_BONUS = value,
+        .line_potential_1 => LINE_POTENTIAL_TABLE[1] = value,
+        .line_potential_2 => LINE_POTENTIAL_TABLE[2] = value,
+        .line_potential_3 => LINE_POTENTIAL_TABLE[3] = value,
+        .line_potential_4 => LINE_POTENTIAL_TABLE[4] = value,
+    }
+}
+
+/// id の現在の重みを返す。不明な id は EVAL_PARAM_UNKNOWN。
+pub fn getEvalParam(id: u32) i32 {
+    const pid = std.meta.intToEnum(EvalParamId, id) catch return EVAL_PARAM_UNKNOWN;
+    return switch (pid) {
+        .open_three => OPEN_THREE,
+        .three => THREE,
+        .open_two => OPEN_TWO,
+        .two => TWO,
+        .center_bonus => CENTER_BONUS,
+        .line_potential_1 => LINE_POTENTIAL_TABLE[1],
+        .line_potential_2 => LINE_POTENTIAL_TABLE[2],
+        .line_potential_3 => LINE_POTENTIAL_TABLE[3],
+        .line_potential_4 => LINE_POTENTIAL_TABLE[4],
+    };
+}
+
+/// id の正準名（null 終端）。TS 期待名との照合用（任意の追加ドリフト検出）。
+pub fn getEvalParamName(id: u32) [*:0]const u8 {
+    const pid = std.meta.intToEnum(EvalParamId, id) catch return "";
+    return switch (pid) {
+        .open_three => "OPEN_THREE",
+        .three => "THREE",
+        .open_two => "OPEN_TWO",
+        .two => "TWO",
+        .center_bonus => "CENTER_BONUS",
+        .line_potential_1 => "LINE_POTENTIAL_1",
+        .line_potential_2 => "LINE_POTENTIAL_2",
+        .line_potential_3 => "LINE_POTENTIAL_3",
+        .line_potential_4 => "LINE_POTENTIAL_4",
+    };
+}
+
+const PARAM_COUNT: u32 = @typeInfo(EvalParamId).@"enum".fields.len;
+
+test "resetEvalParams 後は全 id が固有の既定値に一致（id 取り違え検出）" {
+    // まず全 id を別の値で汚す
+    var id: u32 = 0;
+    while (id < PARAM_COUNT) : (id += 1) {
+        setEvalParam(id, 7777);
+    }
+    resetEvalParams();
+
+    const expected = [_]i32{ 1000, 30, 50, 10, 0, 3, 12, 40, 60 };
+    // 既定値は全て相異なる（id↔ターゲットの対応ズレを検出できる前提）
+    id = 0;
+    while (id < PARAM_COUNT) : (id += 1) {
+        try std.testing.expectEqual(expected[id], getEvalParam(id));
+    }
+}
+
+test "setEvalParam→getEvalParam 往復" {
+    resetEvalParams();
+    var id: u32 = 0;
+    while (id < PARAM_COUNT) : (id += 1) {
+        const v: i32 = @as(i32, @intCast(id)) * 100 + 1;
+        setEvalParam(id, v);
+        try std.testing.expectEqual(v, getEvalParam(id));
+    }
+    resetEvalParams();
+}
+
+test "不明な id は無視 / sentinel" {
+    resetEvalParams();
+    try std.testing.expectEqual(EVAL_PARAM_UNKNOWN, getEvalParam(PARAM_COUNT));
+    setEvalParam(PARAM_COUNT, 12345); // 無視されてクラッシュしない
+    // 既存 id は無傷
+    try std.testing.expectEqual(@as(i32, 1000), getEvalParam(@intFromEnum(EvalParamId.open_three)));
+}
+
+test "LINE_POTENTIAL_TABLE の注入は配列に反映され sentinel は不変" {
+    resetEvalParams();
+    setEvalParam(@intFromEnum(EvalParamId.line_potential_3), 999);
+    try std.testing.expectEqual(@as(i32, 999), LINE_POTENTIAL_TABLE[3]);
+    // sentinel [0]/[5] は対象外で 0 のまま
+    try std.testing.expectEqual(@as(i32, 0), LINE_POTENTIAL_TABLE[0]);
+    try std.testing.expectEqual(@as(i32, 0), LINE_POTENTIAL_TABLE[5]);
+    resetEvalParams();
+    try std.testing.expectEqual(@as(i32, 40), LINE_POTENTIAL_TABLE[3]);
+}


### PR DESCRIPTION
## 目的（/goal: Zigアルゴリズムを強くする の土台）
eval 形系重みを **リビルド無しに振れる**ようにし、Rapfi 教師による重みチューニングを高速に回す土台。

## 背景
- 形系重み(OPEN_THREE 等)は Zig comptime 定数で wasm に焼き込み。実対局探索 `findBestMove` にはブール9bitフラグしか渡らず、`patternScoreOverrides` は消費者ゼロの死んだ引数。
- 今 eval 重みを A/B 検証できるのは commit-bench(重み1行違いコミット×worktreeリビルド)のみで重い。

## 変更
- `scores.zig`: 形系重み(OPEN_THREE/THREE/OPEN_TWO/TWO/CENTER_BONUS/LINE_POTENTIAL)を `const`→`var` 化。既定値スナップショットで `resetEvalParams` 復元。
- wasm export: `setEvalParam/getEvalParam/resetEvalParams/getEvalParamName`。
- `scripts/lib/evalParams.ts`: param-id SSoT(手動ミラー禁止・reset後=固有既定でドリフト検出)。
- `scripts/verify-eval-injection.ts`: **注入版≡ベイク版ビット一致**ゲート。
- chore: `scripts/rapfi/`(GPL) を gitignore+lint除外。

## 検証
- Zig 単体テスト緑(reset=固有既定 / set→get / 不明id / LINE_POTENTIAL)。
- **注入版≡ベイク版ビット一致: evaluateBoard 1134/1134, findBestMove 29/29**（const→var は最適化含めリビルドと完全等価。LINE_POTENTIAL インクリメンタルキャッシュ汚染も否定）。
- 既定不変ゆえ既存スイート全緑(vitest 1519, zig-test, renjuParity)。

## 不変条件
override 未適用時は const 時代と完全同一バイナリ挙動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)