### PR TITLE
fix(review): 被詰タブを相手の詰み木で展開する (#26)

### DIFF
--- a/src/components/cpu/composables/progressionModel.test.ts
+++ b/src/components/cpu/composables/progressionModel.test.ts
@@ -346,6 +346,103 @@ describe("buildRows (詰み木モード #22)", () => {
   });
 });
 
+describe("buildRows 被詰タブ詰み木モード (#26)", () => {
+  /**
+   * 被詰タブ用の eval を組み立てる:
+   * - moveIndex=10: プレイヤー実着手 pos(5,5) で被詰確定
+   * - 相手攻め手 pos(0,0) → 防御2件: 主筋 pos(1,1)→pos(2,2)終端 / 代替 pos(8,8)→pos(9,9)終端
+   */
+  function tabWithLossTree(): ProgressionTab {
+    return buildTopTabs(
+      evaluatedMove({
+        moveIndex: 10,
+        position: pos(5, 5),
+        forcedLossType: "vct",
+        forcedLossSequence: [pos(0, 0), pos(1, 1), pos(2, 2)],
+        forcedLossTree: {
+          attackerMove: pos(0, 0),
+          defenses: [
+            {
+              defenderMove: pos(1, 1),
+              next: { attackerMove: pos(2, 2), defenses: [] },
+            },
+            {
+              defenderMove: pos(8, 8),
+              next: { attackerMove: pos(9, 9), defenses: [] },
+            },
+          ],
+        },
+      }),
+      10,
+    ).find((t) => t.id === "loss")!;
+  }
+
+  it("被詰タブに tree が乗り、attackerIsSelf=false / leadingPlayerMove が前置される", () => {
+    const tab = tabWithLossTree();
+    expect(tab.tree).toBeDefined();
+    expect(tab.attackerIsSelf).toBe(false);
+    expect(tab.leadingPlayerMove?.position).toEqual(pos(5, 5));
+    expect(tab.leadingPlayerMove?.isSelf).toBe(true);
+    // tree モードでは flat 経路を抑制
+    expect(tab.branches).toEqual([]);
+  });
+
+  it("先頭の実着手・攻め手の isSelf 反転・分岐行の挿入を行う", () => {
+    const rows = buildRows(tabWithLossTree(), {});
+    // [leading(self), attacker(opp), branch, defender(self)] のはず（既定 best 選択で末端も入る）
+    expect(rows.map((r) => r.type)).toEqual(["move", "move", "branch", "move"]);
+    // leading: 実着手 pos(5,5) で自分・moveNum=10
+    expect(rows[0]?.type === "move" && rows[0].item.position).toEqual(
+      pos(5, 5),
+    );
+    expect(rows[0]?.type === "move" && rows[0].item.isSelf).toBe(true);
+    expect(rows[0]?.type === "move" && rows[0].item.moveNum).toBe(10);
+    // 攻め手: 相手 pos(0,0)・moveNum=11
+    expect(rows[1]?.type === "move" && rows[1].item.position).toEqual(
+      pos(0, 0),
+    );
+    expect(rows[1]?.type === "move" && rows[1].item.isSelf).toBe(false);
+    expect(rows[1]?.type === "move" && rows[1].item.moveNum).toBe(11);
+    // 分岐行: 防御2件・moveNum=12（プレイヤー視点で自分の手）
+    expect(
+      rows[2]?.type === "branch" && rows[2].options.map((o) => o.id),
+    ).toEqual(["best", "1"]);
+    expect(rows[2]?.type === "branch" && rows[2].moveNum).toBe(12);
+    expect(rows[2]?.type === "branch" && rows[2].options[0]?.item.isSelf).toBe(
+      true,
+    );
+    // 主筋末端: 相手の攻め pos(2,2)・moveNum=13
+    expect(rows[3]?.type === "move" && rows[3].item.position).toEqual(
+      pos(2, 2),
+    );
+    expect(rows[3]?.type === "move" && rows[3].item.isSelf).toBe(false);
+    expect(rows[3]?.type === "move" && rows[3].item.moveNum).toBe(13);
+  });
+
+  it("代替防御を選択すると別の継続に切り替わる", () => {
+    const rows = buildRows(tabWithLossTree(), { "": "1" });
+    const last = rows[rows.length - 1];
+    expect(last?.type === "move" && last.item.position).toEqual(pos(9, 9));
+    expect(last?.type === "move" && last.item.isSelf).toBe(false);
+  });
+
+  it("forcedLossTree が無い被詰は従来通り flat 経路で表示される（回帰）", () => {
+    const eval_ = evaluatedMove({
+      moveIndex: 0,
+      position: pos(2, 2),
+      forcedLossType: "vcf",
+      forcedLossSequence: [pos(3, 3), pos(4, 4)],
+    });
+    const tab = buildTopTabs(eval_, 0).find((t) => t.id === "loss")!;
+    expect(tab.tree).toBeUndefined();
+    expect(tab.attackerIsSelf).toBeUndefined();
+    expect(tab.leadingPlayerMove).toBeUndefined();
+    // flat 経路: basePV から行が組み立てられる
+    const rows = buildRows(tab, {});
+    expect(rows.length).toBeGreaterThan(0);
+  });
+});
+
 describe("buildVisibleItems", () => {
   it("move 行と branch 行の選択オプションを upToRowIdx まで集める", () => {
     const tab = buildTopTabs(

--- a/src/components/cpu/composables/progressionModel.ts
+++ b/src/components/cpu/composables/progressionModel.ts
@@ -47,8 +47,18 @@ export interface ProgressionTab {
   baseMoveNum: number;
   basePV: PVDisplayItem[];
   branches: InlineBranch[];
-  /** 詰み木（#22）。あれば buildRows は木を再帰的に展開する */
+  /** 詰み木（#22 / #26）。あれば buildRows は木を再帰的に展開する */
   tree?: ForcedWinNode;
+  /**
+   * 木モードでの攻め手の役割。`true` = 攻め=自分（追詰）、`false` = 攻め=相手（被詰）。
+   * 未指定時は `true`（追詰タブの既定）。
+   */
+  attackerIsSelf?: boolean;
+  /**
+   * 木モード時、ルート前に 1 行差し込むプレイヤー実着手（#26 被詰タブ用）。
+   * 例: 被詰タブの先頭にプレイヤー実着手を置き、その次から相手攻め手の木を展開する。
+   */
+  leadingPlayerMove?: PVDisplayItem;
 }
 
 export type Row =
@@ -287,19 +297,43 @@ export function buildTopTabs(
 
   const forcedLossPV = buildForcedLossPV(eval_, moveIndex);
   if (forcedLossPV.length > 0) {
-    result.push({
-      id: "loss",
-      label: forcedLossLabelOf(eval_) ?? "被詰",
-      sub: formatMove(eval_.position),
-      emitType: "played",
-      baseMoveNum: moveIndex,
-      basePV: forcedLossPV,
-      branches: buildInlineBranches(
-        eval_.forcedLossBranches ?? [],
-        moveIndex,
-        "loss",
-      ),
-    });
+    if (eval_.forcedLossTree) {
+      // 木モード（#26）: 先頭にプレイヤー実着手を前置し、ルートから相手攻め手を展開。
+      // baseMoveNum は moveIndex+1（実着手の次手 = 相手攻め手の手番）。
+      const leading: PVDisplayItem = {
+        isSelf: true,
+        position: eval_.position,
+        coord: formatMove(eval_.position),
+        moveNum: moveIndex,
+      };
+      result.push({
+        id: "loss",
+        label: forcedLossLabelOf(eval_) ?? "被詰",
+        sub: formatMove(eval_.position),
+        emitType: "played",
+        baseMoveNum: moveIndex + 1,
+        basePV: forcedLossPV,
+        branches: [],
+        tree: eval_.forcedLossTree,
+        attackerIsSelf: false,
+        leadingPlayerMove: leading,
+      });
+    } else {
+      // フラット経路（VCF 被詰など線形ケース、または木が無い場合のフォールバック）
+      result.push({
+        id: "loss",
+        label: forcedLossLabelOf(eval_) ?? "被詰",
+        sub: formatMove(eval_.position),
+        emitType: "played",
+        baseMoveNum: moveIndex,
+        basePV: forcedLossPV,
+        branches: buildInlineBranches(
+          eval_.forcedLossBranches ?? [],
+          moveIndex,
+          "loss",
+        ),
+      });
+    }
   }
 
   return result;
@@ -322,7 +356,16 @@ export function buildRows(
   selection: Record<string, string>,
 ): Row[] {
   if (tab.tree) {
-    return walkTree(tab, tab.tree, selection);
+    const rows: Row[] = [];
+    if (tab.leadingPlayerMove) {
+      rows.push({
+        type: "move",
+        key: `${tab.id}-lead`,
+        item: tab.leadingPlayerMove,
+      });
+    }
+    rows.push(...walkTree(tab, tab.tree, selection));
+    return rows;
   }
   return buildRowsFlat(tab, selection);
 }
@@ -349,6 +392,8 @@ function walkTree(
   selection: Record<string, string>,
 ): Row[] {
   const rows: Row[] = [];
+  const attackerIsSelf = tab.attackerIsSelf ?? true;
+  const defenderIsSelf = !attackerIsSelf;
 
   const walk = (
     node: ForcedWinNode,
@@ -359,11 +404,11 @@ function walkTree(
     if (depth >= MAX_WALK_DEPTH) {
       return;
     }
-    // 攻め手（ply 偶数 = self）
+    // 攻め手（ply 偶数 = 攻め手番）。isSelf は tab.attackerIsSelf で反転可。
     rows.push({
       type: "move",
       key: `${tab.id}-m-${pathKey}-${ply}`,
-      item: moveItem(node.attackerMove, ply % 2 === 0, tab.baseMoveNum + ply),
+      item: moveItem(node.attackerMove, attackerIsSelf, tab.baseMoveNum + ply),
     });
     if (node.defenses.length === 0) {
       return;
@@ -374,7 +419,11 @@ function walkTree(
       rows.push({
         type: "move",
         key: `${tab.id}-m-${pathKey}-${defPly}`,
-        item: moveItem(d.defenderMove, false, tab.baseMoveNum + defPly),
+        item: moveItem(
+          d.defenderMove,
+          defenderIsSelf,
+          tab.baseMoveNum + defPly,
+        ),
       });
       walk(d.next, pathKey, ply + 2, depth + 1);
       return;
@@ -382,7 +431,7 @@ function walkTree(
     // 分岐: 防御2件以上
     const options = node.defenses.map((d, idx) => ({
       id: idx === 0 ? "best" : String(idx),
-      item: moveItem(d.defenderMove, false, tab.baseMoveNum + defPly),
+      item: moveItem(d.defenderMove, defenderIsSelf, tab.baseMoveNum + defPly),
     }));
     rows.push({
       type: "branch",

--- a/src/components/cpu/composables/useReviewEvaluator.ts
+++ b/src/components/cpu/composables/useReviewEvaluator.ts
@@ -187,6 +187,7 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
           if (data.forcedLossType) {
             item.forcedLossType = data.forcedLossType;
             item.forcedLossSequence = data.forcedLossSequence;
+            item.forcedLossTree = data.forcedLossTree;
             onVCTResult?.(item.moveIndex, data);
           }
         },
@@ -234,6 +235,8 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
               ) {
                 data.forcedLossType = oldResult.forcedLossType;
                 data.forcedLossSequence = oldResult.forcedLossSequence;
+                data.forcedLossBranches = oldResult.forcedLossBranches;
+                data.forcedLossTree = oldResult.forcedLossTree;
               }
               results[idx] = data;
             }

--- a/src/logic/cpu/review.worker.ts
+++ b/src/logic/cpu/review.worker.ts
@@ -10,6 +10,7 @@
 import type { Position } from "@/types/game";
 import type {
   ForcedLossType,
+  ForcedWinNode,
   FullEvalResult,
   LightEvalResult,
   ReviewEvalRequest,
@@ -87,6 +88,7 @@ self.onmessage = async (event: MessageEvent<ReviewEvalRequest>) => {
 
       let forcedLossType: ForcedLossType | undefined = undefined;
       let forcedLossSequence: Position[] | undefined = undefined;
+      let forcedLossTree: ForcedWinNode | undefined = undefined;
       if (
         !selfHasFour &&
         (skipStoneThreshold || stoneCountAfter >= VCT_STONE_THRESHOLD)
@@ -100,6 +102,7 @@ self.onmessage = async (event: MessageEvent<ReviewEvalRequest>) => {
         if (oppVCT) {
           forcedLossType = oppVCT.isForbiddenTrap ? "forbidden-trap" : "vct";
           forcedLossSequence = oppVCT.sequence;
+          forcedLossTree = oppVCT.tree;
         }
       }
 
@@ -108,6 +111,7 @@ self.onmessage = async (event: MessageEvent<ReviewEvalRequest>) => {
         moveIndex,
         forcedLossType,
         forcedLossSequence,
+        forcedLossTree,
       };
       self.postMessage(response);
       return;

--- a/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
+++ b/src/logic/cpu/review/__snapshots__/reviewSnapshot.test.ts.snap
@@ -379,6 +379,233 @@ exports[`review 戦術出力スナップショット (#37 P0) > checkForcedLoss:
       "row": 5,
     },
   ],
+  "tree": {
+    "attackerMove": {
+      "col": 9,
+      "row": 6,
+    },
+    "defenses": [
+      {
+        "defenderMove": {
+          "col": 9,
+          "row": 5,
+        },
+        "next": {
+          "attackerMove": {
+            "col": 9,
+            "row": 7,
+          },
+          "defenses": [
+            {
+              "defenderMove": {
+                "col": 9,
+                "row": 10,
+              },
+              "next": {
+                "attackerMove": {
+                  "col": 10,
+                  "row": 7,
+                },
+                "defenses": [
+                  {
+                    "defenderMove": {
+                      "col": 11,
+                      "row": 7,
+                    },
+                    "next": {
+                      "attackerMove": {
+                        "col": 8,
+                        "row": 5,
+                      },
+                      "defenses": [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        "defenderMove": {
+          "col": 9,
+          "row": 7,
+        },
+        "next": {
+          "attackerMove": {
+            "col": 6,
+            "row": 3,
+          },
+          "defenses": [
+            {
+              "defenderMove": {
+                "col": 5,
+                "row": 2,
+              },
+              "next": {
+                "attackerMove": {
+                  "col": 7,
+                  "row": 3,
+                },
+                "defenses": [
+                  {
+                    "defenderMove": {
+                      "col": 7,
+                      "row": 5,
+                    },
+                    "next": {
+                      "attackerMove": {
+                        "col": 8,
+                        "row": 3,
+                      },
+                      "defenses": [
+                        {
+                          "defenderMove": {
+                            "col": 9,
+                            "row": 2,
+                          },
+                          "next": {
+                            "attackerMove": {
+                              "col": 5,
+                              "row": 3,
+                            },
+                            "defenses": [],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              "defenderMove": {
+                "col": 8,
+                "row": 5,
+              },
+              "next": {
+                "attackerMove": {
+                  "col": 7,
+                  "row": 3,
+                },
+                "defenses": [
+                  {
+                    "defenderMove": {
+                      "col": 7,
+                      "row": 5,
+                    },
+                    "next": {
+                      "attackerMove": {
+                        "col": 8,
+                        "row": 3,
+                      },
+                      "defenses": [
+                        {
+                          "defenderMove": {
+                            "col": 9,
+                            "row": 2,
+                          },
+                          "next": {
+                            "attackerMove": {
+                              "col": 5,
+                              "row": 3,
+                            },
+                            "defenses": [],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              "defenderMove": {
+                "col": 10,
+                "row": 7,
+              },
+              "next": {
+                "attackerMove": {
+                  "col": 7,
+                  "row": 3,
+                },
+                "defenses": [
+                  {
+                    "defenderMove": {
+                      "col": 7,
+                      "row": 5,
+                    },
+                    "next": {
+                      "attackerMove": {
+                        "col": 8,
+                        "row": 3,
+                      },
+                      "defenses": [
+                        {
+                          "defenderMove": {
+                            "col": 9,
+                            "row": 2,
+                          },
+                          "next": {
+                            "attackerMove": {
+                              "col": 5,
+                              "row": 3,
+                            },
+                            "defenses": [],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        "defenderMove": {
+          "col": 9,
+          "row": 10,
+        },
+        "next": {
+          "attackerMove": {
+            "col": 9,
+            "row": 7,
+          },
+          "defenses": [
+            {
+              "defenderMove": {
+                "col": 9,
+                "row": 5,
+              },
+              "next": {
+                "attackerMove": {
+                  "col": 10,
+                  "row": 7,
+                },
+                "defenses": [
+                  {
+                    "defenderMove": {
+                      "col": 11,
+                      "row": 7,
+                    },
+                    "next": {
+                      "attackerMove": {
+                        "col": 8,
+                        "row": 5,
+                      },
+                      "defenses": [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
   "type": "vct",
 }
 `;

--- a/src/logic/cpu/review/forcedLossCheck.ts
+++ b/src/logic/cpu/review/forcedLossCheck.ts
@@ -56,7 +56,9 @@ export const FORCED_LOSS_VCT_OPTIONS: VCTSearchOptions = {
   timeLimit: 10_000, // 10秒上限（VCT内部のVCFがノードカウントを共有しないため maxNodes だけでは不十分）
   maxNodes: 500_000,
   vcfOptions: { maxDepth: 16, timeLimit: 3_000, maxNodes: 100_000 },
-  collectBranches: false,
+  // 被詰タブで防御分岐を木展開するための詰み木を収集する（#26）。
+  // Zig の collect-mode は時刻ベース timeLimit (vct.zig:1116/1187) で打ち切るため bulk 完走を阻害しない。
+  collectBranches: true,
 };
 
 /** 候補手検証用（verifyCandidates / verifyCandidatePVs） */
@@ -262,6 +264,7 @@ export function checkForcedLoss(
       return {
         type: oppVCT.isForbiddenTrap ? "forbidden-trap" : "vct",
         sequence: oppVCT.sequence,
+        tree: oppVCT.tree,
       };
     }
   }

--- a/src/logic/reviewLogic.ts
+++ b/src/logic/reviewLogic.ts
@@ -130,6 +130,7 @@ export function buildEvaluatedMove(
     forcedLossType: result.forcedLossType,
     forcedLossSequence: result.forcedLossSequence,
     forcedLossBranches: result.forcedLossBranches,
+    forcedLossTree: result.forcedLossTree,
     missedDoubleMise: result.missedDoubleMise,
     doubleMiseTargets: result.doubleMiseTargets,
   };
@@ -149,6 +150,7 @@ export function applyVCTResult(
     ...existing,
     forcedLossType: result.forcedLossType,
     forcedLossSequence: result.forcedLossSequence,
+    forcedLossTree: result.forcedLossTree,
   };
 }
 

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -29,6 +29,8 @@ export type ForcedWinType = Exclude<
 export interface ForcedLossResult {
   type: ForcedLossType;
   sequence: Position[];
+  /** 相手の必勝手順の詰み木（#26。VCT 被詰のみ。VCF/Mise-VCF 等の線形ケースでは無し） */
+  tree?: ForcedWinNode;
 }
 
 /**
@@ -56,10 +58,14 @@ export interface ForcedWinBranch {
 }
 
 /**
- * 追詰（VCT / Mise-VCF / 両ミセ）の再帰的詰み木ノード（#22）。
+ * 詰み木の再帰的ノード（#22 / #26）。
  *
  * AND-OR 木の攻め手ノード。`defenses` が空なら終端（この攻め手で勝ち確定:
  * 五 / 達四 / VCF 完了）。`defenses[0]` 連鎖が既存 `sequence`（既定経路）に一致する。
+ *
+ * 追詰文脈（#22）では `attackerMove` はプレイヤーの攻め手・`defenderMove` は相手の防御手。
+ * 被詰文脈（#26）では `attackerMove` は相手の攻め手・`defenderMove` はプレイヤーの防御手。
+ * 構造は同一で、役割の違いは表示側で `ProgressionTab.attackerIsSelf` により切り替える。
  */
 export interface ForcedWinNode {
   /** この局面での攻め手（OR を1つに固定） */
@@ -141,6 +147,8 @@ export interface EvaluatedMove {
   forcedLossSequence?: Position[];
   /** 相手の必勝手順の分岐（Phase 3 遡及で構築） */
   forcedLossBranches?: ForcedWinBranch[];
+  /** 相手の必勝手順の詰み木（#26。被詰タブの分岐表示の出所。VCT 被詰のみ） */
+  forcedLossTree?: ForcedWinNode;
   /** 軽量評価（minimax省略、強制勝ち検出のみ） */
   isLightEval?: boolean;
   /** 両ミセ手の見逃し（打つ前の盤面で両ミセ手が存在した） */
@@ -213,6 +221,8 @@ export interface VCTCheckResult extends ReviewWorkerResultBase {
   forcedLossType?: ForcedLossType;
   /** 相手の必勝手順のシーケンス */
   forcedLossSequence?: Position[];
+  /** 相手の必勝手順の詰み木（#26。VCT 被詰のみ） */
+  forcedLossTree?: ForcedWinNode;
 }
 
 /**
@@ -251,6 +261,8 @@ export interface FullEvalResult extends ReviewWorkerResultBase {
   forcedLossSequence?: Position[];
   /** 相手の必勝手順の分岐（Phase 3 遡及で構築） */
   forcedLossBranches?: ForcedWinBranch[];
+  /** 相手の必勝手順の詰み木（#26。VCT 被詰のみ、Phase 2 VCTチェック結果から伝搬） */
+  forcedLossTree?: ForcedWinNode;
   /** 両ミセ手の見逃し（打つ前の盤面で両ミセ手が存在した） */
   missedDoubleMise?: Position[];
   /** 両ミセのターゲット位置（四三を作る位置） */


### PR DESCRIPTION
## Summary
- 被詰タブを相手 VCT の主筋 1 本だけでなく、相手の三に対する自分の複数の止め方を分岐タブとして表示できるよう詰み木化する（#26）
- 追詰タブ側（#22 / PR #33）で導入済みの `ForcedWinNode` / `walkTree` 機構を被詰側でも流用、役割反転は `ProgressionTab.attackerIsSelf` で表現

## 解決する問題（#26 本文より）

例: 棋譜「H8 I9 J10 G8 J9 J11 H7 H6 J7 G7 I5 G6 J6 J8 G5 I10 H9 I11 I8 G10 G9」の 15 手目 G5（被追い詰め）局面で:

- **修正前**: 被詰タブの 17 手目は主筋 `K12` のみ。代替防御 `I10` / `F7` の分岐タブが出ない（純粋な表示バグ）
- **修正後**: 17 手目に `K12（推奨手）/ I10（代替手）/ F7（代替手）` の 3 タブが描画され、各分岐を選択して遷移先の手順を確認できる

実機スクリーンショット: 別添 `docs/screenshots/` 参照（次コメントに貼付）

## 実装の要点

1. **`FORCED_LOSS_VCT_OPTIONS.collectBranches: true`**（`forcedLossCheck.ts:59`）に切替。Zig 側 collect-mode VCT が時刻ベース timeLimit (`vct.zig:1116, 1187`) で打ち切れるため bulk 解析は安全に完走（実機 PoC で 21 手解析の regression なしを確認）。
2. **型追加**: `EvaluatedMove.forcedLossTree?` / `VCTCheckResult.forcedLossTree?` / `FullEvalResult.forcedLossTree?` / `ForcedLossResult.tree?`。`ForcedWinNode.attackerMove` の JSDoc に被詰文脈の補足を追記。
3. **配線**: worker `vctCheckOnly` → `useReviewEvaluator.handleResult` → `applyVCTResult` → `EvaluatedMove` の全経路で tree を伝搬。精密再評価マージで `forcedLossTree` も保持リストに追加。
4. **`progressionModel` の `walkTree` 一般化**: `attackerIsSelf` フラグで攻め手/防御手の isSelf 反転を制御、`leadingPlayerMove` で被詰タブ先頭にプレイヤー実着手を前置。被詰タブの `baseMoveNum` は `moveIndex + 1`（leadingPlayerMove と手番衝突回避）。

## 既知の影響（要確認・受け入れ判断あり）

- 同じ棋譜の 15 手目「最善」タブで bestMove が `G5 (-2212) → G9 (+2901)` に変化、「最善の進行 8 手」が「1 手」に短縮、キャラのコメント変化。
- 原因: `collectBranches=true` で Zig 側 VCT 探索の進行（arena 書き込み）が微妙に変わり、`opponentForcedWin` 判定の一部が変化 → `adjustCandidatesForForcedLoss` が選ぶ best が変わる。
- **影響範囲**: bestMove/bestScore（個別局面の最善判定）のみ。**全体評価（ミス回数 5回 / 敗着位置 13 手目 / 各手の品質ラベル / 5 手目疑問手 etc.）は main と完全一致**。学習ゲームの文脈ではむしろ「G9 で粘れた」と提案する方が学習価値が高い解釈もあり。

## スコープ外（別 issue 検討）

- **遡及伝播（13 手目敗着）の被詰タブ tree 化**: 当初 Phase 2 として実装したが、`candidateVerification` の 2 段呼び出しが上記 Zig 探索動作変化と同じ系統の影響を生み、副作用増を許容できないため見送り。元コミットの設計（`buildBacktrackTree` / `ReviewCandidate.opponentForcedWinTree`）は将来再挑戦時の出発点として有用。
- 当該棋譜では 13 手目で `propagateForcedLossBackward` の発火条件（全候補負け）を満たさないため、もとから 13 手目には被詰タブが出ない。issue 本文の前提（13 手目に被詰タブ表示）は別途調査が必要。

## Test plan
- [x] `pnpm test` 全 1541 件緑（progressionModel.test.ts に被詰 tree 展開テスト 4 件追加）
- [x] `pnpm check-fix` 緑
- [x] 実機 E2E: 棋譜「H8 I9 J10 G8 J9 J11 H7 H6 J7 G7 I5 G6 J6 J8 G5 I10 H9 I11 I8 G10 G9」の 15 手目被詰タブで 3 タブ（K12/I10/F7）描画を確認
- [x] 9 手目「悪手 追い詰め」（追詰タブ #22）が従来通り動作することを確認（回帰なし）
- [ ] レビューア確認: 15 手目「最善」タブの bestScore 変化を受け入れるか

## Closes
- Closes #26（Phase 1 範囲：直接検出の被詰の木化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)