### PR TITLE
fix(cpu): VCT活三受けに夏止め位置を含める（偽VCT成立の修正）

### DIFF
--- a/src/logic/cpu/search/threatMoves.ts
+++ b/src/logic/cpu/search/threatMoves.ts
@@ -10,6 +10,8 @@ import { isValidPosition } from "@/logic/renjuRules";
 
 import { DIRECTION_INDICES, DIRECTIONS } from "../core/constants";
 import { checkEnds, checkEndsForFour, countLine } from "../core/lineAnalysis";
+// 夏止め済み判定（受け点の基準と活三判定を一致させる SSoT）
+import { getOpenThreeDefensePositions } from "../evaluation/threatDetection";
 // #43 PR-3: 跳び四/三の図形判定を Zig アダプタへ委譲（patterns.ts 依存を断つ）。
 import { checkJumpFour, checkJumpThree } from "../wasm/patternsAdapter";
 
@@ -96,10 +98,16 @@ export function createsOpenThree(
     const [dr, dc] = direction;
 
     // 連続三をチェック
+    // 夏止め済み（両外側ブロックで活四にできない三）は脅威でないため除外。
+    // 受け点の基準（getOpenThreeDefensePositions: 空リスト=夏止め済み）と揃える。
     const count = countLine(board, row, col, dr, dc, color);
     if (count === 3) {
       const { end1Open, end2Open } = checkEnds(board, row, col, dr, dc, color);
-      if (end1Open && end2Open) {
+      if (
+        end1Open &&
+        end2Open &&
+        getOpenThreeDefensePositions(board, row, col, dr, dc, color).length > 0
+      ) {
         return true;
       }
     }
@@ -178,9 +186,14 @@ export function classifyThreat(
     }
 
     // 連続三をチェック
-    if (count === 3) {
+    // 夏止め済み（両外側ブロックで活四にできない三）は脅威でないため除外（createsOpenThree と同基準）
+    if (!hasOpenThree && count === 3) {
       const { end1Open, end2Open } = checkEnds(board, row, col, dr, dc, color);
-      if (end1Open && end2Open) {
+      if (
+        end1Open &&
+        end2Open &&
+        getOpenThreeDefensePositions(board, row, col, dr, dc, color).length > 0
+      ) {
         hasOpenThree = true;
       }
     }

--- a/src/logic/cpu/search/threatPatterns.ts
+++ b/src/logic/cpu/search/threatPatterns.ts
@@ -18,6 +18,8 @@ import {
   countLine,
   getLineEnds,
 } from "../core/lineAnalysis";
+// 夏止め済み判定（受け点の基準と活三判定を一致させる SSoT）
+import { getOpenThreeDefensePositions } from "../evaluation/threatDetection";
 import { isNearExistingStone } from "../moveGenerator";
 import { findJumpGapPosition } from "../patterns/threatAnalysis";
 // #43 PR-3: 図形/禁手の葉プリミティブを Zig アダプタへ委譲（patterns.ts/forbiddenMoves.ts 依存を断つ）。
@@ -274,7 +276,9 @@ export function checkDefenseCounterThreat(
     }
 
     // 連続活三
-    if (count === 3) {
+    // 夏止め済み（両外側ブロックで活四にできない三）は本物のカウンター脅威でないため除外。
+    // 受け点の基準（getOpenThreeDefensePositions: 空リスト=夏止め済み）と揃える（classifyThreat と同基準）。
+    if (!hasThree && count === 3) {
       const { end1Open, end2Open } = checkEnds(
         board,
         row,
@@ -283,7 +287,12 @@ export function checkDefenseCounterThreat(
         dc,
         opponentColor,
       );
-      if (end1Open && end2Open) {
+      if (
+        end1Open &&
+        end2Open &&
+        getOpenThreeDefensePositions(board, row, col, dr, dc, opponentColor)
+          .length > 0
+      ) {
         hasThree = true;
       }
     }

--- a/zig/src/vct.zig
+++ b/zig/src/vct.zig
@@ -73,8 +73,12 @@ pub fn classifyThreat(cells: []const Cell, row: u8, col: u8, color: Cell) Threat
         }
 
         // 連続活三
-        if (result.count == 3 and result.end1 == 0 and result.end2 == 0) {
-            has_open_three = true;
+        // 夏止め済み（両外側ブロックで活四にできない三）は脅威でないため除外。
+        // 受け点の基準（getOpenThreeDefensePositions: 空リスト=夏止め済み）と揃え、
+        // 「受けが要る三＝本物の脅威」で意味を一致させる（SSoT）。
+        if (!has_open_three and result.count == 3 and result.end1 == 0 and result.end2 == 0) {
+            const open_three_def = threats.getOpenThreeDefensePositions(cells, row, col, DIRECTIONS[i].dr, DIRECTIONS[i].dc, color);
+            has_open_three = open_three_def.len > 0;
         }
 
         // 跳び三
@@ -362,10 +366,11 @@ pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: C
         }
 
         // 活三をチェック（同方向に跳び四がある場合は不要：跳び四の防御が優先）
+        // 両端＋夏止め位置を返す getOpenThreeDefensePositions を使用（getLineEnds は両端のみで不足）
         if (!has_jump_four and result.count == 3 and result.end1 == 0 and result.end2 == 0) {
-            const ends = threats.getLineEnds(cells, row, col, dir.dr, dir.dc, color);
-            for (0..ends.len) |j| {
-                defense_positions.addUnique(ends.items[j]);
+            const open_three_def = threats.getOpenThreeDefensePositions(cells, row, col, dir.dr, dir.dc, color);
+            for (0..open_three_def.len) |j| {
+                defense_positions.addUnique(open_three_def.items[j]);
             }
         }
 
@@ -424,8 +429,11 @@ pub fn checkDefenseCounterThreat(cells: []const Cell, row: u8, col: u8, opponent
         }
 
         // 連続活三
-        if (result.count == 3 and result.end1 == 0 and result.end2 == 0) {
-            has_three = true;
+        // 夏止め済み（両外側ブロックで活四にできない三）は本物のカウンター脅威でないため除外。
+        // 受け点の基準（getOpenThreeDefensePositions: 空リスト=夏止め済み）と揃える（classifyThreat と同基準）。
+        if (!has_three and result.count == 3 and result.end1 == 0 and result.end2 == 0) {
+            const open_three_def = threats.getOpenThreeDefensePositions(cells, row, col, DIRECTIONS[i].dr, DIRECTIONS[i].dc, opponent_color);
+            has_three = open_three_def.len > 0;
         }
 
         // 跳び三
@@ -2511,4 +2519,113 @@ test "phantom: 偽の追い詰め(VCT)を防御側strictのみ棄却・攻めlen
     try testing.expect(findVCTMoveWithBudget(&cells, .black, 4, 0, 500) != null);
     // strict（防御）は null ＝幻の被詰みを棄却
     try testing.expect(findVCTMoveWithBudgetStrict(&cells, .black, 4, 0, 500) == null);
+}
+
+test "getThreatDefensePositions: 活三の受けに夏止め位置を含む（片側ブロック）" {
+    // 盤面: (7,5)(7,6)(7,7) 横並び活三（方向 dr=0,dc=+1: 正方向=col増加）
+    // 負方向外側(7,3)に白石でブロック → 夏止めは正方向(7,9)側のみ
+    // 受け点は: 端(7,4)、端(7,8)、夏止め(7,9) の3点
+    // （旧 getLineEnds 使用時は端の2点しか返らなかった）
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+    cells[7 * BOARD_SIZE + 3] = .white; // 負方向外側をブロック → 正方向(7,9)に夏止めが発生
+    bitboard.initFromCells(&cells);
+
+    const defense = getThreatDefensePositions(&cells, 7, 6, .black);
+    // 端 (7,4) と (7,8) は必ず含む
+    var has_end1 = false;
+    var has_end2 = false;
+    // 夏止め (7,9) を含む（負方向外側がブロックされたため正方向に夏止め）
+    var has_natsudome = false;
+    for (0..defense.len) |i| {
+        const p = defense.items[i];
+        if (p.row == 7 and p.col == 4) has_end1 = true;
+        if (p.row == 7 and p.col == 8) has_end2 = true;
+        if (p.row == 7 and p.col == 9) has_natsudome = true;
+    }
+    try testing.expect(has_end1);
+    try testing.expect(has_end2);
+    try testing.expect(has_natsudome);
+}
+
+test "getThreatDefensePositions: 夏止め済みの活三は緊急の受け不要" {
+    // 盤面: 両外側(7,3)(7,9)に白石を置いた形（X_●●●_X）
+    // 活三は活四にできないため、この方向からの受け点が追加されない
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+    cells[7 * BOARD_SIZE + 3] = .white; // 正方向の夏止め済み
+    cells[7 * BOARD_SIZE + 9] = .white; // 負方向の夏止め済み
+    bitboard.initFromCells(&cells);
+
+    // getOpenThreeDefensePositions は空リストを返す（夏止め済み）
+    // → この方向から受け点が追加されないことを確認
+    // 他方向（縦・斜め）に活三がないため defense.len == 0
+    const defense = getThreatDefensePositions(&cells, 7, 6, .black);
+    try testing.expectEqual(@as(u8, 0), defense.len);
+}
+
+test "checkDefenseCounterThreat: 夏止め済みの三のみを作る石は .none" {
+    // 盤面: X_●●●_X（白(7,3)(7,9)、黒(7,5)(7,6)(7,7)）
+    // ブロック石が「夏止め済みの三」のみを作る場合、活四にできない＝本物の
+    // カウンター脅威でないため .three でなく .none を返すべき。
+    // .three のままだと processBlockDefenses で受け点空リスト→偽勝ちの残存経路になる。
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black; // ブロック石（夏止め済み三のみを作る）
+    cells[7 * BOARD_SIZE + 3] = .white;
+    cells[7 * BOARD_SIZE + 9] = .white;
+    bitboard.initFromCells(&cells);
+
+    const ct = checkDefenseCounterThreat(&cells, 7, 7, .black);
+    try testing.expect(ct == .none);
+}
+
+test "classifyThreat: 夏止め済みの三は活三でない（脅威手に含まれない）" {
+    // 盤面: X_●●●_X（白(7,3)(7,9)、黒(7,5)(7,6)(7,7)）
+    // 両外側がブロックされた三は活四にできないため脅威ではない。
+    // creates_open_three=true のままだと受け点が空リスト（夏止め済み）と組み合わさり
+    // 「防御不能＝VCT成立」と誤断定される（偽VCT）。
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black; // 黒が最後の1石を置いた形
+    cells[7 * BOARD_SIZE + 3] = .white; // 負方向外側ブロック
+    cells[7 * BOARD_SIZE + 9] = .white; // 正方向外側ブロック
+    bitboard.initFromCells(&cells);
+
+    const result = classifyThreat(&cells, 7, 7, .black);
+    try testing.expect(!result.creates_open_three);
+    try testing.expect(!result.creates_four);
+}
+
+test "hasVCT: 夏止め済みの三しか作れない局面で偽VCTが成立しない" {
+    // 盤面: X_●●_._X（白(7,3)(7,9)、黒(7,5)(7,6)）
+    // 黒の唯一の「三を作る手」は(7,7)だが、できる三は夏止め済み（X_●●●_X）で
+    // 活四にできない＝脅威でない。受け点が空リストでも「防御不能＝勝ち」と
+    // 誤断定してはならない。
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 3] = .white;
+    cells[7 * BOARD_SIZE + 9] = .white;
+    bitboard.initFromCells(&cells);
+
+    var limiter = TimeLimiter{
+        .start_time = 0,
+        .time_limit = 0,
+        .nodes = 0,
+        .max_nodes = 0,
+    };
+
+    try testing.expect(!hasVCT(&cells, .black, 0, &limiter, VCT_MAX_DEPTH));
 }


### PR DESCRIPTION
## 概要

VCT（追い詰め）探索が活三の受けとして**夏止め**（端の外側に打ち、四にさせて止める受け）を見落とし、「全ての受けを論破した→VCT成立」と誤断定して**偽VCT**が成立するバグを修正します。CPU強化ロードマップ施策2「VCT受け点の夏止め欠落修正」です。

偽VCTの影響:
- 対局CPUが threatProbe 経由で偽VCTを勝ち（FIVE−1）と確信して自滅手を指す
- 振り返り表示に実際には勝てない偽の追い詰め手順が出る（学習アプリとして有害）

## 修正内容

**三の判定基準を「受け点の基準」と一致させる**一貫した修正です（受け点列挙の正規実装 `getOpenThreeDefensePositions` は両端＋夏止め、夏止め済みなら「受け不要」として空リストを返す。`mise_vcf.zig` / `threats.zig` は使用済みで、vct.zig だけが取り残されていた）。

1. **受け点列挙**（`getThreatDefensePositions`）: `getLineEnds`（両端2点のみ）→ `getOpenThreeDefensePositions` へ差し替え
2. **攻め手生成**（`classifyThreat`）: 夏止め済みの三（両外側ブロックで活四にできない＝連珠の定義上そもそも三ではない）を脅威手から除外
3. **ブロック石判定**（`checkDefenseCounterThreat`）: 同じ夏止め除外を適用
4. TS側二重実装（`threatMoves.ts` / `threatPatterns.ts`）も同期（TS⇄wasm パリティテスト維持）

2・3 はレビューで検出された退行の封鎖です: 受け点が空リストになる夏止め済みの三を「防御不能＝VCT成立」と誤解釈する経路が複数あり、1 だけだと**偽VCTがむしろ増える**ことを E2E RED テストで実証した上で、攻め手側の根本対処（「受けが要る三＝本物の脅威」）で塞ぎました。これにより「空リスト＝活四で防御不能」の不変条件が回復します。

## 検証

- commit-bench main vs 本ブランチ 208局 r0.02 → **Elo 0.0 [−47.3, +47.3]（WDL +103 =2 −103、勝率50.0%）＝完全中立**。受け分岐増による真正VCT取りこぼし回帰（過去に類似パスで Elo −88 の事例あり）は発生せず。
- TDD: 受け点5テスト（片側ブロック→端2＋夏止め1 / 夏止め済み→受け不要 / 夏止め済み三は脅威でない / hasVCT が偽VCTを返さない E2E / checkDefenseCounterThreat の `.none` 判定）を RED→GREEN で追加。
- `zig build test` 全緑（phantom 非対称ゲート / ResilienceMode / issue#27 含む）/ wasm 41件 / TS 1519件 / pre-commit 全通過。
- `/review`（3観点）を2周実施。1周目で blocker（夏止め済み三の偽VCT化）、2周目で残存経路（ブロック後文脈）を検出・封鎖。跳び三側は構造上同種の問題が発生しないことをレビューで証明済み。

## 影響範囲の注記

`classifyThreatWasm` 経由で振り返り画面の候補検証にも「夏止め済みの三は脅威でない」が波及します。連珠の定義（三＝活四にできる形）に沿った正しい方向の変更です。

## スコープ外（記録）

- `position_eval.zig` L478/L526 の活三用 `getLineEnds`（禁手トラップ/脆弱性評価）— 同種の夏止め考慮の余地あり、別施策
- `hasOpenThree`（vct.zig）の夏止め未チェック — 過剰棄却＝安全側のため非対応
- vct.zig の死蔵 `createsOpenThree` — #43 棚卸しで対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)
