### PR TITLE
feat(review): 敗着チェーン集計 — 被詰み継続手を悪手カウントから除外

### DIFF
--- a/src/components/cpu/CpuReviewPlayer.vue
+++ b/src/components/cpu/CpuReviewPlayer.vue
@@ -372,7 +372,7 @@ function handleLayoutClick(event: MouseEvent): void {
           <ReviewControls
             :current-move-index="reviewStore.currentMoveIndex"
             :total-moves="reviewStore.moves.length"
-            :evaluated-moves="reviewStore.evaluatedMoves"
+            :evaluated-moves="reviewStore.evaluatedMovesWithChains"
             :losing-move-index="reviewStore.losingMove?.moveIndex"
             @go-to-move="advanceToMove"
             @go-to-start="reviewStore.goToStart"

--- a/src/components/cpu/ReviewControls.vue
+++ b/src/components/cpu/ReviewControls.vue
@@ -65,11 +65,15 @@ function getForcedLossLabel(
   return type ? `被${FULL_LABELS[type]}` : undefined;
 }
 
+/** 強制応手（forcedReply）の補足テキスト */
+const FORCED_REPLY_NOTE = "既に被詰みのため評価対象外";
+
 /** 各手の品質ドット表示データ */
 const moveDots = computed(() =>
   Array.from({ length: props.totalMoves }, (_, i) => {
     const evaluated = props.evaluatedMoves.find((e) => e.moveIndex === i);
     const moveNum = String(i + 1);
+    const isForcedReply = evaluated?.quality === "forcedReply";
     const qualityLabel =
       evaluated && !evaluated.isLightEval && evaluated.quality !== "excellent"
         ? getQualityLabel(evaluated.quality, evaluated.isBookMove)
@@ -90,12 +94,14 @@ const moveDots = computed(() =>
         : getUnderlineCount(evaluated?.quality),
       hasForcedWin: forcedWinLabel !== undefined,
       hasForcedLoss: forcedLossLabel !== undefined,
+      isForcedReply,
       isLosingMove,
       ariaLabel: [
         moveNum,
         qualityLabel,
         forcedWinLabel,
         forcedLossLabel,
+        isForcedReply ? FORCED_REPLY_NOTE : undefined,
         isLosingMove ? "敗着" : undefined,
       ]
         .filter(Boolean)
@@ -167,10 +173,12 @@ const moveDots = computed(() =>
           [`underlines-${dot.underlines}`]: dot.underlines > 0,
           'has-forced-win': dot.hasForcedWin,
           'has-forced-loss': dot.hasForcedLoss,
+          'is-forced-reply': dot.isForcedReply,
           'is-losing-move': dot.isLosingMove,
         }"
         :style="dot.color ? { backgroundColor: dot.color } : {}"
         :aria-label="dot.ariaLabel"
+        :title="dot.ariaLabel"
         @click="emit('goToMove', dot.index)"
       >
         {{ dot.index }}
@@ -327,6 +335,13 @@ const moveDots = computed(() =>
   background: hsl(0, 65%, 50%);
   box-shadow: 0 0 0 1px var(--color-bg-white);
   pointer-events: none;
+}
+
+/* 強制応手（forcedReply）: 既に被詰みで選択の余地がなかった手。
+   グレー背景に加えて破線ボーダーで「評価対象外」であることを視覚的に区別する */
+.is-forced-reply {
+  border-style: dashed;
+  opacity: 0.85;
 }
 
 /* 敗着マーカー（二重リング） */

--- a/src/components/cpu/composables/useReviewDialogue.ts
+++ b/src/components/cpu/composables/useReviewDialogue.ts
@@ -142,10 +142,9 @@ const FORCED_WIN_DIALOGUES: Record<MoveQuality, string[]> = {
     "{forcedWin}を逃しちゃった！{bestMove}から決まったよ",
     "ここは{forcedWin}で勝てたね。{bestMove}がポイント！",
   ],
-  forcedReply: [
-    "{forcedWin}を逃しちゃった！{bestMove}から決まったよ",
-    "ここは{forcedWin}で勝てたね。{bestMove}がポイント！",
-  ],
+  // forcedReplyは選択の余地がない手だったため「逃した」とは言わず、
+  // 情報提供に留めるトーンにする
+  forcedReply: ["実は{forcedWin}もあったみたいだね。{bestMove}が起点だよ"],
 };
 
 /**

--- a/src/components/cpu/composables/useReviewDialogue.ts
+++ b/src/components/cpu/composables/useReviewDialogue.ts
@@ -35,6 +35,13 @@ const QUALITY_DIALOGUES: Record<MoveQuality, string[]> = {
     "{bestMove}に打つべきだったかも...",
     "うーん、{bestMove}の方がずっと良かったよ",
   ],
+  // 被詰みチェーンの2手目以降（選択の余地がない手）。forcedLossType が
+  // 常に付いているため実質 FORCED_LOSS_DIALOGUES 経由で選ばれるが、
+  // Record の網羅性のため定義しておく。
+  forcedReply: [
+    "ここは選択の余地がない局面だったね",
+    "もう厳しい流れの中の一手だね",
+  ],
 };
 
 /** 品質別の表情 */
@@ -44,6 +51,7 @@ const QUALITY_EMOTIONS: Record<MoveQuality, EmotionId> = {
   inaccuracy: 1, // 考え中
   mistake: 19, // 強調・指摘
   blunder: 19, // 強調・指摘（mistakeと同じ）
+  forcedReply: 1, // 考え中（仕方ない）
 };
 
 /** 負け確定（相手の必勝手順あり）時のセリフ（品質別） */
@@ -57,6 +65,11 @@ const FORCED_LOSS_DIALOGUES: Record<MoveQuality, string[]> = {
   blunder: [
     "この手で相手に{forcedLoss}を許しちゃったよ！{bestMove}ならまだ粘れたかも",
   ],
+  // 被詰みチェーンの継続手。既に{forcedLoss}を防げない中の一手のため、
+  // ミスとしては指摘しない。
+  forcedReply: [
+    "ここはもう{forcedLoss}を防げない中の一手。他に選びようがなかったね",
+  ],
 };
 
 /** 負け確定時の表情 */
@@ -66,6 +79,7 @@ const FORCED_LOSS_EMOTIONS: Record<MoveQuality, EmotionId> = {
   inaccuracy: 11, // 心配
   mistake: 11, // 心配
   blunder: 11, // 心配
+  forcedReply: 1, // 考え中（仕方ない）
 };
 
 /** 敗着（勝負の分かれ目）のセリフ — bestMove ≠ 打った手の場合 */
@@ -125,6 +139,10 @@ const FORCED_WIN_DIALOGUES: Record<MoveQuality, string[]> = {
     "ここは{forcedWin}で勝てたね。{bestMove}がポイント！",
   ],
   blunder: [
+    "{forcedWin}を逃しちゃった！{bestMove}から決まったよ",
+    "ここは{forcedWin}で勝てたね。{bestMove}がポイント！",
+  ],
+  forcedReply: [
     "{forcedWin}を逃しちゃった！{bestMove}から決まったよ",
     "ここは{forcedWin}で勝てたね。{bestMove}がポイント！",
   ],

--- a/src/logic/reviewLogic.test.ts
+++ b/src/logic/reviewLogic.test.ts
@@ -11,6 +11,7 @@ import {
   OPENING_MOVES,
   adjustCandidatesForForcedLoss,
   allCandidatesLose,
+  applyForcedReplyChains,
   applyVCTResult,
   buildBacktrackBranches,
   buildBacktrackSequence,
@@ -18,6 +19,7 @@ import {
   buildGameReview,
   classifyMoveQuality,
   findLosingMove,
+  getQualityColor,
   getQualityLabel,
   isOpeningMove,
 } from "./reviewLogic";
@@ -142,6 +144,199 @@ describe("buildGameReview", () => {
     const review = buildGameReview(moves);
     expect(review.accuracy).toBe(100);
   });
+
+  it("forcedLossチェーンの2手目以降はforcedReplyとして扱われ、criticalErrors・accuracy分母から除外される", () => {
+    const moves: EvaluatedMove[] = [
+      {
+        moveIndex: 3,
+        position: { row: 0, col: 0 },
+        isPlayerMove: true,
+        quality: "blunder",
+        playedScore: 0,
+        bestScore: 0,
+        scoreDiff: 0,
+        bestMove: { row: 0, col: 0 },
+        candidates: [],
+        forcedLossType: "vct",
+      },
+      {
+        moveIndex: 4,
+        position: { row: 0, col: 0 },
+        isPlayerMove: false,
+        quality: "excellent",
+        playedScore: 0,
+        bestScore: 0,
+        scoreDiff: 0,
+        bestMove: { row: 0, col: 0 },
+        candidates: [],
+      },
+      {
+        moveIndex: 5,
+        position: { row: 0, col: 0 },
+        isPlayerMove: true,
+        quality: "mistake",
+        playedScore: 0,
+        bestScore: 0,
+        scoreDiff: 0,
+        bestMove: { row: 0, col: 0 },
+        candidates: [],
+        forcedLossType: "vcf",
+      },
+    ];
+    const review = buildGameReview(moves);
+    // 分母はプレイヤーの手のうちforcedReply(5手目)を除いた1件(3手目)のみ
+    expect(review.accuracy).toBe(0); // 3手目はblunderなのでgoodOrBetter=0/1
+    expect(review.criticalErrors).toBe(1); // 3手目のみ（5手目はforcedReplyで除外）
+    expect(review.evaluatedMoves.find((m) => m.moveIndex === 5)?.quality).toBe(
+      "forcedReply",
+    );
+  });
+});
+
+describe("applyForcedReplyChains", () => {
+  function makeMove(
+    moveIndex: number,
+    opts?: {
+      isPlayerMove?: boolean;
+      quality?: EvaluatedMove["quality"];
+      forcedLossType?: EvaluatedMove["forcedLossType"];
+    },
+  ): EvaluatedMove {
+    return {
+      moveIndex,
+      position: { row: 0, col: 0 },
+      isPlayerMove: opts?.isPlayerMove ?? true,
+      quality: opts?.quality ?? "excellent",
+      playedScore: 0,
+      bestScore: 0,
+      scoreDiff: 0,
+      bestMove: { row: 0, col: 0 },
+      candidates: [],
+      forcedLossType: opts?.forcedLossType,
+    };
+  }
+
+  it("forcedLossType がひとつもなければ変更しない（同一参照）", () => {
+    const moves = [makeMove(3), makeMove(4), makeMove(5)];
+    expect(applyForcedReplyChains(moves)).toBe(moves);
+  });
+
+  it("ゲーム最初の評価対象手からチェーンが始まる: 初手はそのまま", () => {
+    const moves = [
+      makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+      makeMove(4, { isPlayerMove: false }),
+    ];
+    const result = applyForcedReplyChains(moves);
+    expect(result[0]!.quality).toBe("blunder");
+  });
+
+  it("チェーンが1手だけ: 敗着のみで強制応手は発生しない", () => {
+    const moves = [
+      makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+      makeMove(4, { isPlayerMove: false }),
+      makeMove(5, { quality: "excellent" }), // forcedLossType消滅=脱出
+    ];
+    const result = applyForcedReplyChains(moves);
+    expect(result[0]!.quality).toBe("blunder");
+    expect(result[2]!.quality).toBe("excellent");
+  });
+
+  it("チェーン2手目以降はforcedReplyになる（mistake等の分類を上書き）", () => {
+    const moves = [
+      makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+      makeMove(4, { isPlayerMove: false }),
+      makeMove(5, { quality: "mistake", forcedLossType: "vcf" }),
+      makeMove(6, { isPlayerMove: false }),
+      makeMove(7, { quality: "blunder", forcedLossType: "vct" }),
+    ];
+    const result = applyForcedReplyChains(moves);
+    expect(result[0]!.quality).toBe("blunder"); // 初手=敗着
+    expect(result[2]!.quality).toBe("forcedReply"); // 2手目: mistakeより優先
+    expect(result[4]!.quality).toBe("forcedReply"); // 3手目
+  });
+
+  it("forcedLossType の種類が途中で変わっても同一チェーン扱い", () => {
+    const moves = [
+      makeMove(3, { quality: "blunder", forcedLossType: "vcf" }),
+      makeMove(4, { isPlayerMove: false }),
+      makeMove(5, { quality: "blunder", forcedLossType: "vct" }),
+      makeMove(6, { isPlayerMove: false }),
+      makeMove(7, { quality: "blunder", forcedLossType: "forbidden-trap" }),
+    ];
+    const result = applyForcedReplyChains(moves);
+    expect(result[0]!.quality).toBe("blunder");
+    expect(result[2]!.quality).toBe("forcedReply");
+    expect(result[4]!.quality).toBe("forcedReply");
+  });
+
+  it("相手が勝ちを逃して脱出→再度被詰み: 2チェーン=敗着2つ", () => {
+    const moves = [
+      makeMove(3, { quality: "blunder", forcedLossType: "vct" }), // チェーン1 初手=敗着
+      makeMove(4, { isPlayerMove: false }),
+      makeMove(5, { quality: "blunder", forcedLossType: "vct" }), // チェーン1 継続=forcedReply
+      makeMove(6, { isPlayerMove: false }),
+      makeMove(7, { quality: "excellent" }), // 脱出（forcedLossTypeなし）
+      makeMove(8, { isPlayerMove: false }),
+      makeMove(9, { quality: "blunder", forcedLossType: "vcf" }), // チェーン2 初手=敗着
+      makeMove(10, { isPlayerMove: false }),
+      makeMove(11, { quality: "blunder", forcedLossType: "vcf" }), // チェーン2 継続=forcedReply
+    ];
+    const result = applyForcedReplyChains(moves);
+    expect(result[0]!.quality).toBe("blunder");
+    expect(result[2]!.quality).toBe("forcedReply");
+    expect(result[4]!.quality).toBe("excellent");
+    expect(result[6]!.quality).toBe("blunder");
+    expect(result[8]!.quality).toBe("forcedReply");
+  });
+
+  it("黒白両方が別々にチェーンを持つ棋譜: 色ごとに独立して判定する", () => {
+    const moves = [
+      // 黒(偶数)のチェーン: 3手目=敗着, 5手目=forcedReply
+      makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+      // 白(奇数)のチェーン: 4手目=敗着, 6手目=forcedReply
+      makeMove(4, {
+        isPlayerMove: false,
+        quality: "blunder",
+        forcedLossType: "vcf",
+      }),
+      makeMove(5, { quality: "mistake", forcedLossType: "vct" }),
+      makeMove(6, {
+        isPlayerMove: false,
+        quality: "mistake",
+        forcedLossType: "vcf",
+      }),
+    ];
+    const result = applyForcedReplyChains(moves);
+    expect(result[0]!.quality).toBe("blunder"); // moveIndex3: 黒チェーン初手
+    expect(result[1]!.quality).toBe("blunder"); // moveIndex4: 白チェーン初手
+    expect(result[2]!.quality).toBe("forcedReply"); // moveIndex5: 黒チェーン継続
+    expect(result[3]!.quality).toBe("forcedReply"); // moveIndex6: 白チェーン継続
+  });
+
+  it("最終手でチェーンが終端しても例外は起きない", () => {
+    const moves = [
+      makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+      makeMove(4, { isPlayerMove: false }),
+      makeMove(5, { quality: "blunder", forcedLossType: "vct" }),
+    ];
+    const result = applyForcedReplyChains(moves);
+    expect(result[0]!.quality).toBe("blunder");
+    expect(result[2]!.quality).toBe("forcedReply");
+  });
+
+  it("評価順序に依存しない（入力配列の順序がバラバラでも同じ結果）", () => {
+    const inOrder = [
+      makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+      makeMove(4, { isPlayerMove: false }),
+      makeMove(5, { quality: "blunder", forcedLossType: "vct" }),
+    ];
+    const shuffled = [inOrder[2]!, inOrder[0]!, inOrder[1]!];
+    const result = applyForcedReplyChains(shuffled);
+    const byIndex = (i: number): EvaluatedMove =>
+      result.find((m) => m.moveIndex === i)!;
+    expect(byIndex(3).quality).toBe("blunder");
+    expect(byIndex(5).quality).toBe("forcedReply");
+  });
 });
 
 describe("buildEvaluatedMove: モード別", () => {
@@ -251,6 +446,16 @@ describe("getQualityLabel", () => {
   it("isBookMove が未指定/falseなら通常のラベルを返す", () => {
     expect(getQualityLabel("excellent")).toBe("最善手");
     expect(getQualityLabel("blunder", false)).toBe("悪手");
+  });
+
+  it("forcedReplyは「被詰み継続」を返す", () => {
+    expect(getQualityLabel("forcedReply")).toBe("被詰み継続");
+  });
+});
+
+describe("getQualityColor", () => {
+  it("forcedReplyはグレー系の色を返す", () => {
+    expect(getQualityColor("forcedReply")).toBe("#9e9e9e");
   });
 });
 

--- a/src/logic/reviewLogic.ts
+++ b/src/logic/reviewLogic.ts
@@ -191,10 +191,71 @@ export function applyVCTResult(
 }
 
 /**
+ * forcedLoss チェーンの2手目以降を「強制応手（forcedReply）」に再分類する
+ *
+ * 同一プレイヤー（moveIndex の偶奇 = 手番の色）の forcedLossType 付きの手が
+ * 連続する区間をチェーンとみなす。チェーン初手は従来どおりの品質（多くの場合
+ * blunder への降格を含む）のまま扱い「敗着」としてカウントする。2手目以降は
+ * scoreDiff ベースの分類（mistake 等）を上書きして quality を "forcedReply" に
+ * 固定する — 被詰み確定後は選択の余地がなく、独立したミスとしてカウントすべき
+ * ではないため。
+ *
+ * チェーンは forcedLossType の種類（vcf/vct等）が途中で変わっても継続する。
+ * 途中で forcedLossType が消える（相手が勝ち手順を逃す）とチェーンは途切れ、
+ * 再度検出されれば新しいチェーンとして扱う（= 新たな敗着）。
+ *
+ * 評価順序への依存を避けるため、色（偶奇）ごとに moveIndex 昇順へソートしてから
+ * 走査する。moveIndex が前のチェーン手の直後（+2）でない場合は非連続とみなし、
+ * 新しいチェーンとして扱う（評価が部分的にしか揃っていない場合の防御）。
+ */
+export function applyForcedReplyChains(
+  evaluatedMoves: EvaluatedMove[],
+): EvaluatedMove[] {
+  const forcedReplyIndices = new Set<number>();
+
+  for (const parity of [0, 1] as const) {
+    const colorMoves = evaluatedMoves
+      .filter((m) => m.moveIndex % 2 === parity)
+      .sort((a, b) => a.moveIndex - b.moveIndex);
+
+    let prevChainMoveIndex: number | null = null;
+    for (const move of colorMoves) {
+      if (!move.forcedLossType) {
+        prevChainMoveIndex = null;
+        continue;
+      }
+      const isChainContinuation =
+        prevChainMoveIndex !== null &&
+        move.moveIndex === prevChainMoveIndex + 2;
+      if (isChainContinuation) {
+        forcedReplyIndices.add(move.moveIndex);
+      }
+      prevChainMoveIndex = move.moveIndex;
+    }
+  }
+
+  if (forcedReplyIndices.size === 0) {
+    return evaluatedMoves;
+  }
+
+  return evaluatedMoves.map((move) =>
+    forcedReplyIndices.has(move.moveIndex)
+      ? { ...move, quality: "forcedReply" as const }
+      : move,
+  );
+}
+
+/**
  * 全手の評価結果から対局全体の評価を構築
+ *
+ * forcedLoss チェーンの2手目以降（forcedReply）は accuracy の分母と
+ * criticalErrors から除外する（applyForcedReplyChains 参照）。
  */
 export function buildGameReview(evaluatedMoves: EvaluatedMove[]): GameReview {
-  const playerMoves = evaluatedMoves.filter((m) => m.isPlayerMove);
+  const processedMoves = applyForcedReplyChains(evaluatedMoves);
+  const playerMoves = processedMoves.filter(
+    (m) => m.isPlayerMove && m.quality !== "forcedReply",
+  );
 
   // 精度計算: excellentとgoodの割合
   const goodOrBetter = playerMoves.filter(
@@ -211,10 +272,10 @@ export function buildGameReview(evaluatedMoves: EvaluatedMove[]): GameReview {
   ).length;
 
   return {
-    evaluatedMoves,
+    evaluatedMoves: processedMoves,
     accuracy,
     criticalErrors,
-    losingMove: findLosingMove(evaluatedMoves),
+    losingMove: findLosingMove(processedMoves),
   };
 }
 
@@ -368,6 +429,8 @@ export function getQualityColor(quality: MoveQuality): string {
       return "#f44336";
     case "blunder":
       return "#f44336";
+    case "forcedReply":
+      return "#9e9e9e";
     default: {
       const _exhaustive: never = quality;
       return _exhaustive;
@@ -401,6 +464,8 @@ export function getQualityLabel(
       return "悪手";
     case "blunder":
       return "悪手";
+    case "forcedReply":
+      return "被詰み継続";
     default: {
       const _exhaustive: never = quality;
       return _exhaustive;

--- a/src/logic/reviewLogic.ts
+++ b/src/logic/reviewLogic.ts
@@ -211,6 +211,12 @@ export function applyVCTResult(
 export function applyForcedReplyChains(
   evaluatedMoves: EvaluatedMove[],
 ): EvaluatedMove[] {
+  // forcedLossType が一つも無ければチェーンは存在し得ない。大半の対局
+  // （被詰みが一度も発生しない）で色ごとの filter+sort を丸ごと省略する。
+  if (!evaluatedMoves.some((m) => m.forcedLossType)) {
+    return evaluatedMoves;
+  }
+
   const forcedReplyIndices = new Set<number>();
 
   for (const parity of [0, 1] as const) {

--- a/src/stores/cpuReviewStore.test.ts
+++ b/src/stores/cpuReviewStore.test.ts
@@ -1,0 +1,159 @@
+/**
+ * cpuReviewStore テスト
+ *
+ * forcedLoss チェーン集計（accuracy/criticalErrors から forcedReply を
+ * 除外する挙動）を中心に検証する。
+ */
+
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EvaluatedMove } from "@/types/review";
+
+import { useCpuReviewStore } from "./cpuReviewStore";
+
+// localStorageのモック（reviewCacheが読み書きするため）
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      const { [key]: _, ...rest } = store;
+      store = rest;
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+vi.stubGlobal("localStorage", localStorageMock);
+
+function makeMove(
+  moveIndex: number,
+  opts?: {
+    isPlayerMove?: boolean;
+    quality?: EvaluatedMove["quality"];
+    forcedLossType?: EvaluatedMove["forcedLossType"];
+  },
+): EvaluatedMove {
+  return {
+    moveIndex,
+    position: { row: 0, col: 0 },
+    isPlayerMove: opts?.isPlayerMove ?? true,
+    quality: opts?.quality ?? "excellent",
+    playedScore: 0,
+    bestScore: 0,
+    scoreDiff: 0,
+    bestMove: { row: 0, col: 0 },
+    candidates: [],
+    forcedLossType: opts?.forcedLossType,
+  };
+}
+
+describe("cpuReviewStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("初期状態", () => {
+    it("評価済みの手がなければ精度はnull", () => {
+      const store = useCpuReviewStore();
+      expect(store.playerAccuracy).toBeNull();
+    });
+
+    it("評価済みの手がなければミス数は0", () => {
+      const store = useCpuReviewStore();
+      expect(store.criticalErrors).toBe(0);
+    });
+  });
+
+  describe("forcedLossチェーン集計", () => {
+    it("チェーン2手目以降はcriticalErrorsに含まれない", () => {
+      const store = useCpuReviewStore();
+      store.evaluatedMoves = [
+        makeMove(3, { quality: "blunder", forcedLossType: "vct" }), // 敗着
+        makeMove(4, { isPlayerMove: false }),
+        makeMove(5, { quality: "mistake", forcedLossType: "vcf" }), // 強制応手
+        makeMove(6, { isPlayerMove: false }),
+        makeMove(7, { quality: "blunder", forcedLossType: "vct" }), // 強制応手
+      ];
+
+      expect(store.criticalErrors).toBe(1);
+    });
+
+    it("forcedReplyはaccuracyの分母から除外される", () => {
+      const store = useCpuReviewStore();
+      store.evaluatedMoves = [
+        makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+        makeMove(4, { isPlayerMove: false }),
+        makeMove(5, { quality: "mistake", forcedLossType: "vcf" }),
+      ];
+
+      // 分母は3手目のみ(1件)。blunderなのでgoodOrBetter=0 → 0%
+      expect(store.playerAccuracy).toBe(0);
+    });
+
+    it("evaluatedMovesWithChainsでチェーン継続手がforcedReplyに再分類される", () => {
+      const store = useCpuReviewStore();
+      store.evaluatedMoves = [
+        makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+        makeMove(4, { isPlayerMove: false }),
+        makeMove(5, { quality: "mistake", forcedLossType: "vcf" }),
+      ];
+
+      const chained = store.evaluatedMovesWithChains;
+      expect(chained.find((m) => m.moveIndex === 3)?.quality).toBe("blunder");
+      expect(chained.find((m) => m.moveIndex === 5)?.quality).toBe(
+        "forcedReply",
+      );
+    });
+
+    it("生のevaluatedMovesは再分類されない（逐次追加・部分更新用の生データを維持）", () => {
+      const store = useCpuReviewStore();
+      store.evaluatedMoves = [
+        makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+        makeMove(4, { isPlayerMove: false }),
+        makeMove(5, { quality: "mistake", forcedLossType: "vcf" }),
+      ];
+
+      expect(store.evaluatedMoves.find((m) => m.moveIndex === 5)?.quality).toBe(
+        "mistake",
+      );
+    });
+
+    it("currentEvaluationはforcedReply再分類済みの値を返す", () => {
+      const store = useCpuReviewStore();
+      store.evaluatedMoves = [
+        makeMove(3, { quality: "blunder", forcedLossType: "vct" }),
+        makeMove(4, { isPlayerMove: false }),
+        makeMove(5, { quality: "mistake", forcedLossType: "vcf" }),
+      ];
+      store.currentMoveIndex = 6; // moveIndex 5 (0始まり) を指す
+
+      expect(store.currentEvaluation?.quality).toBe("forcedReply");
+    });
+
+    it("独立した2チェーンはそれぞれ敗着としてcriticalErrorsに含まれる", () => {
+      const store = useCpuReviewStore();
+      store.evaluatedMoves = [
+        makeMove(3, { quality: "blunder", forcedLossType: "vct" }), // 敗着1
+        makeMove(4, { isPlayerMove: false }),
+        makeMove(5, { quality: "excellent" }), // 脱出
+        makeMove(6, { isPlayerMove: false }),
+        makeMove(7, { quality: "blunder", forcedLossType: "vcf" }), // 敗着2
+      ];
+
+      expect(store.criticalErrors).toBe(2);
+    });
+  });
+});

--- a/src/stores/cpuReviewStore.ts
+++ b/src/stores/cpuReviewStore.ts
@@ -19,7 +19,7 @@ import type {
 
 import { parseGameRecord } from "@/logic/gameRecordParser";
 import { checkWin, createEmptyBoard } from "@/logic/renjuRules";
-import { findLosingMove } from "@/logic/reviewLogic";
+import { buildGameReview } from "@/logic/reviewLogic";
 
 /** localStorageキャッシュキー */
 const REVIEW_CACHE_KEY = "holorenju-review-cache";
@@ -194,42 +194,45 @@ export const useCpuReviewStore = defineStore("cpuReview", () => {
     return board;
   });
 
-  /** 現在の手の評価 */
+  /**
+   * 対局全体の評価（forcedLossチェーンのforcedReply再分類・精度・
+   * クリティカルエラー数・敗着推定を一括算出する SSoT）
+   */
+  const gameReview = computed(() => buildGameReview(evaluatedMoves.value));
+
+  /**
+   * forcedLossチェーンの2手目以降を forcedReply に再分類済みの評価一覧
+   *
+   * UI表示（ReviewControlsの品質ドット・ReviewVerdictの品質タグ等）は
+   * こちらを使う。生の evaluatedMoves は評価の逐次追加・部分更新用。
+   */
+  const evaluatedMovesWithChains = computed(
+    () => gameReview.value.evaluatedMoves,
+  );
+
+  /** 現在の手の評価（forcedReply再分類済み） */
   const currentEvaluation = computed<EvaluatedMove | null>(() => {
     if (currentMoveIndex.value === 0) {
       return null;
     }
     return (
-      evaluatedMoves.value.find(
+      evaluatedMovesWithChains.value.find(
         (e) => e.moveIndex === currentMoveIndex.value - 1,
       ) ?? null
     );
   });
 
-  /** プレイヤー精度 */
+  /** プレイヤー精度（forcedReplyは分母から除外。評価済みの手が無ければnull） */
   const playerAccuracy = computed(() => {
-    const playerMoves = evaluatedMoves.value.filter((m) => m.isPlayerMove);
-    if (playerMoves.length === 0) {
-      return null;
-    }
-    const goodOrBetter = playerMoves.filter(
-      (m) => m.quality === "excellent" || m.quality === "good",
-    ).length;
-    return Math.round((goodOrBetter / playerMoves.length) * 100);
+    const hasPlayerMoves = evaluatedMoves.value.some((m) => m.isPlayerMove);
+    return hasPlayerMoves ? gameReview.value.accuracy : null;
   });
 
-  /** ミス数（mistake + blunder） */
-  const criticalErrors = computed(
-    () =>
-      evaluatedMoves.value.filter(
-        (m) =>
-          m.isPlayerMove &&
-          (m.quality === "mistake" || m.quality === "blunder"),
-      ).length,
-  );
+  /** ミス数（mistake + blunder。forcedReplyは含まない） */
+  const criticalErrors = computed(() => gameReview.value.criticalErrors);
 
   /** 敗着の推定結果 */
-  const losingMove = computed(() => findLosingMove(evaluatedMoves.value));
+  const losingMove = computed(() => gameReview.value.losingMove);
 
   // ========== Actions ==========
 
@@ -349,13 +352,14 @@ export const useCpuReviewStore = defineStore("cpuReview", () => {
   function setEvaluationResults(results: EvaluatedMove[]): void {
     evaluatedMoves.value = results;
 
-    // cpuBattle のみキャッシュ保存
+    // cpuBattle のみキャッシュ保存（evaluatedMoves は生データ、
+    // accuracy/criticalErrors/losingMove は forcedReply 再分類を反映した値）
     if (currentRecord.value) {
       const review: GameReview = {
         evaluatedMoves: results,
-        accuracy: playerAccuracy.value ?? 100,
-        criticalErrors: criticalErrors.value,
-        losingMove: losingMove.value,
+        accuracy: gameReview.value.accuracy,
+        criticalErrors: gameReview.value.criticalErrors,
+        losingMove: gameReview.value.losingMove,
       };
       reviewCache.value.set(currentRecord.value.id, review);
       saveCache(reviewCache.value);
@@ -406,6 +410,7 @@ export const useCpuReviewStore = defineStore("cpuReview", () => {
     currentPlayerSide,
     gameResult,
     boardAtCurrentMove,
+    evaluatedMovesWithChains,
     currentEvaluation,
     playerAccuracy,
     criticalErrors,

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -105,13 +105,18 @@ export interface ReviewCandidate {
 
 /**
  * 手の品質分類
+ *
+ * "forcedReply"（被詰み継続）: 同一プレイヤーの forcedLoss（被追詰）チェーンの
+ * 2手目以降。選択の余地がない手のため、mistake/blunder 等のミス評価を上書きし、
+ * criticalErrors カウントと accuracy 分母から除外する（applyForcedReplyChains 参照）。
  */
 export type MoveQuality =
   | "excellent"
   | "good"
   | "inaccuracy"
   | "mistake"
-  | "blunder";
+  | "blunder"
+  | "forcedReply";
 
 /**
  * 1手分の評価結果


### PR DESCRIPTION
## 概要

振り返りの被詰み（forcedLoss）チェーン集計を改善。従来は一度被詰みに入ると以降の強制応手が毎手独立に「悪手」カウントされ、1つの敗着が5〜10件の悪手に見えていた（「判定が厳しすぎる」体感の残り主因候補）。

## 変更内容

- **チェーン初手のみ敗着（blunder）**、2手目以降は新分類 `forcedReply` に（純関数 `applyForcedReplyChains`、色ごとの forcedLoss 連続区間で判定。相手が勝ちを逃して脱出→再突入は新チェーン=敗着2つ）
- forcedReply は **criticalErrors に数えず、accuracy の分母からも除外**（選択の余地がない手のため）
- UI: 品質ドットをグレー+破線で区別、ラベル「被詰み継続」、ツールチップ「既に被詰みのため評価対象外」
- 副次改善: cpuReviewStore の独自集計を `buildGameReview` 経由に一本化（SSoT 化）

## テスト

- 追加テスト 19 件（チェーン純関数 9・store 7・ラベル/集計 3）。全体 1806 件 + zig-test 全緑（全4コミットで pre-commit 確認済み）
- /review 3観点実施済み: パフォーマンス LGTM・イシュー LGTM・SOLID は下記2点を設計判断として保留

## レビュー時の確認ポイント（ボス向け）

1. **UI 文言「被詰み継続」**の妥当性（代替: 表示なしのミニマル案あり）
2. キャラのセリフ選択は既存の losingMove（遡及敗着）基準を優先するため、forcedReply 専用セリフはほぼ発火しない（無害・表示と集計は正しい）。セリフ粒度もチェーン概念に揃えるかは別途判断
3. ブラウザでの体感確認（被詰みが長い棋譜で悪手カウントが 1 になること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RM5iEfn2Aq5rU8eXe89NnZ
