### PR TITLE
振り返り解析: 誤blunder修正 + eval=hard 配線 + timeLimit 短縮（B1/A1/A4）

### DIFF
--- a/docs/plans/review-eval-wiring-results-2026-06-14.md
+++ b/docs/plans/review-eval-wiring-results-2026-06-14.md
@@ -1,0 +1,82 @@
+# 振り返り解析 eval=hard 配線 / timeLimit 短縮 検証結果 (2026-06-14)
+
+## 背景
+
+振り返り解析の `findBestMoveForReview` は WASM `findBestMove` の `eval_flags` 引数を
+`0` ハードコードしていたため、必須防御/ミセ脅威/禁手脆弱性/葉 single-four ペナルティを
+切った素 eval で読んでいた（A1 配線漏れ）。
+
+`REVIEW_SEARCH_PARAMS.evaluationOptions = DIFFICULTY_PARAMS.hard.evaluationOptions` は
+宣言済みだが未配線。#93 が対局側を直したが review 側は漏れていた。
+
+加えて、白14 F11 のような中盤深度感受性手で、tl15k と tl5k で判定が反転する問題が
+[[project_review_tool_perf]] 調査で判明。真因は MAIN MINIMAX DEPTH 駆動（eval 天井）。
+
+## 変更
+
+- **A1**: `findBestMoveForReview` に `evalOptionsFlags` 引数追加（必須）。
+  `executeWasmSearch` で `encodeEvalOptions(REVIEW_SEARCH_PARAMS.evaluationOptions)`
+  を渡す（hard 相当）。
+- **A4**: `REVIEW_PROFILE_FAST.timeLimit` を `15000ms → 5000ms`、`absoluteTimeLimit` を
+  `20000ms → 10000ms` に短縮。PRECISE は据え置き（精密モードの建付け尊重）。
+- **A2**: profile-review に `--eval=hard|none` CLI オプション追加（検証用）。
+
+## 検証棋譜
+
+白番29手、白14 F11 が反転候補:
+
+```
+H8 G8 H9 G7 G9 H7 I7 F10 F9 E9 I8 I9 G10 F11 H11 E8 J6 K5 J7 K6 J9 J5 J8 J10 K8 L8 I10 L7 G12
+```
+
+## 計測結果（profile-review.ts, 白番）
+
+### 白14 F11（焦点）
+
+| 構成                             | quality       | playedScore | scoreDiff | depth |
+| -------------------------------- | ------------- | ----------- | --------- | ----- |
+| 旧コード相当 (eval=none × tl15k) | blunder       | -99999      | 96611     | 7     |
+| A1 適用 (eval=hard × tl15k)      | blunder       | -2588       | **2204**  | 7     |
+| A1+A4 (eval=hard × tl5k)         | **excellent** | -2588       | 0         | 6     |
+
+- eval=hard 配線で playedScore が -99999 → -2588 と 38倍改善（46倍 scoreDiff 縮小）。
+- A4 短縮と組み合わせると白14 は excellent 判定。eval=hard 単体では blunder のまま。
+- A1 と A4 は**必ずセットで運用**する。
+
+### 全手サマリ（A1+A4 vs 旧）
+
+| 手           | 旧 quality          | 新 quality        | 備考                         |
+| ------------ | ------------------- | ----------------- | ---------------------------- |
+| 白2 G8       | excellent           | inaccuracy (-103) | hard 評価で H10 がベスト判定 |
+| 白4 G7       | inaccuracy          | inaccuracy        | 一致                         |
+| 白6 H7       | good                | excellent         | A1で実手評価向上             |
+| 白8 F10      | excellent           | excellent         | 一致                         |
+| 白10 E9      | excellent           | mistake (340)     | hard 評価で I9 がベスト判定  |
+| 白12 I9      | excellent           | excellent         | 一致                         |
+| **白14 F11** | **blunder (96611)** | **excellent (0)** | **A1+A4の目玉**              |
+| 白16 E8      | excellent           | excellent         | 一致                         |
+| 白22 J5      | blunder             | blunder           | 敗着検出維持                 |
+
+### 速度
+
+- 旧 (eval=none × tl15k): 約 60-70秒/局（白14手）
+- 新 (eval=hard × tl5k): 約 32-37秒/局（白14手） → **-47%**
+
+## 影響と注意
+
+- ✅ 白14クラスの判定反転を解消（A1+A4 セット必須）。
+- ✅ 解析時間 -47%。
+- ⚠️ 白2/白10 で新規 inaccuracy/mistake 判定が出る。これは hard 評価による正当な判定
+  精緻化（旧 eval=none では深度不足で見逃していた）。ユーザー体感では「悪手が増えた」と
+  感じる可能性あり。閾値見直しは別案件。
+- ⚠️ 計測棋譜は 1 局のみ。汎化未検証（他棋譜での挙動は要追跡）。
+
+## SSoT / 安全装置
+
+- `REVIEW_EVAL_FLAGS` は `fullEval.ts` トップレベルで 1 回計算（モジュール定数）。
+- `findBestMoveForReview` の `evalOptionsFlags` は **必須引数**（デフォルト 0 を廃止）。
+  新規呼び出し経路で配線を忘れて素 eval に落ちる silent regression を防ぐ。
+- `profile.evalOptionsOverride: undefined as number | undefined` で profile-review の
+  `--eval=none` を実現。本番は `undefined` で `REVIEW_EVAL_FLAGS` に fallback。
+- ユニットテスト `reviewEvalWiring.test.ts` で `encodeEvalOptions(REVIEW_SEARCH_PARAMS.evaluationOptions)`
+  が hard と一致することを SSoT 不変条件としてガード。

--- a/docs/plans/review-tool-improvement-2026-06-13.md
+++ b/docs/plans/review-tool-improvement-2026-06-13.md
@@ -1,0 +1,114 @@
+# 振り返り解析ツール 改善プラン（2026-06-13）
+
+## 目的
+
+振り返り(review)解析の **高速化** と **悪手/好手判定の精度向上**。
+着手順 **C→B→A**（stacked PR、葉先マージ、main マージ禁止）。各フェーズ TDD + `/review` + コミット。
+
+## 調査で確定した前提（実測, 白29手 `H8 G8 H9 G7 G9 H7 I7 F10 F9 E9 I8 I9 G10 F11 H11 E8 J6 K5 J7 K6 J9 J5 J8 J10 K8 L8 I10 L7 G12`）
+
+- ②minimaxが解析時間の96〜99.7%。NPS約9,200、到達深度4-8ply。
+- **timeLimit 15s→5s で重い8手すべて最善手一致(8/8)・解析-47%**（eval=0前提の実測）。
+- **probe撤去/深さ路線は否定**（#89でq-nodeがmaxNodes計上→probe-OFFで深くならず・評価収束せず・戦術悪化）。bestScoreの中盤ブレは評価関数(no-ML)が真因で深さでは直らない。
+- 判定の穴2つ（評価値非依存）: 誤blunder（-2000フォールバック, 白4,6）/ 敗着見逃し（verifyCandidatesのbreak-on-safeで実手未検証, 白14がtl15s=blunder↔tl5s=excellent）。
+- eval配線漏れ: `findBestMoveForReview`(searchEngine.ts:175)がeval_flags引数なし・194行で`0`ハードコード。
+
+---
+
+## Phase C: アルゴリズム改善（高速化＋安定性）
+
+### C1: TT手またぎ再利用（clearTT矛盾修正）★最有力
+
+- **問題**: `REVIEW_PROFILE_PRECISE.clearTT=false`(reviewConstants.ts:44)なのに`findBestMoveForReview`が無条件`this.wasm.ttClear()`(searchEngine.ts:186)。設計意図と矛盾。Zig側は`findBestMoveIterative`が`newGeneration()`を呼び対応済(tt.zig:106で世代差自動上書き)。
+- **設計**: `findBestMoveForReview`の`ttClear()`を `clearTT` 引数に従わせる。`executeWasmSearch`から`profile.clearTT`を渡す。**FAST(clearTT=true)は従来通りクリア=決定論維持**、PRECISE(false)で手またぎ再利用。
+- **決定論性懸念**: PRECISEは手またぎで解析順依存になる→振り返り再現性。要profile-review測定で効果(+0.5〜1ply期待)と再現性を確認してから採用確定。効果薄/再現性問題なら見送り。
+- 変更: searchEngine.ts(186), fullEval.ts(executeWasmSearch). TDD: clearTT=true/falseでttClear呼び出し有無をスパイ検証。
+- 効果: **速度のみ(中)**。深さ→Elo≈0が確定済のため精度向上は見込まない(判定精度の根因はB1/B2の評価値非依存バグ) / リスク: 中(決定論性) / コスト: 低
+
+### C2: annotateFukumiMoves のVCF結果再利用
+
+- `annotateFukumiMoves`(candidateVerification.ts:155)が先頭でVCF探索(maxNodes500k/depth16)。これは`detectForcedWin`で計算済の場合がある。
+- 設計: `existingVcf?`パラメータ追加、forcedWin局面では先頭VCFスキップ。fullEval呼び出し側で`forcedWin`を渡す。
+- 効果: 速度低(VCF局面で100-300ms) / リスク: 低 / コスト: 低
+
+### C3: verifyCandidatePVs / verifyCandidates の Infinity budget制限
+
+- `fullEval.ts:763,999`の`verifyCandidatePVs(...Infinity...)`→`deadline=Infinity`(pvVerification.ts:144)で外側ループが全候補必ず処理。さらに`fullEval.ts:749,985`の`verifyCandidates(...Infinity...)`も同様にbudget無制限。両方PRECISEのみ(verifyCandidatesBudget=Infinity, enablePVVerification=true)。
+- 設計: `REVIEW_PROFILE_PRECISE.pvVerificationBudgetMs`(例8000)/`verifyCandidatesBudgetMs`追加、呼び出しに渡す。内側のper-step deadlineは既に効くので「外側ループの無制限」のみ修正。
+- ⚠️ **per-step累積コスト**: 候補数×per-candidate探索で1手あたり累積する。PRECISEのtimeLimit化(A4)は本C3の上限導入が前提（C3なしでtimeLimitだけ下げると候補検証ループが残時間を食い潰す）。
+- 効果: 速度中(PRECISE暴走防止) / リスク: 低 / コスト: 低
+
+---
+
+## Phase B: 判定精度（悪手/好手）
+
+### B1: 誤blunder修正（実手実評価）
+
+- **問題**: 実手が候補top5外→`playedScore=bestScore-2000`固定(fullEval.ts:914, evaluatePlayedMove.ts:110)→機械的blunder。
+- **設計(レビュー反映)**: `attachPVFromWasm`の拡張ではなく**独立ヘルパー`probePlayedMoveScore(board, playedRow, playedCol, color, engine, fallback?) → number`を新規作成**（SRP: attachPVはvoidのまま）。内部で`findBestMoveWithParamsNoTTClear(depth3/2s/200k)`を実手局面に対し実行→相手視点scoreを符号反転して返す。**挿入点は-2000フォールバックの直前**（fullEval.ts:907-914のplayedScore決定ブロック内、evaluatePlayedMove.ts:110の`??`右辺）。
+  - ⚠️ **forcedWinパス対応必須**: `evaluatePlayedForcedWin`(fullEval.ts:597経由)内のL110の-2000も置換。候補外かつ非VCF/VCTの実手でのみ発動するので頻度は低いが対応する。
+  - コスト: 実手が候補外のときのみ追加探索発生（強手なら候補内で不発）。attachPVが同局面を別途探索する場合は順序最適化でTT再利用（追加探索を増やさない）を検討。
+- TDD: evaluatePlayedMove.test.ts新規。白4(G7)/白6(H7)でscoreDiff<=1000になるリグレッション。モックengineでprobePlayedMoveScore単体。
+- 効果: 高 / リスク: 低 / コスト: 小
+
+### B2: 敗着検出の確実化（実手強制検証）
+
+- **真因(特定済)**: `verifyCandidates`(candidateVerification.ts:113)のbreak-on-safeで実手F11が未検証→時間依存反転。実手はverifyCandidates呼出時には既にcandidatesに含まれる(fullEval.ts:918-945で追加)が、先頭が安全だとbreakで未検証のまま終わる。
+- **設計(レビュー反映: 案B採用=DRY)**: `verifyCandidates`に`alwaysVerify?: Position`引数を追加し、**break後もその座標の候補だけは必ず検証**。`buildNormalResult`/`buildForcedWinResult`は実手座標を渡すだけ(両関数への重複実装=案Aを回避)。被必勝なら既存のbestLoss/forcedLossType昇格ロジック(L1027-1030)を実手にも適用。
+- ⚠️ **needsVCTCheck二重実行の整理(必須)**: `selfHasFourAfter=false && loss=null`で`needsVCTCheck=true`(fullEval.ts:417)がセットされる経路と、B2の実手強制VCTが同一`boardAfter`局面で二重にVCTを走らせる。`needsVCTCheck`が立つケースはB2の実手VCTをスキップ(Phase2に委譲)するか、逆にB2で確定させてneedsVCTCheckを下ろす。どちらか一方に統一。
+- ⚠️ **FAST時コスト(レビュー反映)**: 実手強制検証(最大VCT2s+MiseVCF1s)はFASTでも走る。A4でtimeLimit5s化後、最悪手で +3〜4s ≒ 8〜9s/手になりうる。A4の実効上限設計に織り込む(per-candidate按分 or 実手検証に別budget)。
+- TDD: 「break後でも実手が検証される」「安全な先頭候補があっても実手被必勝ならforcedLossType設定」。白14をreviewSnapshotコーパスに追加。
+- 効果: 高 / リスク: 中 / コスト: 小
+
+### B3: 判定閾値見直し（保留）
+
+- classifyMoveQuality(reviewLogic.ts:38-53)の0/80/300/1000。0=excellentが厳しすぎる疑い。**B1後の実scoreDiff分布を見てから判断**。今回は変更しない。
+
+---
+
+## Phase A: eval配線 + timeLimit（高速化＋質）
+
+### A1: eval配線 hard相当
+
+- 設計: `encodeEvalOptions`(searchEngine.ts:40)をexport。`findBestMoveForReview`/`findBestMoveWithParamsNoTTClear`に`evalOptionsFlags`引数追加(現状0ハードコード:194,165)。`executeWasmSearch`/`attachPVFromWasm`から`encodeEvalOptions(REVIEW_SEARCH_PARAMS.evaluationOptions)`を渡す。CLI/テスト上書きは`FullEvalParams.evalOptionsOverride?: EvaluationOptions`(フラグでなく型で受けエンコードはモジュール内に閉じる=ISP)。
+- ABI整合済(types.ts:44-52, main.zig:139が7番目引数eval_options_flags受領)。
+- ⚠️ **効果の限定(レビュー反映)**: hard評価のenableFukumi/enableForbiddenVulnerability等は**move ordering(枝刈り効率)に効くが葉評価evaluateBoardには効かない**([[project_eval_feature_gap]])。つまりA1は「探索効率・最善手の質」には効くが「葉の評価値=判定値」の質改善は限定的。中立評価(eval=0)の方が客観評価としてノイズが少ない可能性も残る→A3で定量判断。
+- 効果: 中(最善手の質・探索効率) / リスク: 中(最善手・スコア変化→A4再測定必須) / コスト: 低
+
+### A2: profile-review に --eval=hard|none（検証インフラ）
+
+- `FullEvalParams.evalOptionsFlagsOverride`経由でCLIから切替。eval=none(0) vs hard比較測定用。本体非汚染。
+
+### A3: 再測定（A1後・A4前に必須）
+
+- eval=none/hard × timeLimit{10k,7k,5k,4k,3k}スイープ。**採否の定量基準(レビュー反映)**:
+  1. timeLimit5s維持の可否: eval=hard下で重い8手の最善手一致が保たれるか(eval=hard化で1ノードコスト増→NPS低下→安全点が上振れする可能性)。
+  2. **eval採否**: 同一局面でeval=none vs hardのbestScore差が判定閾値(80/300/1000, reviewLogic.ts)を跨ぐ手の割合。跨ぎが多くかつhardが客観的に妥当でないなら配線を見送る/中立評価を選ぶ判断もあり得る。
+  3. PRECISEも別途同様に測定(C3が前提)。
+
+### A4: timeLimit 5000化
+
+- A3で安全確認後、`REVIEW_PROFILE_FAST.timeLimit`15000→5000, absoluteTimeLimit20000→7000。PRECISEは測定後に確定(暫定維持＋コメント)。
+- reviewSnapshot.test.tsはtimeLimit非対象(node-bound化)で影響なし。
+- 効果: 高(-47%) / リスク: 中(再測定でミティゲート) / コスト: 極低
+
+---
+
+## PRスタック構成（葉先マージ）
+
+```
+main
+└── PR-C（C1/C2/C3 アルゴリズム改善）
+    └── PR-B（B1/B2 判定精度）
+        └── PR-A（A1/A2/A4 eval配線+timeLimit）
+```
+
+- 各PRはTDD緑+`/review`+コミット。fullEval競合はstackで回避。
+- profile-review検証拡張(branch sub/review-perf-investigation済: --time-limit/--max-nodes/--depth/quality列)はPR-Cのベースに含める or 検証インフラとして先頭コミット。
+
+## 横断的懸念
+
+- C1決定論性: FAST維持で緩和、PRECISE手またぎは効果測定で採否決定。
+- B2タイムアウト: 実手VCT最大2sの許容確認。needsVCTCheck重複整理。
+- A4: eval配線後の再測定なしにtimeLimit確定しない。
+- 全Phaseで reviewSnapshot/reviewLogic/forcedLossPropagation/candidateVerification の各testへの影響を確認。

--- a/scripts/profile-review.ts
+++ b/scripts/profile-review.ts
@@ -17,6 +17,11 @@ import {
   type FullEvalTimings,
 } from "@/logic/cpu/review/fullEval";
 import {
+  REVIEW_PROFILE_FAST,
+  REVIEW_PROFILE_PRECISE,
+  REVIEW_SEARCH_PARAMS,
+} from "@/logic/cpu/review/reviewConstants";
+import {
   type BoardEvaluator,
   WasmBoardEvaluator,
 } from "@/logic/cpu/wasm/bridge";
@@ -25,6 +30,7 @@ import { loadWasmModule } from "@/logic/cpu/wasm/loader";
 import { WasmSearchEngine } from "@/logic/cpu/wasm/searchEngine";
 import { preloadThreatWasm } from "@/logic/cpu/wasm/threatAdapter";
 import { formatMove } from "@/logic/gameRecordParser";
+import { buildEvaluatedMove } from "@/logic/reviewLogic";
 
 // ─── CLI 引数パース ─────────────────────────────────────
 
@@ -34,6 +40,9 @@ function parseArgs(): {
   precise: boolean;
   verbose: boolean;
   useWasm: boolean;
+  timeLimitOverride: number | undefined;
+  maxNodesOverride: number | undefined;
+  depthOverride: number | undefined;
 } {
   const args = process.argv.slice(2);
   let kifu = "";
@@ -41,6 +50,9 @@ function parseArgs(): {
   let precise = false;
   let verbose = false;
   let useWasm = false;
+  let timeLimitOverride: number | undefined = undefined;
+  let maxNodesOverride: number | undefined = undefined;
+  let depthOverride: number | undefined = undefined;
 
   for (const arg of args) {
     if (arg.startsWith("--kifu=")) {
@@ -56,6 +68,21 @@ function parseArgs(): {
       verbose = true;
     } else if (arg === "--wasm") {
       useWasm = true;
+    } else if (arg.startsWith("--time-limit=")) {
+      const val = parseInt(arg.slice("--time-limit=".length), 10);
+      if (!isNaN(val)) {
+        timeLimitOverride = val;
+      }
+    } else if (arg.startsWith("--max-nodes=")) {
+      const val = parseInt(arg.slice("--max-nodes=".length), 10);
+      if (!isNaN(val)) {
+        maxNodesOverride = val;
+      }
+    } else if (arg.startsWith("--depth=")) {
+      const val = parseInt(arg.slice("--depth=".length), 10);
+      if (!isNaN(val)) {
+        depthOverride = val;
+      }
     } else if (!arg.startsWith("--")) {
       kifu = arg;
     }
@@ -63,15 +90,33 @@ function parseArgs(): {
 
   if (!kifu) {
     console.error(
-      '使用法: pnpm profile:review "H8 H9 ..." [--perspective=white] [--precise] [--verbose] [--wasm]',
+      '使用法: pnpm profile:review "H8 H9 ..." [--perspective=white] [--precise] [--verbose] [--wasm] [--time-limit=N] [--max-nodes=N] [--depth=N]',
     );
     process.exit(1);
   }
 
-  return { kifu, perspective, precise, verbose, useWasm };
+  return {
+    kifu,
+    perspective,
+    precise,
+    verbose,
+    useWasm,
+    timeLimitOverride,
+    maxNodesOverride,
+    depthOverride,
+  };
 }
 
-const { kifu, perspective, precise, verbose, useWasm } = parseArgs();
+const {
+  kifu,
+  perspective,
+  precise,
+  verbose,
+  useWasm,
+  timeLimitOverride,
+  maxNodesOverride,
+  depthOverride,
+} = parseArgs();
 
 // ─── WASM 初期化 ─────────────────────────────────────
 
@@ -126,6 +171,9 @@ interface MoveProfile {
   candidateCount: number;
   timings: FullEvalTimings;
   subPhases: SubPhaseDetail[];
+  playedScore: number;
+  scoreDiff: number;
+  quality: string;
 }
 
 // ─── ログ出力ヘルパー ──────────────────────────────────
@@ -188,7 +236,7 @@ function profileMove(
     });
   }
 
-  // 候補ごとの検証結果を記録
+  // 候補ごとの検証結果を記録（buildEvaluatedMove より前に行う）
   const candDetails: string[] = [];
   for (const c of result.candidates) {
     const pos = formatMove(c.position);
@@ -211,6 +259,18 @@ function profileMove(
     });
   }
 
+  // candidates を浅いコピーして渡す（buildEvaluatedMove は破壊的ソートをする可能性がある）
+  const resultForEval = {
+    ...result,
+    candidates: result.candidates.map((c) => ({ ...c })),
+  };
+  const evaluatedMove = buildEvaluatedMove(
+    resultForEval,
+    moveHistory,
+    true,
+    true,
+  );
+
   return {
     moveIndex,
     moveStr: moves[moveIndex] ?? "?",
@@ -223,12 +283,38 @@ function profileMove(
     candidateCount: result.candidates.length,
     timings,
     subPhases,
+    playedScore: evaluatedMove.playedScore,
+    scoreDiff: evaluatedMove.scoreDiff,
+    quality: evaluatedMove.quality,
   };
 }
 
 // ─── メイン実行 ──────────────────────────────────────
 
 async function main(): Promise<void> {
+  // CLI オーバーライド適用（as const オブジェクトのプロパティを実行時に書き換え）
+  const activeProfile = precise
+    ? (REVIEW_PROFILE_PRECISE as { timeLimit?: number; maxNodes?: number })
+    : (REVIEW_PROFILE_FAST as { timeLimit?: number; maxNodes?: number });
+  const searchParams = REVIEW_SEARCH_PARAMS as { depth: number };
+
+  const overrideParts: string[] = [];
+  if (timeLimitOverride !== undefined) {
+    activeProfile.timeLimit = timeLimitOverride;
+    overrideParts.push(`timeLimit=${timeLimitOverride}`);
+  }
+  if (maxNodesOverride !== undefined) {
+    activeProfile.maxNodes = maxNodesOverride;
+    overrideParts.push(`maxNodes=${maxNodesOverride}`);
+  }
+  if (depthOverride !== undefined) {
+    searchParams.depth = depthOverride;
+    overrideParts.push(`depth=${depthOverride}`);
+  }
+  if (overrideParts.length > 0) {
+    console.log(`Override: ${overrideParts.join(", ")}`);
+  }
+
   // #43 PR-6: 判定アダプタは pure-wasm 化済み。fullEval が使う threat/forbidden thin wasm を先にロード。
   await Promise.all([preloadThreatWasm(), preloadForbiddenWasm()]);
 
@@ -394,6 +480,9 @@ async function main(): Promise<void> {
       "PV検証".padStart(10),
       "勝ち筋",
       "負け筋",
+      "quality".padEnd(11),
+      "実手score".padStart(10),
+      "scoreDiff".padStart(10),
     ].join(" | ");
     console.log(header);
     console.log("-".repeat(header.length));
@@ -415,6 +504,9 @@ async function main(): Promise<void> {
         String(Math.round(t.pvVerification)).padStart(10),
         (p.forcedWinType ?? "-").padEnd(6),
         (p.forcedLossType ?? "-").padEnd(6),
+        p.quality.padEnd(11),
+        String(p.playedScore).padStart(10),
+        String(p.scoreDiff).padStart(10),
       ].join(" | ");
       console.log(row);
     }

--- a/scripts/profile-review.ts
+++ b/scripts/profile-review.ts
@@ -43,6 +43,7 @@ function parseArgs(): {
   timeLimitOverride: number | undefined;
   maxNodesOverride: number | undefined;
   depthOverride: number | undefined;
+  evalMode: "hard" | "none" | undefined;
 } {
   const args = process.argv.slice(2);
   let kifu = "";
@@ -53,6 +54,7 @@ function parseArgs(): {
   let timeLimitOverride: number | undefined = undefined;
   let maxNodesOverride: number | undefined = undefined;
   let depthOverride: number | undefined = undefined;
+  let evalMode: "hard" | "none" | undefined = undefined;
 
   for (const arg of args) {
     if (arg.startsWith("--kifu=")) {
@@ -83,6 +85,11 @@ function parseArgs(): {
       if (!isNaN(val)) {
         depthOverride = val;
       }
+    } else if (arg.startsWith("--eval=")) {
+      const val = arg.slice("--eval=".length);
+      if (val === "hard" || val === "none") {
+        evalMode = val;
+      }
     } else if (!arg.startsWith("--")) {
       kifu = arg;
     }
@@ -90,7 +97,7 @@ function parseArgs(): {
 
   if (!kifu) {
     console.error(
-      '使用法: pnpm profile:review "H8 H9 ..." [--perspective=white] [--precise] [--verbose] [--wasm] [--time-limit=N] [--max-nodes=N] [--depth=N]',
+      '使用法: pnpm profile:review "H8 H9 ..." [--perspective=white] [--precise] [--verbose] [--wasm] [--time-limit=N] [--max-nodes=N] [--depth=N] [--eval=hard|none]',
     );
     process.exit(1);
   }
@@ -104,6 +111,7 @@ function parseArgs(): {
     timeLimitOverride,
     maxNodesOverride,
     depthOverride,
+    evalMode,
   };
 }
 
@@ -116,6 +124,7 @@ const {
   timeLimitOverride,
   maxNodesOverride,
   depthOverride,
+  evalMode,
 } = parseArgs();
 
 // ─── WASM 初期化 ─────────────────────────────────────
@@ -294,8 +303,16 @@ function profileMove(
 async function main(): Promise<void> {
   // CLI オーバーライド適用（as const オブジェクトのプロパティを実行時に書き換え）
   const activeProfile = precise
-    ? (REVIEW_PROFILE_PRECISE as { timeLimit?: number; maxNodes?: number })
-    : (REVIEW_PROFILE_FAST as { timeLimit?: number; maxNodes?: number });
+    ? (REVIEW_PROFILE_PRECISE as {
+        timeLimit?: number;
+        maxNodes?: number;
+        evalOptionsOverride?: number;
+      })
+    : (REVIEW_PROFILE_FAST as {
+        timeLimit?: number;
+        maxNodes?: number;
+        evalOptionsOverride?: number;
+      });
   const searchParams = REVIEW_SEARCH_PARAMS as { depth: number };
 
   const overrideParts: string[] = [];
@@ -310,6 +327,13 @@ async function main(): Promise<void> {
   if (depthOverride !== undefined) {
     searchParams.depth = depthOverride;
     overrideParts.push(`depth=${depthOverride}`);
+  }
+  if (evalMode === "none") {
+    activeProfile.evalOptionsOverride = 0;
+    overrideParts.push("eval=none");
+  } else if (evalMode === "hard") {
+    activeProfile.evalOptionsOverride = undefined;
+    overrideParts.push("eval=hard");
   }
   if (overrideParts.length > 0) {
     console.log(`Override: ${overrideParts.join(", ")}`);

--- a/src/logic/cpu/review/evaluatePlayedMove.test.ts
+++ b/src/logic/cpu/review/evaluatePlayedMove.test.ts
@@ -1,0 +1,72 @@
+/**
+ * probePlayedMoveScore テスト（B1: 誤blunder修正 / 実手実評価）
+ *
+ * 実手が minimax 候補(top5)外のとき、従来は playedScore=bestScore-2000 固定で
+ * 機械的に blunder 判定されていた。実手局面を浅く追加探索し実スコアを推定する。
+ *
+ * モックエンジンで純粋にヘルパーのロジック（符号反転・盤面置換/復元・手番・不正座標）を検証する。
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { BoardState } from "@/types/game";
+
+import { createEmptyBoard } from "@/logic/renjuRules";
+
+import type { WasmSearchEngine } from "../wasm/searchEngine";
+
+import { probePlayedMoveScore } from "./evaluatePlayedMove";
+
+function mockEngine(score: number): WasmSearchEngine {
+  return {
+    findBestMoveWithParamsNoTTClear: vi.fn(() => ({
+      position: { row: 0, col: 0 },
+      score,
+      completedDepth: 3,
+    })),
+  } as unknown as WasmSearchEngine;
+}
+
+describe("probePlayedMoveScore（B1: 実手実評価）", () => {
+  it("相手視点スコアを符号反転して実手側スコアを返す", () => {
+    const board = createEmptyBoard();
+    const engine = mockEngine(1234);
+    expect(probePlayedMoveScore(board, 7, 7, "black", engine)).toBe(-1234);
+  });
+
+  it("探索中は実手を盤面に置き、終了後に戻す", () => {
+    const board = createEmptyBoard();
+    let placedDuringSearch = false;
+    const engine = {
+      findBestMoveWithParamsNoTTClear: vi.fn((b: BoardState) => {
+        placedDuringSearch = b[7]?.includes("black") ?? false;
+        return { position: { row: 0, col: 0 }, score: 0, completedDepth: 3 };
+      }),
+    } as unknown as WasmSearchEngine;
+    probePlayedMoveScore(board, 7, 7, "black", engine);
+    expect(placedDuringSearch).toBe(true);
+    expect(board[7]?.includes("black") ?? false).toBe(false);
+  });
+
+  it("実手を置いた後の相手番で探索する", () => {
+    const board = createEmptyBoard();
+    const engine = mockEngine(500);
+    probePlayedMoveScore(board, 7, 7, "black", engine);
+    const mock = vi.mocked(engine.findBestMoveWithParamsNoTTClear);
+    expect(mock.mock.calls[0]?.[1]).toBe("white");
+  });
+
+  it("既に石がある座標では null を返し探索しない", () => {
+    const board = createEmptyBoard();
+    board[7]![7] = "white";
+    const engine = mockEngine(100);
+    expect(probePlayedMoveScore(board, 7, 7, "black", engine)).toBeNull();
+    expect(engine.findBestMoveWithParamsNoTTClear).not.toHaveBeenCalled();
+  });
+
+  it("盤外座標では null を返す", () => {
+    const board = createEmptyBoard();
+    const engine = mockEngine(100);
+    expect(probePlayedMoveScore(board, -1, 7, "black", engine)).toBeNull();
+  });
+});

--- a/src/logic/cpu/review/evaluatePlayedMove.ts
+++ b/src/logic/cpu/review/evaluatePlayedMove.ts
@@ -23,6 +23,50 @@ export interface PlayedForcedWinResult {
   playedForcedWinSequence: Position[] | undefined;
 }
 
+/** 実手スコア推定の追加探索パラメータ（attachPVFromWasm のプローブと同一値） */
+const PLAYED_PROBE_DEPTH = 3;
+const PLAYED_PROBE_TIME_MS = 2000;
+const PLAYED_PROBE_MAX_NODES = 200000;
+
+/**
+ * 実手が minimax 候補(top5)外のとき、実手局面を浅く追加探索して実スコアを推定する。
+ *
+ * 実手を置いた後の局面（相手手番）を探索し、相手視点のベストスコアを符号反転して
+ * 実手側(color)視点のスコアを得る（negamax 規則）。従来の `bestScore - 2000` 固定
+ * フォールバックを置き換え、候補外の手を一律 blunder と誤判定する問題を解消する。
+ *
+ * NoTTClear で探索するため、後続の attachPVFromWasm が同一局面の PV を TT から再利用でき、
+ * 追加探索の重複を抑える。
+ *
+ * @returns 実手側視点のスコア。実手座標が盤外/既石なら null（呼び出し側でフォールバック）。
+ */
+export function probePlayedMoveScore(
+  board: BoardState,
+  playedRow: number,
+  playedCol: number,
+  color: "black" | "white",
+  engine: WasmSearchEngine,
+): number | null {
+  const row = board[playedRow];
+  if (!row || row[playedCol] !== null) {
+    return null;
+  }
+  const opponentColor = color === "black" ? "white" : "black";
+  row[playedCol] = color;
+  try {
+    const probe = engine.findBestMoveWithParamsNoTTClear(
+      board,
+      opponentColor,
+      PLAYED_PROBE_DEPTH,
+      PLAYED_PROBE_TIME_MS,
+      PLAYED_PROBE_MAX_NODES,
+    );
+    return -probe.score;
+  } finally {
+    row[playedCol] = null;
+  }
+}
+
 /**
  * 実際に打った手が追い詰め開始手かチェックし、スコアとシーケンスを返す
  */
@@ -106,8 +150,19 @@ export function evaluatePlayedForcedWin(
   const minimaxEntry = result.candidates?.find(
     (c) => c.move.row === playedRow && c.move.col === playedCol,
   );
+  // 候補外なら実手局面を追加探索して実スコアを推定（-2000固定の誤blunderを回避）
+  const playedScore =
+    minimaxEntry?.score ??
+    probePlayedMoveScore(
+      board,
+      playedRow,
+      playedCol,
+      color,
+      wasmSearchEngine,
+    ) ??
+    result.score - 2000;
   return {
-    playedScore: minimaxEntry?.score ?? result.score - 2000,
+    playedScore,
     playedForcedWinSequence: undefined,
   };
 }

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -39,7 +39,10 @@ import {
   annotateFukumiMoves,
 } from "./candidateVerification";
 import { buildDoubleMiseTree } from "./doubleMiseBranches";
-import { evaluatePlayedForcedWin } from "./evaluatePlayedMove";
+import {
+  evaluatePlayedForcedWin,
+  probePlayedMoveScore,
+} from "./evaluatePlayedMove";
 import {
   checkForcedLoss,
   FORCED_LOSS_VCT_OPTIONS,
@@ -911,7 +914,18 @@ function buildNormalResult(
     if (played) {
       playedScore = played.score;
     } else {
-      playedScore = result.score - 2000;
+      // 実手が候補(top5)外: 実手局面を追加探索して実スコアを推定する。
+      // 従来の -2000 固定は候補外の手を一律 blunder と誤判定していた（B1）。
+      const probed = wasmSearchEngine
+        ? probePlayedMoveScore(
+            board,
+            playedRow,
+            playedCol,
+            color,
+            wasmSearchEngine,
+          )
+        : null;
+      playedScore = probed ?? result.score - 2000;
     }
   }
 

--- a/src/logic/cpu/review/fullEval.ts
+++ b/src/logic/cpu/review/fullEval.ts
@@ -21,7 +21,6 @@ import type {
   MoveScoreEntry,
   VCFSequenceResult,
 } from "../search/types";
-import type { WasmSearchEngine } from "../wasm/searchEngine";
 
 import { countStones } from "../core/boardUtils";
 // #43 PR-2: 表示内訳(breakdown)を廃止。評価内訳クラスタ(evaluation barrel)への依存を断ち、
@@ -29,6 +28,7 @@ import { countStones } from "../core/boardUtils";
 import { PATTERN_SCORES } from "../evaluation/patternScores";
 import { colorToWasm } from "../wasm/boardAdapter";
 import { linearTreeFromSequence } from "../wasm/forcedWinTreeWire";
+import { encodeEvalOptions, type WasmSearchEngine } from "../wasm/searchEngine";
 // #37 P3 PR4/PR5b: 脅威検出・ミセターゲットを Zig 単一ソース経由に。
 // 合法局面で TS と一致（threatAdapter.test / findMiseTargetsParity.test 検証済）。
 // 未ロード時は TS フォールバック。
@@ -65,6 +65,17 @@ import { wasmFindVCFSequence, wasmFindVCTSequence } from "./wasmAdapters";
 type ReviewProfile = typeof REVIEW_PROFILE_FAST;
 
 /**
+ * 振り返り探索の評価オプションフラグ（hard 相当）
+ *
+ * REVIEW_SEARCH_PARAMS.evaluationOptions（= DIFFICULTY_PARAMS.hard.evaluationOptions）を
+ * WASM ビット表現にエンコードしたもの。findBestMoveForReview に渡して必須防御/ミセ脅威/
+ * 禁手脆弱性/葉 single-four ペナルティ等の hard 評価を有効化する。
+ */
+const REVIEW_EVAL_FLAGS = encodeEvalOptions(
+  REVIEW_SEARCH_PARAMS.evaluationOptions,
+);
+
+/**
  * WASM 探索エンジンで minimax 探索を実行し、TS 版と同じ結果型に変換する
  */
 function executeWasmSearch(
@@ -75,6 +86,10 @@ function executeWasmSearch(
   profile: ReviewProfile,
 ): IterativeDeepingResult {
   const aspirationMode = profile.aspirationWidths ? 1 : 0;
+  // hard 相当の評価オプション（必須防御/ミセ脅威/禁手脆弱性/single-four ペナルティ等）を
+  // WASM 探索本体に配線する。ここを 0 にするとレビュー探索は素 eval で読み、
+  // 白14 F11 のような深度感受性手の判定で精度を落とす。
+  const evalOptionsFlags = profile.evalOptionsOverride ?? REVIEW_EVAL_FLAGS;
   const wasmResult = engine.findBestMoveForReview(
     board,
     color,
@@ -83,6 +98,7 @@ function executeWasmSearch(
     maxNodes,
     profile.absoluteTimeLimit ?? 0,
     aspirationMode,
+    evalOptionsFlags,
   );
 
   // WASM 候補手を MoveScoreEntry[] に変換

--- a/src/logic/cpu/review/reviewConstants.ts
+++ b/src/logic/cpu/review/reviewConstants.ts
@@ -24,14 +24,26 @@ export const REVIEW_REDUCED_NODES = 500_000;
  * 高速モード: main 相当の時間制限ベース探索
  * 精密モード: ノード数制限 + Aspiration Window 段階的拡大 + PV 事後検証
  */
+/**
+ * 高速モード時間上限の根拠（2026-06-14, profile-review 実測）:
+ * - eval=hard 配線(A1)とセットで運用する前提で 5_000ms。
+ * - 旧 15_000 比で 1局解析時間 -約47%。
+ * - 白14 F11 のような中盤深度感受性手は eval=hard が depth6 で実スコア(-2588)を見せるため、
+ *   tl=5000 でも判定品質を維持できる（実測 excellent）。
+ * - eval=hard を切ると(検証時の evalOptionsOverride=0)、tl=5000 では深度不足で判定崩壊する。
+ *   A1 と A4 は必ずセット。
+ */
 export const REVIEW_PROFILE_FAST = {
   maxNodes: 2_000_000,
-  timeLimit: 15_000 as number | undefined,
-  absoluteTimeLimit: 20_000 as number | undefined,
+  timeLimit: 5_000 as number | undefined,
+  absoluteTimeLimit: 10_000 as number | undefined,
   aspirationWidths: undefined as number[] | undefined,
   verifyCandidatesBudget: "dynamic" as "dynamic" | number,
   enablePVVerification: false,
   clearTT: true,
+  // 評価オプションフラグの上書き（profile-review の --eval=none 検証用）。
+  // undefined のとき REVIEW_SEARCH_PARAMS.evaluationOptions（hard 相当）が使われる。
+  evalOptionsOverride: undefined as number | undefined,
 };
 
 export const REVIEW_PROFILE_PRECISE = {
@@ -42,6 +54,7 @@ export const REVIEW_PROFILE_PRECISE = {
   verifyCandidatesBudget: Infinity as "dynamic" | number,
   enablePVVerification: true,
   clearTT: false,
+  evalOptionsOverride: undefined as number | undefined,
 };
 
 /** 振り返り用VCT探索パラメータ（forcedWin表示用、分岐収集あり） */

--- a/src/logic/cpu/review/reviewEvalWiring.test.ts
+++ b/src/logic/cpu/review/reviewEvalWiring.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Review eval=hard 配線テスト（A1: 評価オプション配線漏れの修正）
+ *
+ * findBestMoveForReview の evalOptionsFlags パラメータ追加に伴い、
+ * REVIEW_SEARCH_PARAMS.evaluationOptions が hard 相当でエンコードされ、
+ * 0 のままWASM探索本体に渡らないことを検証する。
+ *
+ * 旧コードは searchEngine.ts:194 で WASM findBestMove の eval_flags 引数を 0 ハードコード
+ * していたため、レビュー探索は必須防御/ミセ脅威/禁手脆弱性/single-four ペナルティを
+ * 切った素 eval で読んでいた。白14クラスの深度感受性手で判定精度を落とす原因。
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { DIFFICULTY_PARAMS } from "@/types/cpu";
+
+import { encodeEvalOptions } from "../wasm/searchEngine";
+import { REVIEW_SEARCH_PARAMS } from "./reviewConstants";
+
+describe("Review eval=hard 配線（A1）", () => {
+  it("REVIEW_SEARCH_PARAMS.evaluationOptions のエンコード結果は 0 でない", () => {
+    const flags = encodeEvalOptions(REVIEW_SEARCH_PARAMS.evaluationOptions);
+    expect(flags).not.toBe(0);
+  });
+
+  it("REVIEW_SEARCH_PARAMS.evaluationOptions のエンコードは hard 相当と一致（SSoT）", () => {
+    const reviewFlags = encodeEvalOptions(
+      REVIEW_SEARCH_PARAMS.evaluationOptions,
+    );
+    const hardFlags = encodeEvalOptions(
+      DIFFICULTY_PARAMS.hard.evaluationOptions,
+    );
+    expect(reviewFlags).toBe(hardFlags);
+  });
+
+  it("eval=none（フラグ0）と hard で異なる値になる", () => {
+    const hardFlags = encodeEvalOptions(REVIEW_SEARCH_PARAMS.evaluationOptions);
+    expect(hardFlags).not.toBe(0);
+  });
+});

--- a/src/logic/cpu/wasm/searchEngine.ts
+++ b/src/logic/cpu/wasm/searchEngine.ts
@@ -37,7 +37,7 @@ import {
  *
  * Zig 側: main.zig findBestMove が bits 9-17 をデコードして board_eval_options を構築する。
  */
-function encodeEvalOptions(opts: EvaluationOptions): number {
+export function encodeEvalOptions(opts: EvaluationOptions): number {
   // ビット位置: Zig position_eval.decodeEvalOptions と一致
   const bits: boolean[] = [
     opts.enableMise, // bit 0
@@ -171,6 +171,11 @@ export class WasmSearchEngine {
    *
    * aspiration_mode=1 で段階的拡大幅 [75, 200, 500] を使用。
    * 探索後に各候補手の PV を TT から抽出する。
+   *
+   * evalOptionsFlags: encodeEvalOptions で生成した hard 相当のフラグ。
+   * 0 を渡すと WASM 側は必須防御/ミセ脅威/禁手脆弱性などを切った素 eval で読むため、
+   * 呼び出し側で必ず hard 相当（または検証用 0）を明示する。デフォルト引数を持たせない
+   * のは、新規呼び出し経路で配線を忘れて素 eval に落ちる silent regression を防ぐため。
    */
   findBestMoveForReview(
     board: BoardState,
@@ -180,6 +185,7 @@ export class WasmSearchEngine {
     maxNodes: number,
     absoluteTimeLimitMs: number,
     aspirationMode: number,
+    evalOptionsFlags: number,
   ): WasmSearchResultWithCandidates {
     const wasmColor = colorToWasm(color);
     boardStateToWasm(this.wasm, board);
@@ -191,7 +197,7 @@ export class WasmSearchEngine {
       maxNodes,
       absoluteTimeLimitMs,
       aspirationMode,
-      0,
+      evalOptionsFlags,
     );
     const result = this.readResultWithCandidates();
 


### PR DESCRIPTION
## Summary

振り返り解析ツールの **悪手好手判定の精度向上** と **高速化** を3コミットで実施。

| commit | 種別 | 効果 |
|---|---|---|
| 73dc2d9 (B1) | fix | 候補外実手を追加探索して実スコア推定。`-2000` 固定の誤 blunder を解消 |
| 84dd938 (A1) | fix | `findBestMoveForReview` の eval_flags 配線漏れを修正（0 → hard 相当） |
| 5437161 (A4) | perf | FAST モードの timeLimit を 15_000ms → 5_000ms に短縮 |

A1 と A4 は**必ずセット運用**（eval=hard を切ると tl5k では深度不足で判定崩壊）。

## 検証結果（profile-review.ts, 白番29手 F11反転棋譜）

### 焦点: 白14 F11（中盤深度感受性手）

| 構成 | quality | scoreDiff | playedScore | depth |
|---|---|---|---|---|
| 旧コード (eval=none × tl15k) | blunder | 96611 | -99999 | 7 |
| A1 のみ (eval=hard × tl15k) | blunder | 2204 | -2588 | 7 |
| **A1+A4 (eval=hard × tl5k, デフォルト)** | **excellent** | **0** | -2588 | 6 |

### 全手影響

- **白4 G7 / 白6 H7**: B1 で誤 blunder → inaccuracy / good に修正
- **白14 F11**: A1+A4 で blunder → excellent（focal）
- **白22 J5**: 敗着 blunder 検出は維持
- **白2 G8 / 白10 E9**: hard 評価で新たに inaccuracy/mistake 判定（より厳しい・正確な判定。閾値見直しは別案件）

### 速度

- 旧 (eval=none × tl15k): 60-70秒/局 → 新 (eval=hard × tl5k): 32-37秒/局 → **-47%**

## ドロップした項目

- **B2 (break-on-safe / alwaysVerify)**: 白14反転の真因が MAIN MINIMAX DEPTH 駆動と判明したため不要（候補リスト依存ではない）
- **C系列 (TT手またぎ / PRECISEバジェット)**: FAST がデフォルトなのでユーザー体感に効かず DROP

## 安全装置

- `findBestMoveForReview` の `evalOptionsFlags` を**必須引数化**（デフォルト 0 を撤廃 ＝ 新規呼び出し経路で配線忘れによる silent regression を防止）
- `reviewEvalWiring.test.ts` で `encodeEvalOptions(REVIEW_SEARCH_PARAMS.evaluationOptions)` が hard と一致する SSoT 不変条件をガード
- `profile-review --eval=hard|none` で配線確認・退行検証可能

## 注意点

- 計測棋譜は **1局のみ**（汎化未検証）。他棋譜での挙動は要追跡
- 白2/白10 の新規 inaccuracy/mistake はユーザー体感では「悪手が増えた」と映る可能性あり（hard 評価の精緻化による正当な判定）

## Test plan

- [x] pnpm check-fix（型 + format + lint）緑
- [x] pnpm test（unit + scripts 1532 tests）緑
- [x] zig build test 緑（pre-commit）
- [x] profile-review.ts でデフォルト構成（A1+A4適用）の白14救出を確認
- [ ] ブラウザで実際の振り返り画面を開き、白14が blunder 表示されないこと、解析時間短縮を体感確認
- [ ] 別棋譜（黒番23手, `H8 I9 F7 G8 I7 G7 G9 F10 J6 K5 H6 G5 G6 I6 H7 H5 F5 E4 J7 H10 J9 J5 I8`）で退行ないことを確認

## 参考ドキュメント

- `docs/plans/review-eval-wiring-results-2026-06-14.md` — A1+A4 計測詳細