### PR TITLE
refactor(bench): 対局ループを runMatch に抽出 [stack 2/3]

### DIFF
--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -17,8 +17,7 @@ import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 
 import type { CpuDifficulty } from "../src/types/cpu.ts";
-import type { Position } from "../src/types/game.ts";
-import type { SPRTConfig, WDLCount } from "./types/ab.ts";
+import type { SPRTConfig } from "./types/ab.ts";
 import type {
   CommitBenchResult,
   CommitGameResult,
@@ -26,12 +25,13 @@ import type {
   PlayerPerformanceStats,
 } from "./types/commit-bench.ts";
 
-import {
-  getAllJushuNames,
-  getJushuPositions,
-} from "../src/logic/cpu/opening.ts";
-import { runCommitGame } from "./commit-game-runner.ts";
 import { estimateEloDiff, formatEloDiff } from "./lib/eloDiff.ts";
+import {
+  buildJushuTasks,
+  createBridgeWorker,
+  gamesPerSet as computeGamesPerSet,
+  runMatch,
+} from "./lib/match.ts";
 import { DEFAULT_SPRT_CONFIG, formatSPRT, updateSPRT } from "./lib/sprt.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -289,10 +289,6 @@ function aggregateSearchStats(
 // ステータス表示
 // ============================================================================
 
-function writeStatus(message: string): void {
-  process.stdout.write(`\r${message.padEnd(100)}`);
-}
-
 function clearStatus(): void {
   process.stdout.write(`\r${" ".repeat(100)}\r`);
 }
@@ -422,60 +418,6 @@ function removeWorktree(worktreePath: string): void {
 }
 
 // ============================================================================
-// Bridge Worker管理
-// ============================================================================
-
-function createBridgeWorker(
-  worktreePath: string,
-  difficulty: string,
-  randomFactor?: number,
-): Promise<Worker> {
-  return new Promise<Worker>((resolve, reject) => {
-    const workerPath = path.join(__dirname, "cpu-bridge-worker.ts");
-
-    const customParams =
-      randomFactor === undefined ? undefined : { randomFactor };
-
-    const worker = new Worker(workerPath, {
-      workerData: { worktreePath, difficulty, customParams },
-      execArgv: [
-        "--experimental-strip-types",
-        "--disable-warning=ExperimentalWarning",
-        "--import",
-        path.join(worktreePath, "scripts", "register-loader.mjs"),
-      ],
-    });
-
-    const initTimeout = setTimeout(() => {
-      worker.terminate();
-      reject(
-        new Error(`Bridge worker initialization timed out for ${worktreePath}`),
-      );
-    }, 60000);
-
-    const readyHandler = (msg: unknown): void => {
-      if (
-        typeof msg === "object" &&
-        msg !== null &&
-        "ready" in msg &&
-        (msg as { ready: unknown }).ready === true
-      ) {
-        clearTimeout(initTimeout);
-        worker.off("message", readyHandler);
-        resolve(worker);
-      }
-    };
-
-    worker.on("message", readyHandler);
-
-    worker.on("error", (err) => {
-      clearTimeout(initTimeout);
-      reject(err);
-    });
-  });
-}
-
-// ============================================================================
 // メイン処理
 // ============================================================================
 
@@ -496,8 +438,7 @@ async function main(): Promise<void> {
       }
     : null;
 
-  const jushuNames = getAllJushuNames();
-  const gamesPerSet = jushuNames.length * 2; // 26珠型 × 2色
+  const gamesPerSet = computeGamesPerSet(); // 全珠型 × 2色
   const totalGames = options.sets * gamesPerSet;
 
   console.log(`\n=== コミット間CPU強度比較ベンチマーク ===`);
@@ -559,20 +500,22 @@ async function main(): Promise<void> {
     worktreePathB = createWorktree(commitB.sha, "B");
 
     // bridge workerを起動（--jobs 組のペアを並列初期化）
+    const workerPath = path.join(__dirname, "cpu-bridge-worker.ts");
+    const makeWorker = (worktreePath: string): Promise<Worker> =>
+      createBridgeWorker({
+        workerPath,
+        loaderPath: path.join(worktreePath, "scripts", "register-loader.mjs"),
+        worktreePath,
+        difficulty: options.difficulty,
+        randomFactor: options.randomFactor,
+      });
+
     console.log(`Bridge workerを初期化中... (${options.jobs}並列)`);
     const createdPairs = await Promise.all(
       Array.from({ length: options.jobs }, async () => {
         const [a, b] = await Promise.all([
-          createBridgeWorker(
-            worktreePathA!,
-            options.difficulty,
-            options.randomFactor,
-          ),
-          createBridgeWorker(
-            worktreePathB!,
-            options.difficulty,
-            options.randomFactor,
-          ),
+          makeWorker(worktreePathA!),
+          makeWorker(worktreePathB!),
         ]);
         return { a, b };
       }),
@@ -580,172 +523,18 @@ async function main(): Promise<void> {
     pairs.push(...createdPairs);
     console.log("Bridge worker初期化完了\n");
 
-    // 珠型タスクリスト生成（フラット化）
-    interface CommitJushuTask {
-      jushuName: string;
-      positions: [Position, Position, Position];
-      isABlack: boolean;
-    }
-    const jushuTasks: CommitJushuTask[] = [];
-    for (let set = 0; set < options.sets; set++) {
-      for (const jn of jushuNames) {
-        const pos = getJushuPositions(jn, true);
-        if (!pos) {
-          continue;
-        }
-        for (const ab of [true, false]) {
-          jushuTasks.push({ jushuName: jn, positions: pos, isABlack: ab });
-        }
-      }
-    }
-
-    // WDL集計（commitA視点）
-    const wdl: WDLCount = { wins: 0, draws: 0, losses: 0 };
-    const games: CommitGameResult[] = [];
-    let completedGames = 0;
-
-    // 累積性能統計アキュムレータ
-    const cumAcc = {
-      A: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
-      B: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
-    };
-
-    // 珠型タスクを --jobs 組の worker ペアで並列消化する。
-    // ゲームはターン制で実質1コアしか使わないため、複数ペア同時対局で遊休コアを活用。
-    // 結果処理（WDL/統計/ステータス/SPRT）は await を挟まず同期実行されるため競合しない。
-    let nextTask = 0;
-    let stop = false;
-    const runPair = async (pair: { a: Worker; b: Worker }): Promise<void> => {
-      while (!stop) {
-        const taskIdx = nextTask;
-        nextTask += 1;
-        if (taskIdx >= jushuTasks.length) {
-          break;
-        }
-        const { jushuName, positions, isABlack } = jushuTasks[taskIdx]!;
-        const result = await runCommitGame(pair.a, pair.b, isABlack, {
-          verbose: options.verbose,
-          moveTimeoutMs: 30000,
-          openingMoves: positions,
-        });
-        if (stop) {
-          break;
-        }
-
-        // WDL更新（commitA = playerA 視点）
-        if (result.winner === "draw") {
-          wdl.draws++;
-        } else if (result.winner === "A") {
-          wdl.wins++;
-        } else {
-          wdl.losses++;
-        }
-
-        games.push({ ...result, jushuName });
-
-        completedGames++;
-
-        // 初回ゲーム後のサニティチェック
-        if (completedGames === 1) {
-          const avgTime =
-            result.moveHistory.reduce(
-              (s: number, m: { time: number }) => s + m.time,
-              0,
-            ) / result.moveHistory.length;
-          const maxTime = Math.max(
-            ...result.moveHistory.map((m: { time: number }) => m.time),
-          );
-          console.log(`\n[サニティチェック] 初回ゲーム完了`);
-          console.log(
-            `  手数: ${result.moves} | 勝者: ${result.winner} | 理由: ${result.reason}`,
-          );
-          console.log(
-            `  平均思考時間: ${Math.round(avgTime)}ms | 最大: ${Math.round(maxTime)}ms`,
-          );
-          console.log(`  duration: ${Math.round(result.duration)}ms`);
-          if (avgTime < 1) {
-            console.warn(
-              "  ⚠ 平均思考時間が1ms未満 — エンジンが正しくロードされていない可能性",
-            );
-          }
-        }
-
-        // この局のA/B統計を集計し、累積にも加算
-        const gameAcc = {
-          A: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
-          B: { depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 },
-        };
-        for (let i = 0; i < result.moveHistory.length; i++) {
-          const move = result.moveHistory[i]!;
-          if (move.isOpening) {
-            continue;
-          }
-          const isBlackMove = i % 2 === 0;
-          const player =
-            (isBlackMove && isABlack) || (!isBlackMove && !isABlack)
-              ? "A"
-              : "B";
-          const ga = gameAcc[player];
-          const ca = cumAcc[player];
-          if (move.depth !== undefined) {
-            ga.depthSum += move.depth;
-            ga.maxDepth = Math.max(ga.maxDepth, move.depth);
-            ca.depthSum += move.depth;
-            ca.maxDepth = Math.max(ca.maxDepth, move.depth);
-          }
-          ga.timeSum += move.time;
-          ga.count++;
-          ca.timeSum += move.time;
-          ca.count++;
-        }
-
-        // ステータス表示
-        const elapsed = ((performance.now() - startTime) / 1000).toFixed(0);
-        const elo = estimateEloDiff(wdl);
-        let statusMsg = `[${elapsed}s] ${completedGames}/${totalGames} ${jushuName} ${isABlack ? "A黒" : "A白"} +${wdl.wins}=${wdl.draws}-${wdl.losses} Elo:${elo.eloDiff > 0 ? "+" : ""}${elo.eloDiff}`;
-
-        if (sprtConfig) {
-          const sprt = updateSPRT(wdl, sprtConfig);
-          statusMsg += ` LLR:${sprt.llr.toFixed(2)}`;
-          if (sprt.decision !== "continue") {
-            writeStatus(statusMsg);
-            clearStatus();
-            console.log(
-              `SPRT判定: ${sprt.decision} (${completedGames}局目で停止)`,
-            );
-            stop = true;
-          }
-        }
-
-        writeStatus(statusMsg);
-
-        // 1局ごとの性能統計（改行で表示）
-        const fmtDepth = (a: {
-          depthSum: number;
-          timeSum: number;
-          count: number;
-        }): string =>
-          a.count > 0
-            ? `d=${(a.depthSum / a.count).toFixed(1)} t=${Math.round(a.timeSum / a.count)}ms`
-            : "n/a";
-        const fmtCum = (a: {
-          depthSum: number;
-          count: number;
-          maxDepth: number;
-          timeSum: number;
-        }): string =>
-          a.count > 0
-            ? `d=${(a.depthSum / a.count).toFixed(2)} max=${a.maxDepth} t=${Math.round(a.timeSum / a.count)}ms`
-            : "n/a";
-        console.log(
-          `\n  局: A[${fmtDepth(gameAcc.A)}] B[${fmtDepth(gameAcc.B)}] | 累計: A[${fmtCum(cumAcc.A)}] B[${fmtCum(cumAcc.B)}]`,
-        );
-      }
-    };
-
-    await Promise.all(pairs.map((p) => runPair(p)));
-
-    clearStatus();
+    // 珠型タスクを生成し、共有の対局ループ（runMatch）で消化する。
+    // commit-bench は recreatePair を渡さない＝従来どおりエラーは伝播（出力同一）。
+    const tasks = buildJushuTasks(options.sets);
+    const { wdl, games, completedGames } = await runMatch({
+      pairs,
+      tasks,
+      totalGames,
+      sprtConfig,
+      moveTimeoutMs: 30000,
+      verbose: options.verbose,
+      startTime,
+    });
 
     const elapsedSeconds = (performance.now() - startTime) / 1000;
 

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -1,0 +1,366 @@
+/**
+ * 対局オーケストレーション共有モジュール。
+ *
+ * commit-bench（worktree 比較）と weight-bench（ローカル wasm + 重み注入）の
+ * 両方で使う「珠型タスク生成 / bridge worker 生成 / ワークスティール並列ループ＋
+ * WDL・Elo・SPRT・状態表示」を集約する。両ベンチの差は
+ *   (1) worker ペアの作り方（worktree vs ローカル wasm + evalWeights）
+ *   (2) 結果の保存形式・ラベル
+ * だけ。対局ループ本体は本モジュールに一本化（DRY）。
+ *
+ * Elo/WDL は **A=playerA 視点**（commitA / baseline）。
+ */
+import { Worker } from "node:worker_threads";
+
+import type { Position } from "../../src/types/game.ts";
+import type { SPRTConfig, WDLCount } from "../types/ab.ts";
+import type { CommitGameResult } from "../types/commit-bench.ts";
+
+import {
+  getAllJushuNames,
+  getJushuPositions,
+} from "../../src/logic/cpu/opening.ts";
+import { runCommitGame } from "../commit-game-runner.ts";
+import { estimateEloDiff } from "./eloDiff.ts";
+import { updateSPRT } from "./sprt.ts";
+
+/** 1局分の珠型タスク（開始局面＋先後割当）。 */
+export interface MatchTask {
+  jushuName: string;
+  positions: [Position, Position, Position];
+  isABlack: boolean;
+}
+
+/** runMatch の結果（caller が後処理＝性能統計や保存を行う）。 */
+export interface RunMatchResult {
+  wdl: WDLCount;
+  games: CommitGameResult[];
+  completedGames: number;
+  stoppedBySprt: boolean;
+}
+
+export interface RunMatchParams {
+  /** A/B bridge worker のペア群（--jobs 組）。生成方法は caller が決める。 */
+  pairs: { a: Worker; b: Worker }[];
+  /** 消化する珠型タスク列（buildJushuTasks 等で生成）。 */
+  tasks: MatchTask[];
+  /** 進捗表示の分母。 */
+  totalGames: number;
+  sprtConfig: SPRTConfig | null;
+  moveTimeoutMs: number;
+  verbose: boolean;
+  /** 経過時間表示の基点（performance.now()）。 */
+  startTime: number;
+  /**
+   * 1局隔離用のペア再生成関数（weight-bench 用）。
+   * 指定すると runCommitGame が throw してもその局を破棄し worker を再生成して続行。
+   * **未指定なら旧挙動**（エラーを伝播＝commit-bench を出力同一に保つ）。
+   */
+  recreatePair?: (idx: number) => Promise<{ a: Worker; b: Worker }>;
+}
+
+// ============================================================================
+// 珠型タスク生成
+// ============================================================================
+
+/** sets セット分の珠型タスク（各セット = 全珠型 × 2色）をフラット化して返す。 */
+export function buildJushuTasks(sets: number): MatchTask[] {
+  const jushuNames = getAllJushuNames();
+  const tasks: MatchTask[] = [];
+  for (let set = 0; set < sets; set++) {
+    for (const jn of jushuNames) {
+      const pos = getJushuPositions(jn, true);
+      if (!pos) {
+        continue;
+      }
+      for (const ab of [true, false]) {
+        tasks.push({ jushuName: jn, positions: pos, isABlack: ab });
+      }
+    }
+  }
+  return tasks;
+}
+
+/** 1セットあたりの局数（全珠型 × 2色）。 */
+export function gamesPerSet(): number {
+  return getAllJushuNames().length * 2;
+}
+
+// ============================================================================
+// Bridge Worker 生成
+// ============================================================================
+
+export interface CreateBridgeWorkerParams {
+  /** cpu-bridge-worker.ts の絶対パス。 */
+  workerPath: string;
+  /** worker の register-loader.mjs の絶対パス（worktree or ローカル）。 */
+  loaderPath: string;
+  /** CPU 実装を読む worktree（ローカル比較ならリポジトリルート）。 */
+  worktreePath: string;
+  difficulty: string;
+  randomFactor?: number;
+  /** eval 形系重みの実行時注入（weight-bench 用。commit-bench は未使用）。 */
+  evalWeights?: Record<string, number>;
+}
+
+/** bridge worker を起動し、ready 通知を待って resolve する。 */
+export function createBridgeWorker(
+  params: CreateBridgeWorkerParams,
+): Promise<Worker> {
+  const {
+    workerPath,
+    loaderPath,
+    worktreePath,
+    difficulty,
+    randomFactor,
+    evalWeights,
+  } = params;
+  return new Promise<Worker>((resolve, reject) => {
+    const customParams =
+      randomFactor === undefined ? undefined : { randomFactor };
+
+    const worker = new Worker(workerPath, {
+      workerData: { worktreePath, difficulty, customParams, evalWeights },
+      execArgv: [
+        "--experimental-strip-types",
+        "--disable-warning=ExperimentalWarning",
+        "--import",
+        loaderPath,
+      ],
+    });
+
+    const initTimeout = setTimeout(() => {
+      worker.terminate();
+      reject(
+        new Error(`Bridge worker initialization timed out for ${worktreePath}`),
+      );
+    }, 60000);
+
+    const readyHandler = (msg: unknown): void => {
+      if (
+        typeof msg === "object" &&
+        msg !== null &&
+        "ready" in msg &&
+        (msg as { ready: unknown }).ready === true
+      ) {
+        clearTimeout(initTimeout);
+        worker.off("message", readyHandler);
+        resolve(worker);
+      }
+    };
+
+    worker.on("message", readyHandler);
+
+    worker.on("error", (err) => {
+      clearTimeout(initTimeout);
+      reject(err);
+    });
+  });
+}
+
+// ============================================================================
+// 状態表示
+// ============================================================================
+
+function writeStatus(message: string): void {
+  process.stdout.write(`\r${message.padEnd(100)}`);
+}
+
+function clearStatus(): void {
+  process.stdout.write(`\r${" ".repeat(100)}\r`);
+}
+
+// ============================================================================
+// 対局ループ（ワークスティール並列）
+// ============================================================================
+
+interface Acc {
+  depthSum: number;
+  timeSum: number;
+  count: number;
+  maxDepth: number;
+}
+const newAcc = (): Acc => ({ depthSum: 0, timeSum: 0, count: 0, maxDepth: 0 });
+
+/**
+ * 珠型タスクを pairs（--jobs 組）でワークスティール並列消化する。
+ * 結果処理（WDL/統計/ステータス/SPRT）は await を挟まず同期実行＝競合しない。
+ *
+ * **1局隔離**: runCommitGame が throw（move timeout/worker死）しても、その局だけ
+ * 「敗北扱い」で記録して残りを続行する。ハングした worker は terminate→再生成し、
+ * 実効並列度を保つ。1局のハングで全体が落ちないようにする（weight-bench の必須要件）。
+ */
+export async function runMatch(
+  params: RunMatchParams,
+): Promise<RunMatchResult> {
+  const {
+    pairs,
+    tasks,
+    totalGames,
+    sprtConfig,
+    moveTimeoutMs,
+    verbose,
+    startTime,
+    recreatePair,
+  } = params;
+
+  const wdl: WDLCount = { wins: 0, draws: 0, losses: 0 };
+  const games: CommitGameResult[] = [];
+  let completedGames = 0;
+  let stoppedBySprt = false;
+
+  const cumAcc = { A: newAcc(), B: newAcc() };
+
+  let nextTask = 0;
+  let stop = false;
+
+  const runPair = async (
+    pairIdx: number,
+    pairRef: { a: Worker; b: Worker },
+  ): Promise<void> => {
+    let pair = pairRef;
+    while (!stop) {
+      const taskIdx = nextTask;
+      nextTask += 1;
+      if (taskIdx >= tasks.length) {
+        break;
+      }
+      const { jushuName, positions, isABlack } = tasks[taskIdx]!;
+
+      let result: CommitGameResult | null = null;
+      try {
+        const r = await runCommitGame(pair.a, pair.b, isABlack, {
+          verbose,
+          moveTimeoutMs,
+          openingMoves: positions,
+        });
+        result = { ...r, jushuName };
+      } catch (err: unknown) {
+        // recreatePair 未指定なら旧挙動でエラー伝播（commit-bench 出力同一）。
+        if (!recreatePair) {
+          throw err;
+        }
+        // 1局隔離: ハング/worker死。当該局は破棄し worker を再生成して続行。
+        const msg = err instanceof Error ? err.message : String(err);
+        clearStatus();
+        console.warn(
+          `\n⚠ 局 ${jushuName}(${isABlack ? "A黒" : "A白"}) を破棄: ${msg}`,
+        );
+        try {
+          pair.a.terminate();
+          pair.b.terminate();
+          pair = await recreatePair(pairIdx);
+          pairs[pairIdx] = pair;
+        } catch (reErr: unknown) {
+          const m = reErr instanceof Error ? reErr.message : String(reErr);
+          console.error(`worker 再生成に失敗（このペアを終了）: ${m}`);
+          break;
+        }
+        continue;
+      }
+      if (stop || result === null) {
+        break;
+      }
+
+      // WDL更新（A=playerA 視点）
+      if (result.winner === "draw") {
+        wdl.draws++;
+      } else if (result.winner === "A") {
+        wdl.wins++;
+      } else {
+        wdl.losses++;
+      }
+
+      games.push(result);
+      completedGames++;
+
+      // 初回ゲーム後のサニティチェック
+      if (completedGames === 1) {
+        const avgTime =
+          result.moveHistory.reduce(
+            (s: number, m: { time: number }) => s + m.time,
+            0,
+          ) / result.moveHistory.length;
+        const maxTime = Math.max(
+          ...result.moveHistory.map((m: { time: number }) => m.time),
+        );
+        console.log(`\n[サニティチェック] 初回ゲーム完了`);
+        console.log(
+          `  手数: ${result.moves} | 勝者: ${result.winner} | 理由: ${result.reason}`,
+        );
+        console.log(
+          `  平均思考時間: ${Math.round(avgTime)}ms | 最大: ${Math.round(maxTime)}ms`,
+        );
+        console.log(`  duration: ${Math.round(result.duration)}ms`);
+        if (avgTime < 1) {
+          console.warn(
+            "  ⚠ 平均思考時間が1ms未満 — エンジンが正しくロードされていない可能性",
+          );
+        }
+      }
+
+      // この局の A/B 統計を集計し、累積にも加算
+      const gameAcc = { A: newAcc(), B: newAcc() };
+      for (let i = 0; i < result.moveHistory.length; i++) {
+        const move = result.moveHistory[i]!;
+        if (move.isOpening) {
+          continue;
+        }
+        const isBlackMove = i % 2 === 0;
+        const player =
+          (isBlackMove && isABlack) || (!isBlackMove && !isABlack) ? "A" : "B";
+        const ga = gameAcc[player];
+        const ca = cumAcc[player];
+        if (move.depth !== undefined) {
+          ga.depthSum += move.depth;
+          ga.maxDepth = Math.max(ga.maxDepth, move.depth);
+          ca.depthSum += move.depth;
+          ca.maxDepth = Math.max(ca.maxDepth, move.depth);
+        }
+        ga.timeSum += move.time;
+        ga.count++;
+        ca.timeSum += move.time;
+        ca.count++;
+      }
+
+      // ステータス表示
+      const elapsed = ((performance.now() - startTime) / 1000).toFixed(0);
+      const elo = estimateEloDiff(wdl);
+      let statusMsg = `[${elapsed}s] ${completedGames}/${totalGames} ${jushuName} ${isABlack ? "A黒" : "A白"} +${wdl.wins}=${wdl.draws}-${wdl.losses} Elo:${elo.eloDiff > 0 ? "+" : ""}${elo.eloDiff}`;
+
+      if (sprtConfig) {
+        const sprt = updateSPRT(wdl, sprtConfig);
+        statusMsg += ` LLR:${sprt.llr.toFixed(2)}`;
+        if (sprt.decision !== "continue") {
+          writeStatus(statusMsg);
+          clearStatus();
+          console.log(
+            `SPRT判定: ${sprt.decision} (${completedGames}局目で停止)`,
+          );
+          stop = true;
+          stoppedBySprt = true;
+        }
+      }
+
+      writeStatus(statusMsg);
+
+      const fmtDepth = (a: Acc): string =>
+        a.count > 0
+          ? `d=${(a.depthSum / a.count).toFixed(1)} t=${Math.round(a.timeSum / a.count)}ms`
+          : "n/a";
+      const fmtCum = (a: Acc): string =>
+        a.count > 0
+          ? `d=${(a.depthSum / a.count).toFixed(2)} max=${a.maxDepth} t=${Math.round(a.timeSum / a.count)}ms`
+          : "n/a";
+      console.log(
+        `\n  局: A[${fmtDepth(gameAcc.A)}] B[${fmtDepth(gameAcc.B)}] | 累計: A[${fmtCum(cumAcc.A)}] B[${fmtCum(cumAcc.B)}]`,
+      );
+    }
+  };
+
+  await Promise.all(pairs.map((p, idx) => runPair(idx, p)));
+
+  clearStatus();
+
+  return { wdl, games, completedGames, stoppedBySprt };
+}


### PR DESCRIPTION
## 目的
commit-bench の `main()` に埋もれていた対局オーケストレーションを `scripts/lib/match.ts` へ抽出し、後続の weight-bench(stack 3/3)と共有する（DRY）。**出力同一リファクタ**。

## 変更
- `scripts/lib/match.ts`(新): `buildJushuTasks` / `createBridgeWorker`(evalWeights/loaderPath 引数化) / `runMatch`(ワークスティール並列+WDL/Elo/SPRT/状態表示)。
- `commit-bench.ts`: 上記を使う形に。**`recreatePair` を渡さない＝エラー伝播の旧挙動を維持(出力同一)**。
- weight-bench 用に **1局隔離**(try/catch+worker再生成)を `recreatePair` 指定時のみ有効化。

## 検証
- oxlint 0/0、match.ts ロード OK。commit-bench は recreatePair 未指定で従来挙動。

> ⚠️ base は `feat/eval-weight-injection`(stack 1/3)。1/3 マージ後に main へリベース。

🤖 Generated with [Claude Code](https://claude.com/claude-code)