### PR TITLE
refactor(ui): 残りのアイコンボタン 5 箇所を IconButton に統合

### DIFF
--- a/src/components/cpu/CpuGameStatus.vue
+++ b/src/components/cpu/CpuGameStatus.vue
@@ -9,6 +9,9 @@ import { computed, ref } from "vue";
 
 import { useCpuGameStore } from "@/stores/cpuGameStore";
 import { DIFFICULTY_ARIA_LABELS, DIFFICULTY_LABELS } from "@/types/cpu";
+import IconButton from "@/components/common/IconButton.vue";
+import ContentCopyIcon from "@/assets/icons/content_copy.svg?component";
+import CheckIcon from "@/assets/icons/check.svg?component";
 
 // 座標を棋譜形式に変換
 function formatPosition(row: number, col: number): string {
@@ -109,13 +112,17 @@ async function handleCopy(): Promise<void> {
   <div class="move-history-card">
     <div class="section-header">
       <h4 class="section-title">棋譜</h4>
-      <button
+      <IconButton
         v-if="cpuGameStore.moveHistory.length > 0"
-        class="copy-button"
+        size="xs"
+        variant="ghost"
+        :tone="isCopied ? 'accent' : 'default'"
+        aria-label="棋譜をコピー"
         @click="handleCopy"
       >
-        {{ isCopied ? "✓" : "コピー" }}
-      </button>
+        <CheckIcon v-if="isCopied" />
+        <ContentCopyIcon v-else />
+      </IconButton>
     </div>
     <div
       v-if="cpuGameStore.moveHistory.length === 0"
@@ -229,20 +236,6 @@ async function handleCopy(): Promise<void> {
   font-weight: 500;
   color: var(--color-text-secondary);
   margin: 0;
-}
-
-.copy-button {
-  font-size: var(--size-10);
-  padding: var(--size-2) var(--size-6);
-  background: var(--color-background-tertiary);
-  border: 1px solid var(--color-border-light);
-  border-radius: var(--size-4);
-  cursor: pointer;
-  transition: background 0.2s;
-}
-
-.copy-button:hover {
-  background: var(--color-background-hover);
 }
 
 .empty-history {

--- a/src/components/cpu/CpuRecordDialog.vue
+++ b/src/components/cpu/CpuRecordDialog.vue
@@ -15,6 +15,8 @@ import {
   DIFFICULTY_LABELS,
   type BattleResult,
 } from "@/types/cpu";
+import IconButton from "@/components/common/IconButton.vue";
+import CloseIcon from "@/assets/icons/close.svg?component";
 
 const appStore = useAppStore();
 const cpuRecordStore = useCpuRecordStore();
@@ -72,13 +74,14 @@ defineExpose({
     <div class="dialog-content">
       <header class="dialog-header">
         <h2 class="dialog-title">対戦記録</h2>
-        <button
-          type="button"
-          class="close-button"
+        <IconButton
+          size="sm"
+          variant="ghost"
+          label="閉じる"
           @click="handleClose"
         >
-          ×
-        </button>
+          <CloseIcon />
+        </IconButton>
       </header>
 
       <section class="stats-section">
@@ -225,21 +228,6 @@ defineExpose({
   font-size: var(--size-20);
   font-weight: 500;
   color: var(--color-text-primary);
-}
-
-.close-button {
-  background: none;
-  border: none;
-  font-size: var(--size-24);
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  padding: var(--size-4);
-  line-height: 1;
-  transition: color 0.2s;
-
-  &:hover {
-    color: var(--color-text-primary);
-  }
 }
 
 .section-title {

--- a/src/components/cpu/JushuSelectDialog.vue
+++ b/src/components/cpu/JushuSelectDialog.vue
@@ -10,6 +10,8 @@ import { ref, watch } from "vue";
 
 import { useLightDismiss } from "@/composables/useLightDismiss";
 import { DIAGONAL_PATTERNS, ORTHOGONAL_PATTERNS } from "@/logic/cpu/opening";
+import IconButton from "@/components/common/IconButton.vue";
+import CloseIcon from "@/assets/icons/close.svg?component";
 
 type TabType = "orthogonal" | "diagonal";
 
@@ -89,13 +91,14 @@ defineExpose({
     <div class="dialog-content">
       <header class="dialog-header">
         <h2 class="dialog-title">珠型を選択</h2>
-        <button
-          type="button"
-          class="close-button"
+        <IconButton
+          size="sm"
+          variant="ghost"
+          label="閉じる"
           @click="handleClose"
         >
-          ×
-        </button>
+          <CloseIcon />
+        </IconButton>
       </header>
 
       <!-- タブ切替 -->
@@ -302,21 +305,6 @@ defineExpose({
   font-size: var(--size-16);
   font-weight: 500;
   color: var(--color-text-primary);
-}
-
-.close-button {
-  background: none;
-  border: none;
-  font-size: var(--size-24);
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  padding: var(--size-4);
-  line-height: 1;
-  transition: color 0.2s;
-
-  &:hover {
-    color: var(--color-text-primary);
-  }
 }
 
 .tab-bar {

--- a/src/editor/components/EmotionPickerDialog.vue
+++ b/src/editor/components/EmotionPickerDialog.vue
@@ -7,6 +7,8 @@ import {
 } from "@/types/character";
 import CharacterSprite from "@/components/character/CharacterSprite.vue";
 import { useLightDismiss } from "@/composables/useLightDismiss";
+import IconButton from "@/components/common/IconButton.vue";
+import CloseIcon from "@/assets/icons/close.svg?component";
 
 interface Props {
   character: CharacterType;
@@ -54,13 +56,14 @@ const characterName = computed(() =>
     <div class="dialog-wrapper">
       <div class="dialog-header">
         <h2>{{ characterName }}の表情を選択</h2>
-        <button
-          class="close-button"
-          aria-label="ダイアログを閉じる"
+        <IconButton
+          size="sm"
+          variant="ghost"
+          label="閉じる"
           @click="dialogRef?.close()"
         >
-          ✕
-        </button>
+          <CloseIcon />
+        </IconButton>
       </div>
 
       <div class="dialog-content">
@@ -125,25 +128,6 @@ const characterName = computed(() =>
   margin: 0;
   font-size: 1.2rem;
   font-weight: 500;
-}
-
-.close-button {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-
-  &:hover {
-    color: var(--color-text-primary);
-  }
-  overflow-y: auto;
-  flex: 1;
-  .active {
-    border-bottom-color: var(--color-primary);
-    color: var(--color-text-primary);
-    font-weight: 500;
-  }
 }
 
 .emotion-grid {

--- a/src/editor/components/GameBrowser/GameBrowserDialog.vue
+++ b/src/editor/components/GameBrowser/GameBrowserDialog.vue
@@ -4,6 +4,8 @@ import { useLightDismiss } from "@/composables/useLightDismiss";
 import { useGameBrowser } from "@/editor/composables/useGameBrowser";
 import GameListPanel from "./GameListPanel.vue";
 import GamePlaybackPanel from "./GamePlaybackPanel.vue";
+import IconButton from "@/components/common/IconButton.vue";
+import CloseIcon from "@/assets/icons/close.svg?component";
 
 const dialogRef = ref<HTMLDialogElement | null>(null);
 useLightDismiss(dialogRef);
@@ -61,12 +63,14 @@ defineExpose({ showModal, close });
     <div class="dialog-inner">
       <div class="dialog-header">
         <h2>棋譜ブラウザ</h2>
-        <button
-          class="close-button"
+        <IconButton
+          size="sm"
+          variant="ghost"
+          label="閉じる"
           @click="close"
         >
-          ✕
-        </button>
+          <CloseIcon />
+        </IconButton>
       </div>
 
       <div
@@ -162,19 +166,6 @@ defineExpose({ showModal, close });
 .dialog-header h2 {
   margin: 0;
   font-size: 16px;
-}
-
-.close-button {
-  background: none;
-  border: none;
-  font-size: 18px;
-  cursor: pointer;
-  padding: 4px 8px;
-  color: #666;
-}
-
-.close-button:hover {
-  color: #333;
 }
 
 .loading,


### PR DESCRIPTION
## Summary
PR #95（ラベル追加）・PR #96（IconButton 抽出）でスコープ外だった残りのアイコンボタン群を IconButton に揃える。

## 対象
| ファイル | 変更前 | 変更後 |
| --- | --- | --- |
| \`cpu/CpuRecordDialog.vue\` | \`×\` テキスト (font-size 24px) | \`IconButton sm + CloseIcon + 「閉じる」\` |
| \`cpu/JushuSelectDialog.vue\` | \`×\` テキスト | 同上 |
| \`cpu/CpuGameStatus.vue\` | テキスト「コピー」/「✓」ボタン | \`IconButton xs + ContentCopyIcon/CheckIcon + tone='accent'\` |
| \`editor/EmotionPickerDialog.vue\` | \`✕\` テキスト | \`IconButton sm + CloseIcon + 「閉じる」\` |
| \`editor/GameBrowser/GameBrowserDialog.vue\` | \`✕\` テキスト | 同上 |

すべて a11y アクセシブル名は可視テキスト（「閉じる」）または \`aria-label\`（\`xs\` ラベルなしのコピーボタン）で確保。各ファイルからローカル \`.close-button\` / \`.copy-button\` CSS を全削除。

## 対象外（今 PR では触らず）
- \`editor/GameBrowser/GamePlaybackPanel.vue\` のコピーボタン: 元は **フル幅の青色プライマリ CTA**（\`background: #4a90e2\`, \`width: 100%\`）。28×28 アイコンへの置換は視覚的に大きなダウングレードになるため、IconButton の責務範囲外として保留。

## 視覚的な変化
- \`×\` / \`✕\` テキスト → 統一された IconButton アイコン + 「閉じる」 ラベル（他ダイアログと同じ見た目）
- CpuGameStatus の「コピー」テキストボタン → アイコンのみ（24×24）。tooltip 代わりに aria-label="棋譜をコピー" を付与し、コピー成功時は CheckIcon + fubuki 色に切替（ReviewStatus と同じパターン）

## Test plan
- [x] \`pnpm check-fix\`（型 / format / lint）緑
- [x] \`pnpm test\` 1532 件緑、Zig テスト緑、pre-commit / pre-push 全通過
- [x] Chrome で JushuSelectDialog / CpuRecordDialog の閉じるボタンが他ダイアログと同じ見た目で表示されることを目視確認
- [x] a11y ツリーで close ボタンが「閉じる」というアクセシブル名を持つことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)