### PR TITLE
feat(ui): アイコンボタンに下部ラベルを追加し aria-label を整理

### DIFF
--- a/src/components/common/FullscreenButton.vue
+++ b/src/components/common/FullscreenButton.vue
@@ -44,7 +44,7 @@ const toggle = async (): Promise<void> => {
       class="fullscreen-button__icon"
     />
     <span class="fullscreen-button__label">
-      {{ isFullscreen ? "終了" : "全画面" }}
+      {{ isFullscreen ? "画面縮小" : "全画面" }}
     </span>
   </button>
 </template>
@@ -81,7 +81,8 @@ const toggle = async (): Promise<void> => {
 }
 
 .fullscreen-button__label {
-  font-size: var(--size-9);
+  /* 「画面縮小」が 40px ボタン枠に収まるよう他ボタン(9px)より小さく */
+  font-size: var(--size-7);
   line-height: 1;
   font-weight: 500;
   white-space: nowrap;

--- a/src/components/common/FullscreenButton.vue
+++ b/src/components/common/FullscreenButton.vue
@@ -33,11 +33,19 @@ const toggle = async (): Promise<void> => {
   <button
     v-if="isSupported"
     class="fullscreen-button"
-    :aria-label="isFullscreen ? '全画面を終了' : '全画面表示'"
     @click="toggle"
   >
-    <FullscreenExitIcon v-if="isFullscreen" />
-    <FullscreenIcon v-else />
+    <FullscreenExitIcon
+      v-if="isFullscreen"
+      class="fullscreen-button__icon"
+    />
+    <FullscreenIcon
+      v-else
+      class="fullscreen-button__icon"
+    />
+    <span class="fullscreen-button__label">
+      {{ isFullscreen ? "終了" : "全画面" }}
+    </span>
   </button>
 </template>
 
@@ -45,25 +53,37 @@ const toggle = async (): Promise<void> => {
 .fullscreen-button {
   width: var(--size-40);
   height: var(--size-40);
-  padding: var(--size-8);
+  padding: var(--size-3);
   background: rgba(255, 255, 255, 0.9);
   border: var(--size-2) solid var(--color-border);
   border-radius: var(--size-8);
   cursor: pointer;
   transition: all 0.2s ease;
   color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-2);
 
   &:hover {
     background: white;
     border-color: var(--color-border-heavy);
     color: var(--color-text-primary);
   }
+}
 
-  svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-    margin: auto;
-  }
+.fullscreen-button__icon {
+  display: block;
+  width: var(--size-20);
+  height: var(--size-20);
+  flex-shrink: 0;
+}
+
+.fullscreen-button__label {
+  font-size: var(--size-9);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/common/InfoButton.vue
+++ b/src/components/common/InfoButton.vue
@@ -9,10 +9,10 @@ defineEmits<{
 <template>
   <button
     class="info-button"
-    aria-label="情報"
     @click="$emit('click')"
   >
-    <InfoIcon />
+    <InfoIcon class="info-button__icon" />
+    <span class="info-button__label">情報</span>
   </button>
 </template>
 
@@ -20,25 +20,37 @@ defineEmits<{
 .info-button {
   width: var(--size-40);
   height: var(--size-40);
-  padding: var(--size-8);
+  padding: var(--size-3);
   background: rgba(255, 255, 255, 0.9);
   border: var(--size-2) solid var(--color-border);
   border-radius: var(--size-8);
   cursor: pointer;
   transition: all 0.2s ease;
   color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-2);
 
   &:hover {
     background: white;
     border-color: var(--color-border-heavy);
     color: var(--color-text-primary);
   }
+}
 
-  svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-    margin: auto;
-  }
+.info-button__icon {
+  display: block;
+  width: var(--size-20);
+  height: var(--size-20);
+  flex-shrink: 0;
+}
+
+.info-button__label {
+  font-size: var(--size-9);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/common/InfoDialog.vue
+++ b/src/components/common/InfoDialog.vue
@@ -24,10 +24,10 @@ defineExpose({
         <button
           type="button"
           class="close-button"
-          aria-label="閉じる"
           @click="dialogRef?.close()"
         >
-          <CloseIcon />
+          <CloseIcon class="close-button__icon" />
+          <span class="close-button__label">閉じる</span>
         </button>
       </div>
 
@@ -261,23 +261,37 @@ defineExpose({
 .close-button {
   width: var(--size-32);
   height: var(--size-32);
-  padding: var(--size-6);
+  padding: var(--size-2);
   background: transparent;
   border: none;
   border-radius: var(--size-6);
   cursor: pointer;
   color: var(--color-text-secondary);
   transition: all 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-1);
 
   &:hover {
     background: var(--color-bg-gray);
     color: var(--color-text-primary);
   }
+}
 
-  svg {
-    width: 100%;
-    height: 100%;
-  }
+.close-button__icon {
+  display: block;
+  width: var(--size-14);
+  height: var(--size-14);
+  flex-shrink: 0;
+}
+
+.close-button__label {
+  font-size: var(--size-8);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .dialog-body {

--- a/src/components/common/PreferencesDialog.vue
+++ b/src/components/common/PreferencesDialog.vue
@@ -84,10 +84,10 @@ defineExpose({
         <button
           type="button"
           class="close-button"
-          aria-label="閉じる"
           @click="dialogRef?.close()"
         >
-          <CloseIcon />
+          <CloseIcon class="close-button__icon" />
+          <span class="close-button__label">閉じる</span>
         </button>
       </div>
 
@@ -476,23 +476,37 @@ defineExpose({
 .close-button {
   width: var(--size-32);
   height: var(--size-32);
-  padding: var(--size-6);
+  padding: var(--size-2);
   background: transparent;
   border: none;
   border-radius: var(--size-6);
   cursor: pointer;
   color: var(--color-text-secondary);
   transition: all 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-1);
 
   &:hover {
     background: var(--color-bg-gray);
     color: var(--color-text-primary);
   }
+}
 
-  svg {
-    width: 100%;
-    height: 100%;
-  }
+.close-button__icon {
+  display: block;
+  width: var(--size-14);
+  height: var(--size-14);
+  flex-shrink: 0;
+}
+
+.close-button__label {
+  font-size: var(--size-8);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .dialog-body {

--- a/src/components/common/SettingsButton.vue
+++ b/src/components/common/SettingsButton.vue
@@ -9,10 +9,10 @@ defineEmits<{
 <template>
   <button
     class="settings-button"
-    aria-label="設定"
     @click="$emit('click')"
   >
-    <SettingsIcon />
+    <SettingsIcon class="settings-button__icon" />
+    <span class="settings-button__label">設定</span>
   </button>
 </template>
 
@@ -20,25 +20,37 @@ defineEmits<{
 .settings-button {
   width: var(--size-40);
   height: var(--size-40);
-  padding: var(--size-8);
+  padding: var(--size-3);
   background: rgba(255, 255, 255, 0.9);
   border: var(--size-2) solid var(--color-border);
   border-radius: var(--size-8);
   cursor: pointer;
   transition: all 0.2s ease;
   color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-2);
 
   &:hover {
     background: white;
     border-color: var(--color-border-heavy);
     color: var(--color-text-primary);
   }
+}
 
-  svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-    margin: auto;
-  }
+.settings-button__icon {
+  display: block;
+  width: var(--size-20);
+  height: var(--size-20);
+  flex-shrink: 0;
+}
+
+.settings-button__label {
+  font-size: var(--size-9);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/cpu/CpuReviewPlayer.vue
+++ b/src/components/cpu/CpuReviewPlayer.vue
@@ -328,25 +328,25 @@ function handleLayoutClick(event: MouseEvent): void {
       <template #header-controls>
         <button
           class="header-icon-button"
-          aria-label="評価の読み方ヘルプ"
           @click="openHelp"
         >
-          <InfoIcon />
+          <InfoIcon class="header-icon-button__icon" />
+          <span class="header-icon-button__label">ヘルプ</span>
         </button>
         <button
           class="header-icon-button"
-          aria-label="棋譜を読み込む"
           @click="importDialogRef?.showModal()"
         >
-          <UploadFileIcon />
+          <UploadFileIcon class="header-icon-button__icon" />
+          <span class="header-icon-button__label">読込</span>
         </button>
         <button
           class="header-icon-button"
-          aria-label="再分析"
           :disabled="evaluator.isEvaluating.value"
           @click="handleReanalyze"
         >
-          <RefreshIcon />
+          <RefreshIcon class="header-icon-button__icon" />
+          <span class="header-icon-button__label">再分析</span>
         </button>
         <SettingsControl />
       </template>
@@ -461,13 +461,18 @@ function handleLayoutClick(event: MouseEvent): void {
 .header-icon-button {
   width: var(--size-40);
   height: var(--size-40);
-  padding: var(--size-8);
+  padding: var(--size-3);
   background: rgba(255, 255, 255, 0.9);
   border: var(--size-2) solid var(--color-border);
   border-radius: var(--size-8);
   cursor: pointer;
   transition: all 0.2s ease;
   color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-2);
 
   &:hover:not(:disabled) {
     background: white;
@@ -479,13 +484,20 @@ function handleLayoutClick(event: MouseEvent): void {
     opacity: 0.4;
     cursor: not-allowed;
   }
+}
 
-  svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-    margin: auto;
-  }
+.header-icon-button__icon {
+  display: block;
+  width: var(--size-20);
+  height: var(--size-20);
+  flex-shrink: 0;
+}
+
+.header-icon-button__label {
+  font-size: var(--size-9);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .control-info-content {

--- a/src/components/cpu/GameRecordImportDialog.vue
+++ b/src/components/cpu/GameRecordImportDialog.vue
@@ -74,10 +74,10 @@ defineExpose({
         <button
           type="button"
           class="close-button"
-          aria-label="閉じる"
           @click="dialogRef?.close()"
         >
-          <CloseIcon />
+          <CloseIcon class="close-button__icon" />
+          <span class="close-button__label">閉じる</span>
         </button>
       </div>
 
@@ -218,23 +218,37 @@ defineExpose({
 .close-button {
   width: var(--size-28);
   height: var(--size-28);
-  padding: var(--size-4);
+  padding: var(--size-2);
   background: transparent;
   border: none;
   border-radius: var(--size-6);
   cursor: pointer;
   color: var(--color-text-secondary);
   transition: all 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-1);
 
   &:hover {
     background: var(--color-bg-gray);
     color: var(--color-text-primary);
   }
+}
 
-  svg {
-    width: 100%;
-    height: 100%;
-  }
+.close-button__icon {
+  display: block;
+  width: var(--size-14);
+  height: var(--size-14);
+  flex-shrink: 0;
+}
+
+.close-button__label {
+  font-size: var(--size-8);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .dialog-body {

--- a/src/components/cpu/ReviewEvalHelpDialog.vue
+++ b/src/components/cpu/ReviewEvalHelpDialog.vue
@@ -27,10 +27,10 @@ defineExpose({
         <button
           type="button"
           class="close-button"
-          aria-label="閉じる"
           @click="dialogRef?.close()"
         >
-          <CloseIcon />
+          <CloseIcon class="close-button__icon" />
+          <span class="close-button__label">閉じる</span>
         </button>
       </div>
       <div class="help-body">
@@ -199,23 +199,37 @@ defineExpose({
 .close-button {
   width: var(--size-28);
   height: var(--size-28);
-  padding: var(--size-4);
+  padding: var(--size-2);
   background: transparent;
   border: none;
   border-radius: var(--size-6);
   cursor: pointer;
   color: var(--color-text-secondary);
   transition: all 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--size-1);
 
   &:hover {
     background: var(--color-bg-gray);
     color: var(--color-text-primary);
   }
+}
 
-  svg {
-    width: 100%;
-    height: 100%;
-  }
+.close-button__icon {
+  display: block;
+  width: var(--size-14);
+  height: var(--size-14);
+  flex-shrink: 0;
+}
+
+.close-button__label {
+  font-size: var(--size-8);
+  line-height: 1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .help-body {

--- a/src/style.css
+++ b/src/style.css
@@ -203,6 +203,7 @@
   --size-4: clamp(3px, calc(var(--effective-vw) * 0.00417), 5px); /* 4px */
   --size-5: clamp(3px, calc(var(--effective-vw) * 0.00521), 7px); /* 5px */
   --size-6: clamp(4px, calc(var(--effective-vw) * 0.00625), 8px); /* 6px */
+  --size-7: clamp(4.5px, calc(var(--effective-vw) * 0.00729), 9.5px); /* 7px */
   --size-8: clamp(5px, calc(var(--effective-vw) * 0.00833), 11px); /* 8px */
   --size-9: clamp(6px, calc(var(--effective-vw) * 0.00938), 12px); /* 9px */
   --size-10: clamp(7px, calc(var(--effective-vw) * 0.01042), 14px); /* 10px */


### PR DESCRIPTION
## Summary
- 40×40 のヘッダー系アイコンボタン群と、28〜32px のダイアログ閉じる（×）ボタンに**可視テキストラベル**を追加。アイコン上 / ラベル下のレイアウトで、**ボタンサイズは維持**。
- 可視ラベルがアクセシブル名を提供するため、冗長になる `aria-label` を全対象から削除（スクリーンリーダの重複読み上げ防止）。
- BEM 風（`__icon` / `__label`）でアイコン・ラベル要素にクラス名を付与し、サイズや色の制御を局所化。

## 対象ボタン
| 区分 | コンポーネント | サイズ | ラベル |
| --- | --- | --- | --- |
| ヘッダー | `common/InfoButton` | 40×40 | 情報 |
| ヘッダー | `common/SettingsButton` | 40×40 | 設定 |
| ヘッダー | `common/FullscreenButton` | 40×40 | 全画面 / 終了 |
| ヘッダー | `cpu/CpuReviewPlayer` 内 `.header-icon-button` × 3 | 40×40 | ヘルプ / 読込 / 再分析 |
| ダイアログ閉じる | `common/InfoDialog` | 32×32 | 閉じる |
| ダイアログ閉じる | `common/PreferencesDialog` | 32×32 | 閉じる |
| ダイアログ閉じる | `cpu/ReviewEvalHelpDialog` | 28×28 | 閉じる |
| ダイアログ閉じる | `cpu/GameRecordImportDialog` | 28×28 | 閉じる |

**対象外**: `cpu/ReviewStatus` の棋譜コピーボタン（24×24）はサイズ不足のため触らず、aria-label を残置。

## 実装メモ
- ラベル文字サイズは `var(--size-9)` / 閉じるボタンは `var(--size-8)` の raw 値を使用（`--font-size-*` の text-size-multiplier 1.5x でボタンからはみ出さないため）。
- 40×40 ボタンはアイコン 20px / ラベル 9px、28〜32px ボタンはアイコン 14px / ラベル 8px。
- a11y ツリー上で button のアクセシブル名が「全画面」「情報」「閉じる」等の可視テキストになることを Chrome DevTools で確認済み。

## Test plan
- [x] `pnpm check-fix`（type-check / format / lint）緑
- [x] `pnpm test`（unit / scripts）1532 件緑
- [x] Zig テスト緑
- [x] Chrome で目視確認: メニュー画面（全画面 / 情報 / 設定）、振り返り画面ヘッダー（ヘルプ / 読込 / 再分析 / 設定）、Info / Preferences / Help / Import の各ダイアログの閉じるボタン
- [x] a11y ツリー（accessibility tree）上でボタンのアクセシブル名が可視テキストどおりであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)