### PR TITLE
feat(cpu): Lv1-3 を弱体化、randomFactor を Worker 層で配線

### DIFF
--- a/scripts/weak-bench.ts
+++ b/scripts/weak-bench.ts
@@ -1,0 +1,428 @@
+/**
+ * 弱体化検証ベンチ
+ *
+ * 目的: ★1（beginner）の弱体化が「初心者でほぼ毎回勝てる」レベルになっているか
+ *   定量確認する。bench-ai.ts は TS CPU 時代の遺物で benchmark/ 依存が削除済みのため、
+ *   このスクリプトは Worker と同じ最終手選択ロジック（WASM 探索 + applyRandomization）で
+ *   ヘッドレス対局を回し、各難易度の勝率だけを出力する。
+ *
+ * 使用例:
+ *   pnpm weak-bench --a=beginner --b=easy --games=20
+ *   pnpm weak-bench --a=beginner --b=hard --games=10
+ */
+
+import type { BoardState, Position } from "../src/types/game.ts";
+
+import { applyMoveInPlace } from "../src/logic/cpu/core/boardUtils.ts";
+import {
+  getAllJushuNames,
+  getJushuPositions,
+  isOpeningPhase,
+} from "../src/logic/cpu/opening.ts";
+import {
+  listChebyshevNeighbors,
+  selectMoveWithRandomization,
+} from "../src/logic/cpu/randomization.ts";
+import {
+  isForbiddenForBlack,
+  preloadForbiddenWasm,
+} from "../src/logic/cpu/wasm/forbiddenAdapter.ts";
+import { loadWasmModule } from "../src/logic/cpu/wasm/loader.ts";
+import { WasmSearchEngine } from "../src/logic/cpu/wasm/searchEngine.ts";
+import { checkWin, createEmptyBoard } from "../src/logic/renjuRules/core.ts";
+import {
+  CPU_DIFFICULTIES,
+  DIFFICULTY_PARAMS,
+  type CpuDifficulty,
+} from "../src/types/cpu.ts";
+
+interface CliOptions {
+  a: CpuDifficulty;
+  b: CpuDifficulty;
+  games: number;
+  all: boolean;
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const opts: CliOptions = {
+    a: "beginner",
+    b: "easy",
+    games: 10,
+    all: false,
+  };
+  for (const arg of args) {
+    if (arg === "--all") {
+      opts.all = true;
+    } else if (arg.startsWith("--a=")) {
+      const v = arg.slice(4);
+      if (CPU_DIFFICULTIES.includes(v as CpuDifficulty)) {
+        opts.a = v as CpuDifficulty;
+      }
+    } else if (arg.startsWith("--b=")) {
+      const v = arg.slice(4);
+      if (CPU_DIFFICULTIES.includes(v as CpuDifficulty)) {
+        opts.b = v as CpuDifficulty;
+      }
+    } else if (arg.startsWith("--games=")) {
+      const n = Number.parseInt(arg.slice(8), 10);
+      if (Number.isFinite(n) && n > 0) {
+        opts.games = n;
+      }
+    }
+  }
+  return opts;
+}
+
+function collectEmptyCells(board: BoardState): Position[] {
+  const empties: Position[] = [];
+  for (let row = 0; row < 15; row++) {
+    const boardRow = board[row];
+    if (!boardRow) {
+      continue;
+    }
+    for (let col = 0; col < 15; col++) {
+      if (boardRow[col] === null) {
+        empties.push({ row, col });
+      }
+    }
+  }
+  return empties;
+}
+
+const RANDOM_NEIGHBOR_RADIUS = 3;
+
+function pickNearbyLegalMove(
+  board: BoardState,
+  turn: "black" | "white",
+  center: Position,
+): Position | null {
+  const neighbors = listChebyshevNeighbors(center, RANDOM_NEIGHBOR_RADIUS);
+  const candidates = neighbors.filter((p) => {
+    if (board[p.row]?.[p.col] !== null) {
+      return false;
+    }
+    if (turn === "black" && isForbiddenForBlack(board, p.row, p.col)) {
+      return false;
+    }
+    return true;
+  });
+  if (candidates.length === 0) {
+    return null;
+  }
+  const idx = Math.floor(Math.random() * candidates.length);
+  return candidates[idx] ?? null;
+}
+
+interface PlayerEngine {
+  difficulty: CpuDifficulty;
+  pick: (board: BoardState, turn: "black" | "white") => Position;
+}
+
+function makePlayer(
+  engine: WasmSearchEngine,
+  difficulty: CpuDifficulty,
+): PlayerEngine {
+  const params = DIFFICULTY_PARAMS[difficulty];
+  return {
+    difficulty,
+    pick(board, turn) {
+      const wasmResult = engine.findBestMove(board, turn, difficulty);
+      return selectMoveWithRandomization({
+        bestMove: wasmResult.position,
+        bestMoveScore: wasmResult.score,
+        criticalScoreThreshold: params.randomCriticalScoreThreshold,
+        randomFactor: params.randomFactor,
+        pickRandomMove: () =>
+          pickNearbyLegalMove(board, turn, wasmResult.position),
+      });
+    },
+  };
+}
+
+type GameOutcome = "blackWin" | "whiteWin" | "draw";
+
+interface GameRecord {
+  outcome: GameOutcome;
+  moves: number;
+  jushu: string;
+  blackDifficulty: CpuDifficulty;
+}
+
+function playGame(
+  black: PlayerEngine,
+  white: PlayerEngine,
+  openingMoves: [Position, Position, Position],
+  jushu: string,
+): GameRecord {
+  const board = createEmptyBoard();
+  const colors: ("black" | "white")[] = ["black", "white", "black"];
+  for (let i = 0; i < 3; i++) {
+    const m = openingMoves[i];
+    const c = colors[i];
+    if (!m || !c) {
+      continue;
+    }
+    applyMoveInPlace(board, m, c);
+  }
+  let moveCount = 3;
+  for (let ply = 0; ply < 200; ply++) {
+    const turn: "black" | "white" = moveCount % 2 === 0 ? "black" : "white";
+    const player = turn === "black" ? black : white;
+    const move: Position = isOpeningPhase(moveCount)
+      ? (collectEmptyCells(board)[0] ?? { row: 7, col: 7 })
+      : player.pick(board, turn);
+    // 黒の禁手チェック
+    if (turn === "black" && isForbiddenForBlack(board, move.row, move.col)) {
+      return {
+        outcome: "whiteWin",
+        moves: moveCount + 1,
+        jushu,
+        blackDifficulty: black.difficulty,
+      };
+    }
+    applyMoveInPlace(board, move, turn);
+    moveCount++;
+    if (checkWin(board, move, turn)) {
+      return {
+        outcome: turn === "black" ? "blackWin" : "whiteWin",
+        moves: moveCount,
+        jushu,
+        blackDifficulty: black.difficulty,
+      };
+    }
+    if (moveCount >= 70) {
+      return {
+        outcome: "draw",
+        moves: moveCount,
+        jushu,
+        blackDifficulty: black.difficulty,
+      };
+    }
+  }
+  return {
+    outcome: "draw",
+    moves: moveCount,
+    jushu,
+    blackDifficulty: black.difficulty,
+  };
+}
+
+interface PairResult {
+  a: CpuDifficulty;
+  b: CpuDifficulty;
+  aWins: number;
+  bWins: number;
+  draws: number;
+  total: number;
+}
+
+function runPair(
+  engine: WasmSearchEngine,
+  a: CpuDifficulty,
+  b: CpuDifficulty,
+  games: number,
+  jushuNames: string[],
+  log: (msg: string) => void,
+): PairResult {
+  const playerA = makePlayer(engine, a);
+  const playerB = makePlayer(engine, b);
+  const result: PairResult = {
+    a,
+    b,
+    aWins: 0,
+    bWins: 0,
+    draws: 0,
+    total: 0,
+  };
+  for (let i = 0; i < games; i++) {
+    const jushuName = jushuNames[i % jushuNames.length] ?? jushuNames[0];
+    if (!jushuName) {
+      break;
+    }
+    const positions = getJushuPositions(jushuName);
+    if (!positions) {
+      continue;
+    }
+    const aIsBlack = i % 2 === 0;
+    const black = aIsBlack ? playerA : playerB;
+    const white = aIsBlack ? playerB : playerA;
+    engine.clearTT();
+    const record = playGame(black, white, positions, jushuName);
+    result.total++;
+    if (record.outcome === "draw") {
+      result.draws++;
+    } else if (
+      (record.outcome === "blackWin" && aIsBlack) ||
+      (record.outcome === "whiteWin" && !aIsBlack)
+    ) {
+      result.aWins++;
+    } else {
+      result.bWins++;
+    }
+    log(
+      `  [${i + 1}/${games}] ${aIsBlack ? `${a}(黒)` : `${b}(黒)`} vs ${aIsBlack ? `${b}(白)` : `${a}(白)`} → ${record.outcome} (${record.moves}手)`,
+    );
+  }
+  return result;
+}
+
+/**
+ * Bradley-Terry 反復で Elo を推定する。
+ * 各プレイヤーの Elo を勾配上昇で更新（K=16、200 イテレーション）。
+ * 平均が 1500 になるよう正規化。
+ */
+function estimateElo(
+  players: CpuDifficulty[],
+  pairs: PairResult[],
+): Record<CpuDifficulty, number> {
+  const elo: Record<string, number> = {};
+  for (const p of players) {
+    elo[p] = 1500;
+  }
+  const K = 16;
+  for (let iter = 0; iter < 200; iter++) {
+    const delta: Record<string, number> = {};
+    for (const p of players) {
+      delta[p] = 0;
+    }
+    for (const r of pairs) {
+      const eA = elo[r.a] ?? 1500;
+      const eB = elo[r.b] ?? 1500;
+      const expA = 1 / (1 + 10 ** ((eB - eA) / 400));
+      const actualA = (r.aWins + 0.5 * r.draws) / r.total;
+      const diff = K * r.total * (actualA - expA);
+      delta[r.a] = (delta[r.a] ?? 0) + diff;
+      delta[r.b] = (delta[r.b] ?? 0) - diff;
+    }
+    for (const p of players) {
+      elo[p] = (elo[p] ?? 1500) + (delta[p] ?? 0) / players.length;
+    }
+  }
+  const mean =
+    players.reduce((sum, p) => sum + (elo[p] ?? 1500), 0) / players.length;
+  const adj: Record<CpuDifficulty, number> = {} as Record<
+    CpuDifficulty,
+    number
+  >;
+  for (const p of players) {
+    adj[p] = (elo[p] ?? 1500) - mean + 1500;
+  }
+  return adj;
+}
+
+async function runAll(games: number): Promise<void> {
+  console.log(`weak-bench --all: 全難易度総当たり, games/pair=${games}`);
+  const wasm = await loadWasmModule();
+  await preloadForbiddenWasm();
+  const engine = new WasmSearchEngine(wasm);
+  const jushuNames = getAllJushuNames();
+  if (jushuNames.length === 0) {
+    console.error("珠型リストが取得できませんでした");
+    process.exit(1);
+  }
+  const players: CpuDifficulty[] = [...CPU_DIFFICULTIES];
+  const pairs: PairResult[] = [];
+  const startTime = Date.now();
+  for (let i = 0; i < players.length; i++) {
+    for (let j = i + 1; j < players.length; j++) {
+      const a = players[i];
+      const b = players[j];
+      if (!a || !b) {
+        continue;
+      }
+      console.log(`\n--- ${a} vs ${b} ---`);
+      const result = runPair(engine, a, b, games, jushuNames, (msg) =>
+        console.log(msg),
+      );
+      pairs.push(result);
+      const winRateA =
+        ((result.aWins + 0.5 * result.draws) / result.total) * 100;
+      console.log(
+        `  → ${a}: ${result.aWins}W ${result.bWins}L ${result.draws}D (勝率 ${winRateA.toFixed(1)}%)`,
+      );
+    }
+  }
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`\n総対局時間: ${elapsed}s`);
+
+  const elo = estimateElo(players, pairs);
+
+  console.log("\n=== ペア勝率表 (行 vs 列, 行の勝率%) ===");
+  const header = ["", ...players].map((s) => s.padEnd(10)).join(" ");
+  console.log(header);
+  for (const a of players) {
+    const row: string[] = [a.padEnd(10)];
+    for (const b of players) {
+      if (a === b) {
+        row.push("-".padEnd(10));
+        continue;
+      }
+      const pair = pairs.find(
+        (p) => (p.a === a && p.b === b) || (p.a === b && p.b === a),
+      );
+      if (!pair) {
+        row.push("-".padEnd(10));
+        continue;
+      }
+      const aWins = pair.a === a ? pair.aWins : pair.bWins;
+      const score = ((aWins + 0.5 * pair.draws) / pair.total) * 100;
+      row.push(`${score.toFixed(1)}%`.padEnd(10));
+    }
+    console.log(row.join(" "));
+  }
+
+  console.log("\n=== Elo ランキング ===");
+  const sorted = [...players].sort((a, b) => (elo[b] ?? 0) - (elo[a] ?? 0));
+  for (let i = 0; i < sorted.length; i++) {
+    const p = sorted[i];
+    if (!p) {
+      continue;
+    }
+    console.log(`  ${i + 1}. ${p.padEnd(10)} Elo ${(elo[p] ?? 0).toFixed(0)}`);
+  }
+}
+
+async function runPairOnly(opts: CliOptions): Promise<void> {
+  console.log(
+    `weak-bench: ${opts.a} vs ${opts.b}, games=${opts.games} (both colors)`,
+  );
+  const wasm = await loadWasmModule();
+  await preloadForbiddenWasm();
+  const engine = new WasmSearchEngine(wasm);
+  const jushuNames = getAllJushuNames();
+  if (jushuNames.length === 0) {
+    console.error("珠型リストが取得できませんでした");
+    process.exit(1);
+  }
+  const result = runPair(
+    engine,
+    opts.a,
+    opts.b,
+    opts.games,
+    jushuNames,
+    (msg) => console.log(msg.trimStart()),
+  );
+  console.log("\n=== 結果 ===");
+  console.log(
+    `${opts.a} 勝率: ${result.aWins}/${result.total} = ${((result.aWins / result.total) * 100).toFixed(1)}%`,
+  );
+  console.log(
+    `${opts.b} 勝率: ${result.bWins}/${result.total} = ${((result.bWins / result.total) * 100).toFixed(1)}%`,
+  );
+  console.log(`引き分け: ${result.draws}/${result.total}`);
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs();
+  if (opts.all) {
+    await runAll(opts.games);
+  } else {
+    await runPairOnly(opts);
+  }
+}
+
+main().catch((e: unknown) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/logic/cpu/cpu.worker.ts
+++ b/src/logic/cpu/cpu.worker.ts
@@ -7,6 +7,8 @@
  * import CpuWorker from './cpu.worker?worker'
  */
 
+import type { Position } from "@/types/game";
+
 import {
   DIFFICULTY_PARAMS,
   type CpuRequest,
@@ -17,6 +19,14 @@ import type { WasmModuleContext } from "./wasm/types";
 
 import { countStones } from "./core/boardUtils";
 import { getOpeningMove, isOpeningPhase } from "./opening";
+import {
+  listChebyshevNeighbors,
+  selectMoveWithRandomization,
+} from "./randomization";
+import {
+  isForbiddenForBlack,
+  preloadForbiddenWasm,
+} from "./wasm/forbiddenAdapter";
 import { loadWasmModule } from "./wasm/loader";
 import { WasmSearchEngine } from "./wasm/searchEngine";
 
@@ -74,11 +84,21 @@ self.onmessage = async (event: MessageEvent<CpuRequest>) => {
       request.difficulty,
     );
 
+    // ★1 等の弱体化: 確率で近傍空き点からランダム選択
+    const finalPosition = await applyRandomization(
+      wasmResult.position,
+      wasmResult.score,
+      request.board,
+      currentTurn,
+      params.randomFactor,
+      params.randomCriticalScoreThreshold,
+    );
+
     const endTime = performance.now();
     const thinkingTime = Math.round(endTime - startTime);
 
     const response: CpuResponse = {
-      position: wasmResult.position,
+      position: finalPosition,
       score: wasmResult.score,
       thinkingTime,
       depth: wasmResult.completedDepth || params.depth,
@@ -97,6 +117,54 @@ self.onmessage = async (event: MessageEvent<CpuRequest>) => {
     self.postMessage(response);
   }
 };
+
+/** 近傍ランダム選択の半径（Chebyshev 距離）。 */
+const RANDOM_NEIGHBOR_RADIUS = 3;
+
+/**
+ * 弱体化レイヤ。確率で「最善手の近傍(Chebyshev≤3)の合法空き点からランダム選択」を返す。
+ *
+ * 全盤面ランダムだと辺境に飛んで不自然なため、bestMove 近辺に絞る。
+ * 黒手番は禁手を除外。近傍に合法手がなければ bestMove にフォールバック。
+ */
+async function applyRandomization(
+  bestMove: Position,
+  bestMoveScore: number,
+  board: CpuRequest["board"],
+  turn: "black" | "white",
+  randomFactor: number,
+  criticalScoreThreshold: number | undefined,
+): Promise<Position> {
+  if (randomFactor <= 0) {
+    return bestMove;
+  }
+  if (turn === "black") {
+    await preloadForbiddenWasm();
+  }
+  const neighbors = listChebyshevNeighbors(bestMove, RANDOM_NEIGHBOR_RADIUS);
+  const candidates = neighbors.filter((p) => {
+    if (board[p.row]?.[p.col] !== null) {
+      return false;
+    }
+    if (turn === "black" && isForbiddenForBlack(board, p.row, p.col)) {
+      return false;
+    }
+    return true;
+  });
+  return selectMoveWithRandomization({
+    bestMove,
+    bestMoveScore,
+    criticalScoreThreshold,
+    randomFactor,
+    pickRandomMove: () => {
+      if (candidates.length === 0) {
+        return null;
+      }
+      const idx = Math.floor(Math.random() * candidates.length);
+      return candidates[idx] ?? null;
+    },
+  });
+}
 
 // TypeScript用の型宣言
 export type { CpuRequest, CpuResponse };

--- a/src/logic/cpu/randomization.test.ts
+++ b/src/logic/cpu/randomization.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import type { Position } from "@/types/game";
+
+import {
+  listChebyshevNeighbors,
+  selectMoveWithRandomization,
+} from "./randomization";
+
+const BEST: Position = { row: 7, col: 7 };
+const FALLBACK: Position = { row: 3, col: 3 };
+
+describe("selectMoveWithRandomization", () => {
+  it("randomFactor が 0 のときは pickRandomMove を呼ばず bestMove を返す", () => {
+    let called = false;
+    const got = selectMoveWithRandomization({
+      bestMove: BEST,
+      randomFactor: 0,
+      random: () => 0,
+      pickRandomMove: () => {
+        called = true;
+        return FALLBACK;
+      },
+    });
+    expect(got).toEqual(BEST);
+    expect(called).toBe(false);
+  });
+
+  it("random() >= randomFactor のときは bestMove を返す", () => {
+    const got = selectMoveWithRandomization({
+      bestMove: BEST,
+      randomFactor: 0.4,
+      random: () => 0.4,
+      pickRandomMove: () => FALLBACK,
+    });
+    expect(got).toEqual(BEST);
+  });
+
+  it("random() < randomFactor のときは pickRandomMove の結果を返す", () => {
+    const got = selectMoveWithRandomization({
+      bestMove: BEST,
+      randomFactor: 0.4,
+      random: () => 0.1,
+      pickRandomMove: () => FALLBACK,
+    });
+    expect(got).toEqual(FALLBACK);
+  });
+
+  it("pickRandomMove が null を返したら bestMove にフォールバックする", () => {
+    const got = selectMoveWithRandomization({
+      bestMove: BEST,
+      randomFactor: 1,
+      random: () => 0,
+      pickRandomMove: () => null,
+    });
+    expect(got).toEqual(BEST);
+  });
+
+  describe("criticalScoreThreshold", () => {
+    it("|score| が閾値以上ならランダム化をスキップする（活三以上の脅威は見逃さない）", () => {
+      const got = selectMoveWithRandomization({
+        bestMove: BEST,
+        bestMoveScore: 1200,
+        criticalScoreThreshold: 800,
+        randomFactor: 1,
+        random: () => 0,
+        pickRandomMove: () => FALLBACK,
+      });
+      expect(got).toEqual(BEST);
+    });
+
+    it("|score| が閾値未満なら通常のランダム化が効く", () => {
+      const got = selectMoveWithRandomization({
+        bestMove: BEST,
+        bestMoveScore: 100,
+        criticalScoreThreshold: 800,
+        randomFactor: 1,
+        random: () => 0,
+        pickRandomMove: () => FALLBACK,
+      });
+      expect(got).toEqual(FALLBACK);
+    });
+
+    it("負の大きいスコア（自分が劣勢）でもスキップする", () => {
+      const got = selectMoveWithRandomization({
+        bestMove: BEST,
+        bestMoveScore: -1500,
+        criticalScoreThreshold: 800,
+        randomFactor: 1,
+        random: () => 0,
+        pickRandomMove: () => FALLBACK,
+      });
+      expect(got).toEqual(BEST);
+    });
+
+    it("threshold 未設定なら従来通り（Lv1 = 脅威も見逃す）", () => {
+      const got = selectMoveWithRandomization({
+        bestMove: BEST,
+        bestMoveScore: 10000,
+        randomFactor: 1,
+        random: () => 0,
+        pickRandomMove: () => FALLBACK,
+      });
+      expect(got).toEqual(FALLBACK);
+    });
+  });
+});
+
+describe("listChebyshevNeighbors", () => {
+  it("中央(7,7)の半径1は8マス（中心を除く）", () => {
+    const got = listChebyshevNeighbors({ row: 7, col: 7 }, 1);
+    expect(got).toHaveLength(8);
+    expect(got).not.toContainEqual({ row: 7, col: 7 });
+    expect(got).toContainEqual({ row: 6, col: 7 });
+    expect(got).toContainEqual({ row: 8, col: 8 });
+  });
+
+  it("中央(7,7)の半径2は24マス（5x5 - 1）", () => {
+    const got = listChebyshevNeighbors({ row: 7, col: 7 }, 2);
+    expect(got).toHaveLength(24);
+  });
+
+  it("中央(7,7)の半径3は48マス（7x7 - 1）", () => {
+    const got = listChebyshevNeighbors({ row: 7, col: 7 }, 3);
+    expect(got).toHaveLength(48);
+  });
+
+  it("盤端(0,0)では盤外を含まない", () => {
+    const got = listChebyshevNeighbors({ row: 0, col: 0 }, 2);
+    // 3x3 - 1 = 8
+    expect(got).toHaveLength(8);
+    expect(got.every((p) => p.row >= 0 && p.col >= 0)).toBe(true);
+  });
+
+  it("盤端(14,14)では盤外を含まない", () => {
+    const got = listChebyshevNeighbors({ row: 14, col: 14 }, 2);
+    expect(got).toHaveLength(8);
+    expect(got.every((p) => p.row < 15 && p.col < 15)).toBe(true);
+  });
+
+  it("半径0は空配列", () => {
+    expect(listChebyshevNeighbors({ row: 7, col: 7 }, 0)).toEqual([]);
+  });
+});

--- a/src/logic/cpu/randomization.ts
+++ b/src/logic/cpu/randomization.ts
@@ -1,0 +1,71 @@
+import type { Position } from "@/types/game";
+
+/**
+ * 確率で「最善手」か「ランダム手選択器の結果」を返す。
+ *
+ * ★1 用の弱体化レイヤ。WASM 探索エンジンには randomFactor 配線がないため、
+ * Worker 層でこの関数を挟んで弱体化を実現する。
+ *
+ * pickRandomMove は呼び出し側で禁手フィルタなどの責務を持つ。
+ * null を返した場合は bestMove にフォールバックする。
+ */
+export interface SelectMoveOptions {
+  readonly bestMove: Position;
+  readonly bestMoveScore?: number;
+  /**
+   * |bestMoveScore| >= この閾値ならランダム化をスキップする。
+   * 連珠の活三 OPEN_THREE=1000 を基準に 800 程度にすると、
+   * 活三以上の脅威がある局面では最善手を選ぶ（脅威を見逃さない）。
+   * undefined のときは閾値判定なし（Lv1 = 脅威も見逃しうる）。
+   */
+  readonly criticalScoreThreshold?: number;
+  readonly randomFactor: number;
+  readonly pickRandomMove: () => Position | null;
+  readonly random?: () => number;
+}
+
+export function selectMoveWithRandomization(opts: SelectMoveOptions): Position {
+  if (opts.randomFactor <= 0) {
+    return opts.bestMove;
+  }
+  if (
+    opts.criticalScoreThreshold !== undefined &&
+    opts.bestMoveScore !== undefined &&
+    Math.abs(opts.bestMoveScore) >= opts.criticalScoreThreshold
+  ) {
+    return opts.bestMove;
+  }
+  const random = opts.random ?? Math.random;
+  if (random() >= opts.randomFactor) {
+    return opts.bestMove;
+  }
+  return opts.pickRandomMove() ?? opts.bestMove;
+}
+
+/**
+ * 中心点から Chebyshev 距離 ≤ radius の位置（中心除く・盤外除く）を列挙する。
+ *
+ * ★1 のランダム選択を「最善手の近傍」に絞るために使う。
+ * 全空き点ランダムだと辺境（O12 など）に飛んで不自然なため。
+ */
+export function listChebyshevNeighbors(
+  center: Position,
+  radius: number,
+  boardSize = 15,
+): Position[] {
+  const result: Position[] = [];
+  for (let dr = -radius; dr <= radius; dr++) {
+    for (let dc = -radius; dc <= radius; dc++) {
+      if (dr === 0 && dc === 0) {
+        continue;
+      }
+      const r = center.row + dr;
+      const c = center.col + dc;
+      if (r < 0 || r >= boardSize || c < 0 || c >= boardSize) {
+        continue;
+      }
+      result.push({ row: r, col: c });
+    }
+  }
+  return result;
+}

--- a/src/types/cpu.ts
+++ b/src/types/cpu.ts
@@ -58,6 +58,13 @@ export interface DifficultyParams {
   timeLimit: number;
   /** ランダム要素（0-1、0で完全決定論的） */
   randomFactor: number;
+  /**
+   * |wasmResult.score| >= この閾値ならランダム化をスキップする。
+   * 活三 OPEN_THREE=1000、止め四 FOUR=1500 を基準に決める。
+   * undefined のときは脅威があってもランダム化される（Lv1 = 三を見逃しうる）。
+   * Lv2 以上はここを設定して「ランダムが発動しても活三以上の脅威は防ぐ」状態にする。
+   */
+  randomCriticalScoreThreshold?: number;
   /** ノード数上限（探索の打ち切り条件） */
   maxNodes: number;
   /** 評価オプション（重い機能の有効/無効） */
@@ -77,9 +84,15 @@ export interface DifficultyParams {
  */
 export const DIFFICULTY_PARAMS: Record<CpuDifficulty, DifficultyParams> = {
   beginner: {
-    depth: 2, // depth 2 で easyとの差はrandomFactor/機能で付ける
-    timeLimit: 1500,
-    randomFactor: 0.25, // 25%で悪手
+    // 「初心者でほぼ毎回勝てる」想定。詰みが正確すぎたため弱体化:
+    // - depth 1: 1手読みで四追いの連続詰みを発見できなくする
+    // - randomFactor 0.3: 30% の確率で近傍空き点からランダム選択（三も時々見逃す）
+    // - randomCriticalScoreThreshold: 未設定（脅威があってもランダム化される）
+    // - enableMandatoryDefense: true: 評価関数が中央付近に寄り、辺境への bestMove を防ぐ
+    //   （防御を切ると bestMove 自体が辺境に飛ぶ → ランダム近傍化が無意味化する）
+    depth: 1,
+    timeLimit: 1000,
+    randomFactor: 0.3,
     maxNodes: 30000,
     evaluationOptions: {
       enableFukumi: false,
@@ -88,34 +101,41 @@ export const DIFFICULTY_PARAMS: Record<CpuDifficulty, DifficultyParams> = {
       enableMultiThreat: false,
       enableCounterFour: false,
       enableVCT: false,
-      enableMandatoryDefense: true, // 活四/活三への最低限の防御（強化）
-      enableSingleFourPenalty: true, // 無駄な四を減らす（強化）
-      singleFourPenaltyMultiplier: 0.6, // 40%減点
+      enableMandatoryDefense: true,
+      enableSingleFourPenalty: true,
+      singleFourPenaltyMultiplier: 0.6,
       enableMiseThreat: false,
       enableDoubleThreeThreat: false,
       enableNullMovePruning: false,
       enableFutilityPruning: false,
       enableForbiddenVulnerability: false,
     },
-    scoreThreshold: 400, // ランダム選択幅（easyより広め）
+    scoreThreshold: 400, // 現状未配線（将来的に候補手フィルタを実装する場合に使う）
   },
   easy: {
-    depth: 2,
-    timeLimit: 2000,
-    randomFactor: 0.12, // 12%で悪手
-    maxNodes: 100000, // 探索予算倍増
+    // depth 1: 連続四（四追い）を読めなくする。
+    // Lv1 との差別化は randomCriticalScoreThreshold / enableDoubleThreeThreat 等で確保。
+    depth: 1,
+    timeLimit: 1500,
+    randomFactor: 0.18, // 18%で近傍ランダム（活三以上の脅威時はスキップされる）
+    randomCriticalScoreThreshold: 800, // 活三 OPEN_THREE=1000 以上の脅威はランダム時もスキップ
+    maxNodes: 60000,
     evaluationOptions: {
       enableFukumi: false,
-      enableMise: true, // 計算コスト低で戦術認識向上（medium-easy格差対策）
+      // 追詰／禁手追込を能動的に使わせない:
+      // - enableMise: false（ミセ=四三・連続四の起点）
+      // - enableCounterFour: false（四返しの攻撃起点）
+      // - enableVCT/enableForbiddenTrap: false（直接機能。元から無効）
+      enableMise: false,
       enableForbiddenTrap: false,
-      enableMultiThreat: true, // 計算コスト低で戦術認識向上（medium-easy格差対策）
-      enableCounterFour: true, // カウンターフォー認識（強化）
+      enableMultiThreat: true, // 複数方向脅威の認識（配置評価。攻撃起点ではない）
+      enableCounterFour: false,
       enableVCT: false,
-      enableMandatoryDefense: true, // 致命的ミスを減らす
-      enableSingleFourPenalty: true, // 無駄な四を減らす
-      singleFourPenaltyMultiplier: 0.4, // 60%減点（より厳しく）
-      enableMiseThreat: true, // ミセ手脅威への防御（強化）
-      enableDoubleThreeThreat: true, // 三三脅威への防御（強化）
+      enableMandatoryDefense: true, // 致命的ミスを減らす（活四/活三防御は維持）
+      enableSingleFourPenalty: true,
+      singleFourPenaltyMultiplier: 0.4, // 60%減点。四は打つが優先度は低め
+      enableMiseThreat: false, // ミセ手脅威への防御は切る（攻撃トラップに引っかかる余地）
+      enableDoubleThreeThreat: true, // 三三脅威への防御（致命的なので維持）
       enableNullMovePruning: false,
       enableFutilityPruning: false,
       enableForbiddenVulnerability: false,
@@ -125,15 +145,17 @@ export const DIFFICULTY_PARAMS: Record<CpuDifficulty, DifficultyParams> = {
   medium: {
     depth: 3,
     timeLimit: 5000, // TPE対策
-    randomFactor: 0.08, // 8%で悪手
+    randomFactor: 0.1, // 10%で悪手（Lv4 との差別化のため微増）
+    randomCriticalScoreThreshold: 800, // 活三以上の脅威はランダム時もスキップ
     maxNodes: 200000,
     evaluationOptions: {
       enableFukumi: false, // 探索効率を優先
-      enableMise: true,
+      // 追詰関連を切る（Lv4 との差別化）
+      enableMise: false,
       enableForbiddenTrap: false,
       enableMultiThreat: true,
       enableCounterFour: true,
-      enableVCT: true,
+      enableVCT: false,
       enableMandatoryDefense: true,
       enableSingleFourPenalty: true,
       singleFourPenaltyMultiplier: 0.3, // 70%減点に緩和（単独四にも価値を認める）


### PR DESCRIPTION
## 背景

★1 (beginner) が「初心者でほぼ毎回勝てる」想定より明らかに強かった。原因調査の結果、`DifficultyParams.randomFactor` / `scoreThreshold` が型上は存在するもののどこにも配線されておらず、WASM 探索結果がそのまま使われていたことが判明。本 PR で配線し、Lv1-3 を再リバランス。

## 主な変更

### 1. `randomFactor` の配線（Worker 層）

WASM 側を改修せず、`cpu.worker.ts` で WASM 結果を後処理する形に。

- `src/logic/cpu/randomization.ts` (新規): \`selectMoveWithRandomization\` 純粋関数を TDD で実装
  - bestMove と「ランダム手選択器の結果」を `randomFactor` の確率で切り替え
  - \`bestMoveScore\` の絶対値が \`criticalScoreThreshold\` 以上ならランダム化スキップ（活三以上の脅威は守る）
  - \`listChebyshevNeighbors\` で bestMove 中心の近傍に絞り、辺境飛びを防ぐ
- \`cpu.worker.ts\`: \`applyRandomization\` を組み込み。黒は \`forbiddenAdapter\` で禁手除外

### 2. レベル別パラメータ再設計

| | Lv1 | Lv2 | Lv3 | Lv4 |
|---|---|---|---|---|
| depth | 1 | 1 | 3 | 7 |
| randomFactor | 0.30 | 0.18 | 0.10 | 0 |
| randomCriticalScoreThreshold | — | 800 | 800 | — |
| enableMise/VCT/ForbiddenTrap | ✗ | ✗ | ✗ | ✓ |
| enableMandatoryDefense | ✓ | ✓ | ✓ | ✓ |

Lv1-3 は **追詰・禁手追込を能動的に使わない** 設計。Lv4 は未変更。

### 3. ベンチスクリプト追加

\`scripts/bench-ai.ts\` は TS CPU 削除に伴い \`benchmark/\` 依存が動作不能のため、目的特化の \`scripts/weak-bench.ts\` を新規追加。

- \`--a=X --b=Y --games=N\`: 2 プレイヤー間
- \`--all --games=N\`: 全 4 難易度総当たり + Elo 反復推定

## ベンチ結果 (10 局/ペア)

```
Elo: hard 2030 / medium 1751 / easy 1475 / beginner 744

ペア勝率表 (行 vs 列):
           beginner  easy    medium  hard
beginner   -         0.0%    0.0%    0.0%
easy       100.0%    -       20.0%   0.0%
medium     100.0%    80.0%   -       20.0%
hard       100.0%    100.0%  80.0%   -
```

Lv2-Lv3-Lv4 は ~280 Elo 間隔で揃った。

## Test plan

- [x] \`pnpm vitest run\` (1537 件全緑)
- [x] \`pnpm check-fix\` (型/lint/format 緑)
- [x] pre-commit hook (check-fix + test + zig-test) 通過
- [x] weak-bench で Lv1<Lv2<Lv3<Lv4 を定量確認
- [ ] 実機で対局し Lv1 が四追いしないこと
- [ ] 実機で対局し Lv2 が四追い／禁手追込しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)