### PR TITLE
chore: pnpm 11 設定移行と worktree の lint 除外

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,8 @@ export default [
       "**/*.d.ts",
       ".oxlint_cache",
       ".eslint_cache",
+      // サブエージェント用 git worktree 置き場。main からは lint 対象外。
+      ".claude/**",
       // GPL の外部解析エンジン（Rapfi）置き場。コミット禁止・lint対象外。
       "scripts/rapfi/**",
       "tools/oracle/**",

--- a/package.json
+++ b/package.json
@@ -75,15 +75,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook"
-    ],
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "vite-plugin-pwa>vite": "8"
-      }
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  lefthook: true
+
+peerDependencyRules:
+  allowedVersions:
+    "vite-plugin-pwa>vite": "8"


### PR DESCRIPTION
開発環境の修復2点（コード変更なし）:

- **pnpm 11.12 対応**: `package.json` の `pnpm.onlyBuiltDependencies` / `peerDependencyRules` が読まれなくなり、lefthook のビルドが未承認扱いで `pnpm test` 等の run 系が依存チェック段階で全滅していた → `pnpm-workspace.yaml` へ移行
- **eslint ignore**: `.claude/worktrees/`（サブエージェント用 worktree）内のファイルを eslint が走査してエラーになっていた → ignore 追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RM5iEfn2Aq5rU8eXe89NnZ