### PR TITLE
feat(bench): weight-bench — リビルド不要の eval 重み A/B ベンチ [stack 3/3]

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "analyze:deep": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/analyze-bench-deep.ts",
     "debug:vcf": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/debug-vcf-false-positive.ts",
     "commit:bench": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/commit-bench.ts",
+    "weight:bench": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/weight-bench.ts",
     "build:wasm": "cd zig && zig build",
     "profile:review": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/profile-review.ts"
   },

--- a/scripts/cpu-bridge-worker.ts
+++ b/scripts/cpu-bridge-worker.ts
@@ -25,6 +25,8 @@ import { parentPort, workerData } from "node:worker_threads";
 import type { DifficultyParams } from "../src/types/cpu.ts";
 import type { BoardState, Position } from "../src/types/game.ts";
 
+import { EVAL_PARAM_IDS } from "./lib/evalParams.ts";
+
 // ============================================================================
 // 型定義
 // ============================================================================
@@ -33,6 +35,12 @@ interface BridgeWorkerData {
   worktreePath: string;
   difficulty: string;
   customParams?: Partial<DifficultyParams>;
+  /**
+   * eval 形系重みの実行時注入（weight-bench 用）。キー名は EVAL_PARAM_IDS。
+   * wasm が setEvalParam を export していれば適用、無ければ warn してスキップ
+   * （setEvalParam 非対応の古い commit を読む commit-bench と後方互換）。
+   */
+  evalWeights?: Record<string, number>;
 }
 
 interface MoveRequest {
@@ -121,6 +129,10 @@ interface WasmModuleExports {
   getResultBuffer: () => number;
   getStatsBuffer?: () => number;
   ttClear: () => void;
+  // eval 重み実行時注入（新しい wasm のみ。古い commit には存在しない＝optional）
+  setEvalParam?: (id: number, value: number) => void;
+  getEvalParam?: (id: number) => number;
+  resetEvalParams?: () => void;
 }
 
 /** WASM探索のハンドラ */
@@ -396,6 +408,38 @@ function callTsFindBestMove(
   );
 }
 
+/**
+ * eval 形系重みを wasm に注入する（純粋関数）。
+ * setEvalParam export があれば resetEvalParams→各 setEvalParam を適用、無ければ
+ * warn してスキップ（setEvalParam 非対応の古い commit を読む commit-bench と後方互換）。
+ * baseline 側（weights 空）でも resetEvalParams を呼びクリーンな既定を保証する。
+ */
+function applyEvalWeights(
+  wasm: WasmModuleExports,
+  weights: Record<string, number> | undefined,
+): void {
+  if (
+    typeof wasm.setEvalParam !== "function" ||
+    typeof wasm.resetEvalParams !== "function"
+  ) {
+    if (weights && Object.keys(weights).length > 0) {
+      console.warn(
+        "[cpu-bridge-worker] この wasm は setEvalParam 非対応。evalWeights を無視します。",
+      );
+    }
+    return;
+  }
+  wasm.resetEvalParams();
+  for (const [name, value] of Object.entries(weights ?? {})) {
+    const id = (EVAL_PARAM_IDS as Record<string, number>)[name];
+    if (id === undefined) {
+      console.warn(`[cpu-bridge-worker] 不明な eval 重みキー: ${name}（無視）`);
+      continue;
+    }
+    wasm.setEvalParam(id, value);
+  }
+}
+
 async function main(): Promise<void> {
   const { worktreePath } = data;
 
@@ -409,6 +453,8 @@ async function main(): Promise<void> {
 
   if (wasm) {
     wasmHandler = createWasmSearchHandler(wasm);
+    // eval 形系重みを注入（baseline は weights 空＝reset のみでクリーン既定）
+    applyEvalWeights(wasm, data.evalWeights);
     console.log(`[cpu-bridge-worker] WASM engine loaded for ${worktreePath}`);
   } else {
     tsFindBestMove = await loadTsCpuFromWorktree(worktreePath);

--- a/scripts/lib/evalParams.ts
+++ b/scripts/lib/evalParams.ts
@@ -36,9 +36,13 @@ export const EVAL_PARAM_DEFAULTS: Record<EvalParamName, number> = {
   LINE_POTENTIAL_4: 60,
 };
 
-/** "OPEN_TWO:25,OPEN_THREE:600" 形式をパースし [id, value][] に。未知キーは例外。 */
-export function parseWeightOverrides(str: string): [number, number][] {
-  const out: [number, number][] = [];
+/**
+ * "OPEN_TWO:25,OPEN_THREE:600" 形式を **名前キーの Record** にパースする。
+ * キー名は EVAL_PARAM_IDS で検証（未知キー/非数値は例外）。
+ * 名前→id 変換は setEvalParam を呼ぶ箇所（bridge worker 等）で行う。
+ */
+export function parseWeightOverrides(str: string): Record<string, number> {
+  const out: Record<string, number> = {};
   for (const pair of str.split(",")) {
     const trimmed = pair.trim();
     if (!trimmed) {
@@ -48,17 +52,17 @@ export function parseWeightOverrides(str: string): [number, number][] {
     if (!k || v === undefined) {
       continue;
     }
-    const id = (EVAL_PARAM_IDS as Record<string, number>)[k.trim()];
-    if (id === undefined) {
+    const name = k.trim();
+    if (!(name in EVAL_PARAM_IDS)) {
       throw new Error(
-        `不明な eval 重みキー "${k.trim()}"。有効: ${Object.keys(EVAL_PARAM_IDS).join(", ")}`,
+        `不明な eval 重みキー "${name}"。有効: ${Object.keys(EVAL_PARAM_IDS).join(", ")}`,
       );
     }
     const num = Number(v.trim());
     if (Number.isNaN(num)) {
-      throw new Error(`"${k.trim()}" の値が数値でない: "${v}"`);
+      throw new Error(`"${name}" の値が数値でない: "${v}"`);
     }
-    out.push([id, num]);
+    out[name] = num;
   }
   return out;
 }

--- a/scripts/weight-bench.ts
+++ b/scripts/weight-bench.ts
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * eval 形系重み A/B ベンチマーク（リビルド不要・単一ビルド）
+ *
+ * ローカルの cpu-engine.wasm を両サイドで使い、side B にだけ --weights を
+ * setEvalParam で実行時注入して対局。重みごとの worktree リビルドが要らないため
+ * commit-bench より桁違いに速く重みを振れる。
+ *
+ *   pnpm weight:bench --weights=OPEN_THREE:600 --sets=4 --jobs=4 --randomFactor=0.02
+ *   pnpm weight:bench --sets=1                    # null test (A=B baseline)
+ *
+ * Elo/WDL は **A=baseline 視点**（正＝baseline が強い＝変種が弱い）。
+ * 前提: scripts/lib/evalParams.ts の setEvalParam を export した wasm
+ *       （feat/eval-weight-injection 以降）。古い wasm では重みが無視される。
+ */
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+
+import type { CpuDifficulty } from "../src/types/cpu.ts";
+import type { SPRTConfig } from "./types/ab.ts";
+
+import { estimateEloDiff, formatEloDiff } from "./lib/eloDiff.ts";
+import { parseWeightOverrides } from "./lib/evalParams.ts";
+import {
+  buildJushuTasks,
+  createBridgeWorker,
+  gamesPerSet as computeGamesPerSet,
+  runMatch,
+} from "./lib/match.ts";
+import { DEFAULT_SPRT_CONFIG, formatSPRT, updateSPRT } from "./lib/sprt.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const OUTPUT_DIR = path.join(PROJECT_ROOT, "bench-results");
+const WASM_PATH = path.join(
+  PROJECT_ROOT,
+  "zig",
+  "zig-out",
+  "bin",
+  "cpu-engine.wasm",
+);
+const ZIG_SRC_DIR = path.join(PROJECT_ROOT, "zig", "src");
+
+interface CliOptions {
+  weights: Record<string, number>;
+  weightsRaw: string;
+  sets: number;
+  difficulty: CpuDifficulty;
+  randomFactor?: number;
+  jobs: number;
+  moveTimeoutMs: number;
+  useSPRT: boolean;
+  sprtElo0: number;
+  sprtElo1: number;
+  verbose: boolean;
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const options: CliOptions = {
+    weights: {},
+    weightsRaw: "",
+    sets: 1,
+    difficulty: "hard",
+    jobs: 1,
+    moveTimeoutMs: 120000,
+    useSPRT: false,
+    sprtElo0: DEFAULT_SPRT_CONFIG.elo0,
+    sprtElo1: DEFAULT_SPRT_CONFIG.elo1,
+    verbose: false,
+  };
+
+  for (const arg of args) {
+    if (arg.startsWith("--weights=")) {
+      options.weightsRaw = arg.slice("--weights=".length);
+      options.weights = parseWeightOverrides(options.weightsRaw);
+    } else if (arg.startsWith("--sets=")) {
+      const v = parseInt(arg.slice("--sets=".length), 10);
+      if (!isNaN(v) && v > 0) {
+        options.sets = v;
+      }
+    } else if (arg.startsWith("--difficulty=")) {
+      const v = arg.slice("--difficulty=".length);
+      if (["beginner", "easy", "medium", "hard"].includes(v)) {
+        options.difficulty = v as CpuDifficulty;
+      }
+    } else if (arg.startsWith("--randomFactor=")) {
+      const v = parseFloat(arg.slice("--randomFactor=".length));
+      if (!isNaN(v) && v >= 0 && v <= 1) {
+        options.randomFactor = v;
+      } else {
+        console.error(`Error: --randomFactor は 0〜1 で指定 (got: ${v})`);
+        process.exit(1);
+      }
+    } else if (arg.startsWith("--jobs=")) {
+      const v = parseInt(arg.slice("--jobs=".length), 10);
+      if (!isNaN(v) && v > 0) {
+        options.jobs = v;
+      }
+    } else if (arg.startsWith("--moveTimeoutMs=")) {
+      const v = parseInt(arg.slice("--moveTimeoutMs=".length), 10);
+      if (!isNaN(v) && v > 0) {
+        options.moveTimeoutMs = v;
+      }
+    } else if (arg === "--sprt") {
+      options.useSPRT = true;
+    } else if (arg.startsWith("--elo0=")) {
+      options.sprtElo0 = parseFloat(arg.slice("--elo0=".length));
+      options.useSPRT = true;
+    } else if (arg.startsWith("--elo1=")) {
+      options.sprtElo1 = parseFloat(arg.slice("--elo1=".length));
+      options.useSPRT = true;
+    } else if (arg === "--verbose" || arg === "-v") {
+      options.verbose = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      console.error(`Error: 不明な引数: ${arg}`);
+      process.exit(1);
+    }
+  }
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`
+eval 形系重み A/B ベンチマーク（リビルド不要）
+
+Usage:
+  pnpm weight:bench [options]
+
+Options:
+  --weights=<K:V,...>   side B に注入する重み (例: "OPEN_THREE:600,OPEN_TWO:25")
+  --sets=<n>            セット数 (1セット = 全珠型 × 2色, default: 1)
+  --difficulty=<d>      beginner|easy|medium|hard (default: hard)
+  --randomFactor=<n>    探索ゆらぎ 0〜1 (default: なし)
+  --jobs=<n>            同時対局ペア数 (default: 1)
+  --moveTimeoutMs=<n>   1手のタイムアウト (default: 120000)
+  --sprt / --elo0 / --elo1
+  --verbose, -v
+  --help, -h
+
+Examples:
+  pnpm weight:bench --weights=OPEN_THREE:600 --sets=4 --jobs=4 --randomFactor=0.02
+  pnpm weight:bench --sets=1            # null test (A=B baseline, Elo≈0)
+`);
+}
+
+/**
+ * wasm が最新ソースより古ければビルドし直す（古い wasm で測る事故を防ぐ）。
+ * ビルド時刻・サイズをログに出す。
+ */
+function ensureFreshWasm(): void {
+  const srcMtime = fs
+    .readdirSync(ZIG_SRC_DIR)
+    .filter((f) => f.endsWith(".zig"))
+    .reduce((mx, f) => {
+      const m = fs.statSync(path.join(ZIG_SRC_DIR, f)).mtimeMs;
+      return Math.max(mx, m);
+    }, 0);
+
+  const needBuild =
+    !fs.existsSync(WASM_PATH) || fs.statSync(WASM_PATH).mtimeMs < srcMtime;
+
+  if (needBuild) {
+    console.log(
+      "wasm がソースより古い/不在 → ビルドします (pnpm build:wasm)...",
+    );
+    execSync("pnpm build:wasm", { cwd: PROJECT_ROOT, stdio: "inherit" });
+  }
+  const st = fs.statSync(WASM_PATH);
+  console.log(
+    `wasm: ${WASM_PATH} (${(st.size / 1024 / 1024).toFixed(1)}MB, built ${st.mtime.toISOString()})`,
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+  const startTime = performance.now();
+
+  ensureFreshWasm();
+
+  const sprtConfig: SPRTConfig | null = options.useSPRT
+    ? {
+        elo0: options.sprtElo0,
+        elo1: options.sprtElo1,
+        alpha: DEFAULT_SPRT_CONFIG.alpha,
+        beta: DEFAULT_SPRT_CONFIG.beta,
+      }
+    : null;
+
+  const gamesPerSet = computeGamesPerSet();
+  const totalGames = options.sets * gamesPerSet;
+  const isNullTest = Object.keys(options.weights).length === 0;
+
+  console.log(`\n=== eval 形系重み A/B ベンチマーク ===`);
+  console.log(`baseline(A): 既定重み`);
+  console.log(
+    `variant(B): ${isNullTest ? "既定重み — null test" : JSON.stringify(options.weights)}`,
+  );
+  console.log(
+    `難易度: ${options.difficulty}${options.randomFactor === undefined ? "" : ` (randomFactor=${options.randomFactor})`}`,
+  );
+  console.log(
+    `セット数: ${options.sets} (${gamesPerSet}局/セット, 計${totalGames}局) jobs=${options.jobs}`,
+  );
+  console.log();
+
+  const workerPath = path.join(__dirname, "cpu-bridge-worker.ts");
+  const loaderPath = path.join(__dirname, "register-loader.mjs");
+  const makeWorker = (evalWeights: Record<string, number>): Promise<Worker> =>
+    createBridgeWorker({
+      workerPath,
+      loaderPath,
+      worktreePath: PROJECT_ROOT,
+      difficulty: options.difficulty,
+      randomFactor: options.randomFactor,
+      evalWeights,
+    });
+  // A=baseline(空), B=variant(weights)
+  const makePair = async (): Promise<{ a: Worker; b: Worker }> => {
+    const [a, b] = await Promise.all([
+      makeWorker({}),
+      makeWorker(options.weights),
+    ]);
+    return { a, b };
+  };
+
+  const pairs: { a: Worker; b: Worker }[] = [];
+  const cleanup = (): void => {
+    for (const p of pairs) {
+      p.a.terminate();
+      p.b.terminate();
+    }
+    pairs.length = 0;
+  };
+  process.on("SIGINT", () => {
+    console.log("\n中断。クリーンアップ中...");
+    cleanup();
+    process.exit(130);
+  });
+
+  try {
+    console.log(`Bridge worker を初期化中... (${options.jobs}並列)`);
+    const created = await Promise.all(
+      Array.from({ length: options.jobs }, () => makePair()),
+    );
+    pairs.push(...created);
+    console.log("初期化完了\n");
+
+    const tasks = buildJushuTasks(options.sets);
+    const { wdl, completedGames } = await runMatch({
+      pairs,
+      tasks,
+      totalGames,
+      sprtConfig,
+      moveTimeoutMs: options.moveTimeoutMs,
+      verbose: options.verbose,
+      startTime,
+      // 1局隔離: ハングした局は破棄しペアを再生成して続行
+      recreatePair: async (idx) => {
+        const fresh = await makePair();
+        pairs[idx] = fresh;
+        return fresh;
+      },
+    });
+
+    const elapsedSeconds = (performance.now() - startTime) / 1000;
+
+    console.log(`\n=== 結果 ===`);
+    console.log(
+      `variant(B): ${isNullTest ? "null test" : JSON.stringify(options.weights)}`,
+    );
+    console.log(`対局数: ${completedGames}`);
+    console.log(
+      `WDL (baseline=A 視点): +${wdl.wins} =${wdl.draws} -${wdl.losses}`,
+    );
+    const eloDiffResult = estimateEloDiff(wdl);
+    console.log(formatEloDiff(eloDiffResult));
+    console.log("(正Elo=baseline強い=変種が弱い / 負Elo=変種が強い)");
+
+    let sprtState = null;
+    if (sprtConfig) {
+      sprtState = updateSPRT(wdl, sprtConfig);
+      console.log(formatSPRT(sprtState, wdl));
+    }
+    console.log(`所要時間: ${elapsedSeconds.toFixed(1)}秒`);
+
+    if (!fs.existsSync(OUTPUT_DIR)) {
+      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+    }
+    const result = {
+      type: "weight-bench",
+      timestamp: new Date().toISOString(),
+      weights: options.weights,
+      config: {
+        difficulty: options.difficulty,
+        sets: options.sets,
+        gamesPerSet,
+        randomFactor: options.randomFactor,
+        sprt: sprtConfig,
+      },
+      totalGames: completedGames,
+      wdl,
+      eloDiff: eloDiffResult,
+      sprt: sprtState,
+      elapsedSeconds,
+    };
+    const ts = result.timestamp.replace(/[:.]/g, "-");
+    const outPath = path.join(OUTPUT_DIR, `weight-bench-${ts}.json`);
+    fs.writeFileSync(outPath, JSON.stringify(result, null, 2));
+    console.log(`\n結果を保存: ${outPath}`);
+  } finally {
+    cleanup();
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## 目的
ローカル wasm を両サイドで使い、side B にだけ `--weights` を `setEvalParam` で実行時注入して対局。**重みごとの worktree リビルドが不要**で commit-bench より桁違いに速く重みを振れる。これで Gate0 減方向プローブや今後の重みスイープを高速に回す。

## 変更
- `cpu-bridge-worker.ts`: `applyEvalWeights`(純粋関数)。setEvalParam export があれば reset→各 setEvalParam、無ければ warn してスキップ(古い commit と後方互換)。
- `weight-bench.ts`(新): A=baseline/B=variant、`runMatch`+1局隔離(moveTimeout 120s)、wasm 鮮度チェック、Elo(A=baseline視点)出力。
- `parseWeightOverrides` を名前キー Record に(名前→id 変換は worker 側)。
- `pnpm weight:bench` スクリプト追加。

## 検証
- 注入時: variant 表示=名前 / 不明キー warn なし=setEvalParam 実適用。
- **null test(A=B baseline): Elo 0 [-94.9, 94.9]** ＝ハーネス健全。

> ⚠️ base は `feat/eval-weight-runmatch`(stack 2/3)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)