### PR TITLE
fix(review): 長い棋譜の解析停止を修正 (#104)

### DIFF
--- a/src/components/cpu/CpuReviewPlayer.vue
+++ b/src/components/cpu/CpuReviewPlayer.vue
@@ -362,6 +362,7 @@ function handleLayoutClick(event: MouseEvent): void {
             :is-evaluating="evaluator.isEvaluating.value"
             :completed-count="evaluator.completedCount.value"
             :total-count="evaluator.totalCount.value"
+            :failed-count="evaluator.failedCount.value"
             :accuracy="reviewStore.playerAccuracy"
             :critical-errors="reviewStore.criticalErrors"
             :difficulty="reviewStore.currentRecord?.difficulty"

--- a/src/components/cpu/ReviewStatus.vue
+++ b/src/components/cpu/ReviewStatus.vue
@@ -20,6 +20,7 @@ interface Props {
   isEvaluating: boolean;
   completedCount: number;
   totalCount: number;
+  failedCount: number;
   accuracy: number | null;
   criticalErrors: number;
   difficulty?: CpuDifficulty;
@@ -95,6 +96,12 @@ async function copyMoveHistory(): Promise<void> {
           解析中
         </span>
         ({{ props.completedCount }}/{{ props.totalCount }})
+        <span
+          v-if="props.failedCount > 0"
+          class="failed-inline"
+        >
+          / 失敗 {{ props.failedCount }}
+        </span>
       </span>
     </div>
 
@@ -112,6 +119,13 @@ async function copyMoveHistory(): Promise<void> {
         class="errors"
       >
         ミス {{ props.criticalErrors }}回
+      </div>
+      <div
+        v-if="props.failedCount > 0"
+        class="failed"
+        role="status"
+      >
+        解析失敗 {{ props.failedCount }}手
       </div>
     </div>
   </div>
@@ -248,5 +262,17 @@ async function copyMoveHistory(): Promise<void> {
   padding: var(--size-2) var(--size-6);
   background: var(--color-background-secondary);
   border-radius: var(--size-4);
+}
+
+.failed {
+  font-size: var(--size-12);
+  color: var(--color-miko-primary);
+  padding: var(--size-2) var(--size-6);
+  background: var(--color-background-secondary);
+  border-radius: var(--size-4);
+}
+
+.failed-inline {
+  color: var(--color-miko-primary);
 }
 </style>

--- a/src/components/cpu/composables/useReviewEvaluator.ts
+++ b/src/components/cpu/composables/useReviewEvaluator.ts
@@ -35,6 +35,27 @@ export { sortReviewQueue } from "@/logic/cpu/review/reviewQueue";
 /** Workerプールサイズ（最大8、最低2） */
 const POOL_SIZE = Math.max(2, Math.min(8, navigator.hardwareConcurrency ?? 4));
 
+/**
+ * Worker が応答しないと判定するまでの猶予（ms）。
+ *
+ * 目的は iOS Safari のメモリ圧迫による silent kill から復帰することであり、
+ * 健全だが探索の長い手を誤 kill してはいけない。
+ * 関連する探索側 time budget（すべて bounded 済み, #104）:
+ * - FAST minimax: absoluteTimeLimit 10s
+ * - PRECISE minimax: absoluteTimeLimit 20s
+ * - Phase 2 VCT: 10s + VCF 3s
+ * - REVIEW_VCT_OPTIONS_WITH_BRANCHES: 10s
+ * - forcedWinDetection fallback: 5s/手
+ * - verifyCandidates: 5s
+ * → 単発タスク worst case ≒ 55s、8 並列 CPU 競合込みで 90s 程度
+ *
+ * 120s は上記に 30% 程度の安全余裕を持たせつつ、真の hang を過度に待たせない値。
+ */
+const WORKER_WATCHDOG_MS = 120_000;
+
+/** watchdog タイムアウト後、同一タスクを再投入する最大回数 */
+const WORKER_MAX_RETRIES = 1;
+
 export interface UseReviewEvaluatorReturn {
   /** 評価中かどうか */
   isEvaluating: Ref<boolean>;
@@ -44,6 +65,8 @@ export interface UseReviewEvaluatorReturn {
   completedCount: Ref<number>;
   /** 評価する総手数 */
   totalCount: Ref<number>;
+  /** 再試行を含めても応答が返らなかった手数（silent kill 判定） */
+  failedCount: Ref<number>;
   /** 全プレイヤーの手を並列評価 */
   evaluate: (
     moveHistory: string,
@@ -65,6 +88,7 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
   const progress = ref(0);
   const completedCount = ref(0);
   const totalCount = ref(0);
+  const failedCount = ref(0);
 
   let workers: Worker[] = [];
   let cancelled = false;
@@ -85,6 +109,10 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
       w.terminate();
     }
     workers = [];
+  }
+
+  function createReplacementWorker(): Worker {
+    return new ReviewWorker();
   }
 
   /** 進捗を1手分進める */
@@ -124,10 +152,21 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
     completedCount.value = 0;
     totalCount.value = allMoveItems.length;
     progress.value = 0;
+    failedCount.value = 0;
 
     const pool = initPool();
     const results: (FullEvalResult | LightEvalResult)[] = [];
     const isCancelled = (): boolean => cancelled;
+
+    /** watchdog 共通設定（silent kill 対策、#104） */
+    const watchdogConfig = {
+      timeoutMs: WORKER_WATCHDOG_MS,
+      maxRetries: WORKER_MAX_RETRIES,
+      createWorker: createReplacementWorker,
+      onTaskFailed: (): void => {
+        failedCount.value++;
+      },
+    };
 
     // キャンセル時に runWorkerPool の await を解除するための Promise
     const cancelPromise = new Promise<void>((resolve) => {
@@ -158,6 +197,7 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
       },
       onProgress: advanceProgress,
       isCancelled,
+      ...watchdogConfig,
     });
 
     if (cancelled) {
@@ -192,6 +232,7 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
         },
         onProgress: advanceProgress,
         isCancelled,
+        ...watchdogConfig,
       });
     }
 
@@ -241,6 +282,7 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
           },
           onProgress: advanceProgress,
           isCancelled,
+          ...watchdogConfig,
         });
       }
 
@@ -277,6 +319,7 @@ export function useReviewEvaluator(): UseReviewEvaluatorReturn {
     progress,
     completedCount,
     totalCount,
+    failedCount,
     evaluate,
     cancel,
   };

--- a/src/logic/cpu/review/forcedWinDetection.ts
+++ b/src/logic/cpu/review/forcedWinDetection.ts
@@ -73,7 +73,10 @@ function findVCTByFirstMoveIteration(
   const threats = findThreatMoves(board, color);
   const perMoveOptions: VCTSearchOptions = {
     ...options,
-    timeLimit: Infinity,
+    // 元は Infinity。密局面で maxNodes が消化されず単発タスクが 60-120s に伸びる
+    // 問題の対策 (#104)。fallback iteration 全体では複数手ぶん時間が積み上がるので、
+    // 1 手あたりは短めに切る。
+    timeLimit: 5_000,
     maxNodes: VCT_FALLBACK_MAX_NODES,
     vcfOptions: {
       ...options.vcfOptions,

--- a/src/logic/cpu/review/reviewConstants.ts
+++ b/src/logic/cpu/review/reviewConstants.ts
@@ -60,7 +60,10 @@ export const REVIEW_PROFILE_PRECISE = {
 /** 振り返り用VCT探索パラメータ（forcedWin表示用、分岐収集あり） */
 export const REVIEW_VCT_OPTIONS_WITH_BRANCHES: VCTSearchOptions = {
   maxDepth: 6,
-  timeLimit: Infinity,
+  // timeLimit を Infinity にすると、maxNodes 500_000 が消化されない密局面で
+  // 単発タスクが 60-120s に伸び、pool のスループットを潰す。#104
+  // 10s を超える場合は VCT を表示しない（forcedWin sequence は minimax PV にフォールバック）。
+  timeLimit: 10_000,
   maxNodes: 500_000,
   vcfOptions: {
     maxDepth: 16,

--- a/src/logic/cpu/review/workerPoolDispatcher.test.ts
+++ b/src/logic/cpu/review/workerPoolDispatcher.test.ts
@@ -2,7 +2,7 @@
  * 汎用ワーカープールディスパッチャーのテスト
  */
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { type WorkerLike, runWorkerPool } from "./workerPoolDispatcher";
 
@@ -11,11 +11,17 @@ class MockWorker implements WorkerLike {
   onmessage: ((event: MessageEvent) => unknown) | null = null;
   onerror: ((event: ErrorEvent) => unknown) | null = null;
   readonly posted: unknown[] = [];
+  terminated = false;
   private pendingResponses: unknown[] = [];
   private shouldError = false;
+  /** true 中は postMessage しても応答を返さない（Worker が死んだ想定） */
+  private hang = false;
 
   postMessage(data: unknown): void {
     this.posted.push(data);
+    if (this.hang) {
+      return;
+    }
     // 非同期でレスポンスを返す（マイクロタスクで）
     const response = this.pendingResponses.shift();
     if (this.shouldError) {
@@ -32,6 +38,10 @@ class MockWorker implements WorkerLike {
     }
   }
 
+  terminate(): void {
+    this.terminated = true;
+  }
+
   /** 次の postMessage でエラーを返すように設定 */
   setNextError(): void {
     this.shouldError = true;
@@ -40,6 +50,11 @@ class MockWorker implements WorkerLike {
   /** 次のレスポンスデータを設定 */
   queueResponse(data: unknown): void {
     this.pendingResponses.push(data);
+  }
+
+  /** postMessage しても応答を返さないモードに切り替え */
+  setHang(hang: boolean): void {
+    this.hang = hang;
   }
 }
 
@@ -166,5 +181,188 @@ describe("runWorkerPool", () => {
 
     expect(calls[0]).toEqual([1, { score: 100 }]);
     expect(calls[1]).toEqual([2, { score: 200 }]);
+  });
+
+  describe("watchdog", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("timeoutMs 超過で worker を terminate し新規 worker で再投入", async () => {
+      vi.useFakeTimers();
+      const w1 = new MockWorker();
+      const w2 = new MockWorker();
+      const created: MockWorker[] = [];
+      let createdIndex = 0;
+
+      w1.setHang(true); // 応答しない = 死亡想定
+      const results: number[] = [];
+
+      const promise = runWorkerPool([w1], [1, 2], {
+        buildRequest: (item) => item,
+        handleResult: (item) => results.push(item),
+        timeoutMs: 20000,
+        maxRetries: 1,
+        createWorker: () => {
+          const w = createdIndex === 0 ? w2 : new MockWorker();
+          createdIndex++;
+          created.push(w);
+          return w;
+        },
+      });
+
+      await Promise.resolve(); // postMessage 発火まで待つ
+      expect(w1.posted).toEqual([1]);
+
+      // タイムアウトを進める
+      await vi.advanceTimersByTimeAsync(20000);
+      expect(w1.terminated).toBe(true);
+      expect(created).toHaveLength(1);
+
+      // w2 で再試行 → 1 が成功、続けて 2 も処理される
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(results).toEqual([1, 2]);
+      expect(w2.posted).toEqual([1, 2]);
+    });
+
+    test("maxRetries 回まで再試行、超過したら onTaskFailed で報告", async () => {
+      vi.useFakeTimers();
+      const workers: MockWorker[] = [];
+      const makeHangWorker = (): MockWorker => {
+        const w = new MockWorker();
+        w.setHang(true);
+        workers.push(w);
+        return w;
+      };
+
+      const initial = makeHangWorker();
+      const failed: number[] = [];
+
+      const promise = runWorkerPool([initial], [1, 2], {
+        buildRequest: (item) => item,
+        handleResult: () => undefined,
+        timeoutMs: 20000,
+        maxRetries: 1,
+        createWorker: makeHangWorker,
+        onTaskFailed: (item) => failed.push(item),
+      });
+
+      // 1回目のタイムアウト → 再試行
+      await vi.advanceTimersByTimeAsync(20000);
+      // 2回目のタイムアウト → 失敗確定
+      await vi.advanceTimersByTimeAsync(20000);
+      // 3回目のタスクも同様に失敗させる
+      await vi.advanceTimersByTimeAsync(20000);
+      await vi.advanceTimersByTimeAsync(20000);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(failed).toEqual([1, 2]);
+      expect(initial.terminated).toBe(true);
+    });
+
+    test("失敗タスクでも onProgress は前進する", async () => {
+      vi.useFakeTimers();
+      const workers: MockWorker[] = [];
+      const makeHang = (): MockWorker => {
+        const w = new MockWorker();
+        w.setHang(true);
+        workers.push(w);
+        return w;
+      };
+      const initial = makeHang();
+      const onProgress = vi.fn();
+
+      const promise = runWorkerPool([initial], [1], {
+        buildRequest: (item) => item,
+        handleResult: () => undefined,
+        onProgress,
+        timeoutMs: 20000,
+        maxRetries: 0,
+        createWorker: makeHang,
+      });
+
+      await vi.advanceTimersByTimeAsync(20000);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(onProgress).toHaveBeenCalledTimes(1);
+    });
+
+    test("timeoutMs 未設定なら watchdog は動かず既存挙動", async () => {
+      const w = new MockWorker();
+      const results: number[] = [];
+      await runWorkerPool([w], [1, 2], {
+        buildRequest: (item) => item,
+        handleResult: (item) => results.push(item),
+      });
+      expect(results).toEqual([1, 2]);
+      expect(w.terminated).toBe(false);
+    });
+
+    test("正常応答は timer をクリアしタスク継続", async () => {
+      vi.useFakeTimers();
+      const w = new MockWorker();
+      const results: number[] = [];
+
+      const promise = runWorkerPool([w], [1, 2, 3], {
+        buildRequest: (item) => item,
+        handleResult: (item) => results.push(item),
+        timeoutMs: 20000,
+        maxRetries: 1,
+        createWorker: () => new MockWorker(),
+      });
+
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(results).toEqual([1, 2, 3]);
+      expect(w.terminated).toBe(false);
+    });
+
+    test("cancel 直後の timeout 発火では新規 Worker を作らない", async () => {
+      vi.useFakeTimers();
+      const w = new MockWorker();
+      w.setHang(true);
+      let cancelFlag = false;
+      let createCount = 0;
+
+      const promise = runWorkerPool([w], [1], {
+        buildRequest: (item) => item,
+        handleResult: () => undefined,
+        isCancelled: () => cancelFlag,
+        timeoutMs: 20000,
+        maxRetries: 1,
+        createWorker: () => {
+          createCount++;
+          return new MockWorker();
+        },
+      });
+
+      // タイムアウト直前で cancel
+      await vi.advanceTimersByTimeAsync(19999);
+      cancelFlag = true;
+      // タイムアウト発火
+      await vi.advanceTimersByTimeAsync(2);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(w.terminated).toBe(true);
+      // cancel 済みなので replacement Worker は作らない
+      expect(createCount).toBe(0);
+    });
+
+    test("timeoutMs 指定で createWorker 未指定なら throw", () => {
+      const w = new MockWorker();
+      expect(() =>
+        runWorkerPool([w], [1], {
+          buildRequest: (item) => item,
+          handleResult: () => undefined,
+          timeoutMs: 20000,
+        }),
+      ).toThrow(/createWorker/);
+    });
   });
 });

--- a/src/logic/cpu/review/workerPoolDispatcher.ts
+++ b/src/logic/cpu/review/workerPoolDispatcher.ts
@@ -3,11 +3,16 @@
  *
  * 共有キューからタスクを取り出し、空きワーカーに1つずつ割り当てる。
  * 全タスク完了で Promise を resolve する。
+ *
+ * timeoutMs + createWorker 併用時は watchdog が有効。応答が来ない Worker を
+ * terminate し、新規 Worker で最大 maxRetries 回まで再投入する。
+ * （iPad Safari のメモリ圧迫で Worker が silent kill されるケース対策 #104）
  */
 
 /** ワーカーの抽象インターフェース（テスト時にモック可能） */
 export interface WorkerLike {
   postMessage(data: unknown): void;
+  terminate(): void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onmessage: ((event: MessageEvent) => any) | null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,6 +29,20 @@ export interface DispatchConfig<TItem, TResult> {
   onProgress?: () => void;
   /** キャンセル判定（true で新規ディスパッチ停止） */
   isCancelled?: () => boolean;
+  /**
+   * Worker が応答しないと判定するまでのミリ秒。
+   * createWorker と併用時のみ watchdog が有効。
+   */
+  timeoutMs?: number;
+  /**
+   * タイムアウト時の最大再試行回数（既定 0）。
+   * 1 なら最大 2 回試行し、超過したら onTaskFailed を呼ぶ。
+   */
+  maxRetries?: number;
+  /** タイムアウト時に死亡した Worker と差し替える新規 Worker を作成 */
+  createWorker?: () => WorkerLike;
+  /** 再試行を使い切ってもタスクが完了しなかった場合の通知 */
+  onTaskFailed?: (item: TItem) => void;
 }
 
 /**
@@ -32,6 +51,9 @@ export interface DispatchConfig<TItem, TResult> {
  * items をコピーしたキューから各ワーカーに1タスクずつ割り当て、
  * 完了したワーカーに次のタスクを割り当てる。全タスク完了で resolve。
  * キャンセル時は in-flight タスクの完了を待ってから resolve。
+ *
+ * 副作用: watchdog 発火時に呼び出し側の `workers` 配列を in-place で書き換える
+ * （死亡想定 Worker のスロットを新規 Worker で置換）。
  */
 export function runWorkerPool<TItem, TResult>(
   workers: WorkerLike[],
@@ -42,16 +64,31 @@ export function runWorkerPool<TItem, TResult>(
     return Promise.resolve();
   }
 
+  if (config.timeoutMs !== undefined && !config.createWorker) {
+    // 設定漏れを silent-noop で吸収しない。開発中に即気付けるよう throw。
+    throw new Error(
+      "runWorkerPool: timeoutMs is set but createWorker is missing — watchdog cannot respawn dead worker",
+    );
+  }
+
   return new Promise<void>((resolve) => {
     const queue = [...items];
     let completed = 0;
     let inFlight = 0;
     const total = items.length;
+    const attempts = new Map<TItem, number>();
+    const watchdogEnabled =
+      config.timeoutMs !== undefined && Boolean(config.createWorker);
+    const maxRetries = config.maxRetries ?? 0;
 
     function tryResolve(): void {
       if (inFlight === 0 && (completed === total || config.isCancelled?.())) {
         resolve();
       }
+    }
+
+    function finishTask(): void {
+      completed++;
     }
 
     function dispatchNext(worker: WorkerLike): void {
@@ -67,25 +104,89 @@ export function runWorkerPool<TItem, TResult>(
       }
 
       inFlight++;
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+      let settled = false;
+
+      const clearWatchdog = (): void => {
+        if (timeoutHandle !== null) {
+          clearTimeout(timeoutHandle);
+          timeoutHandle = null;
+        }
+      };
 
       worker.onmessage = (event: MessageEvent<TResult>) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearWatchdog();
         inFlight--;
         if (!config.isCancelled?.()) {
           config.handleResult(item, event.data);
           config.onProgress?.();
         }
-        completed++;
+        finishTask();
         dispatchNext(worker);
       };
 
       worker.onerror = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearWatchdog();
         inFlight--;
         if (!config.isCancelled?.()) {
           config.onProgress?.();
         }
-        completed++;
+        finishTask();
         dispatchNext(worker);
       };
+
+      if (watchdogEnabled) {
+        timeoutHandle = setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          timeoutHandle = null;
+
+          try {
+            worker.terminate();
+          } catch {
+            // 既に terminate 済みの可能性は無視
+          }
+          inFlight--;
+
+          // cancel 済みなら新規 Worker を作らずに即終了（iOS メモリ節約が本件目的）
+          if (config.isCancelled?.()) {
+            finishTask();
+            tryResolve();
+            return;
+          }
+
+          // 死亡想定 Worker のスロットを新規 Worker で置換
+          const slot = workers.indexOf(worker);
+          const replacement = config.createWorker!();
+          if (slot >= 0) {
+            workers[slot] = replacement;
+          }
+
+          const nextAttempt = (attempts.get(item) ?? 0) + 1;
+          attempts.set(item, nextAttempt);
+
+          if (nextAttempt <= maxRetries) {
+            // 再試行: キュー先頭に戻して同じ Worker スロットで再投入
+            queue.unshift(item);
+          } else {
+            // 上限到達: 失敗として計上して進捗を進める
+            config.onTaskFailed?.(item);
+            config.onProgress?.();
+            finishTask();
+          }
+          dispatchNext(replacement);
+        }, config.timeoutMs);
+      }
 
       worker.postMessage(config.buildRequest(item));
     }


### PR DESCRIPTION
## Summary

- 振り返り解析の探索側 `timeLimit: Infinity` が原因で単発タスクが 60-120s に膨張し、Worker pool のスループットを潰していた。iPad の「28/88 で停止」報告 (#104) の真因。
- `REVIEW_VCT_OPTIONS_WITH_BRANCHES` と `findVCTByFirstMoveIteration` の VCT 探索時間を bounded 化。
- 万一の Worker silent kill（iPad OOM 等）に備え、workerPoolDispatcher にウォッチドッグ + 再試行を追加。上限超過時のみ「解析失敗 N手」バッジを UI に表示。

## 根本原因（動的計測で判明）

Worker に per-task ログを仕込んで 92 手棋譜を計測した結果、以下の task がボトルネックだった:

| task | 実測時間 |
| --- | --- |
| mi=50 | **119.7s** |
| mi=52 | **117.6s** |
| mi=60/62/64 | 60-70s |

FAST profile の `absoluteTimeLimit=10s` に対し **12 倍以上**。`REVIEW_VCT_OPTIONS_WITH_BRANCHES.timeLimit: Infinity` と `forcedWinDetection.findVCTByFirstMoveIteration` の `timeLimit: Infinity` が原因（maxNodes 500K だけでは密局面で消化されない）。

## 変更

### 探索側 (真因の修正)
- `src/logic/cpu/review/reviewConstants.ts`: `REVIEW_VCT_OPTIONS_WITH_BRANCHES.timeLimit` を `Infinity → 10_000`
- `src/logic/cpu/review/forcedWinDetection.ts`: `findVCTByFirstMoveIteration` 内の per-move `timeLimit` を `Infinity → 5_000`

これで単発タスク worst case ≒ 55s に抑制。VCT 表示は 10s 超で minimax PV にフォールバック。

### ウォッチドッグ (silent kill 対策の保険)
- `src/logic/cpu/review/workerPoolDispatcher.ts`: `timeoutMs` / `maxRetries` / `createWorker` / `onTaskFailed` を追加。応答なし Worker を terminate → 新規 Worker で再投入。cancel-race 対策 (SOLID レビュー指摘) / 設定漏れ throw (OCP レビュー指摘) 込み。
- `src/components/cpu/composables/useReviewEvaluator.ts`: 3 phase すべてに watchdog=120s / retry=1 を配線。`failedCount` ref を公開。
- `src/components/cpu/ReviewStatus.vue`: `failedCount > 0` のときのみバッジ表示（silent by default）。

## 検証

92 手棋譜 (issue #104 の棋譜) をデスクトップ Chrome (POOL_SIZE=8) で完走確認:

| watchdog | 探索側 timeLimit | 失敗手数 |
|---|---|---|
| なし（当初） | Infinity | 完全停止（報告された症状） |
| 30s | Infinity | 15/88 失敗 |
| 120s | Infinity | 12/88 失敗 |
| **120s** | **bounded 10s** | **0/88 失敗（全 92 手解析）** |

## Test plan

- [x] `pnpm check-fix` 通過（型 + フォーマット + lint）
- [x] `pnpm vitest run`: 1553 テスト緑（既存 + watchdog テスト 7 件追加）
- [x] `zig build test` 緑
- [x] 実棋譜 (#104) をデスクトップ dev サーバーで完走確認 (0 失敗)
- [ ] iPad Safari で完走確認（現物なし、報告者側で検証依頼）
- [ ] iPad で silent kill が発生した場合の retry+failedCount UI 動作確認

## /review 実施済み

3 サブエージェント (SOLID / Perf / Issue) でレビューし、指摘を反映:
- cancel-race での Worker leak → `isCancelled` チェックを `createWorker` 呼び出し前に移動
- `timeoutMs` だけ設定して `createWorker` なしなら throw
- watchdog 設定の DRY 化 (`watchdogConfig` を spread)
- Issue レビュワー指摘: Precise モード誤 kill 懸念 → プロファイル定数から計算していたが、真因 (探索側 unbounded) の方を修正して解決

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)