### PR TITLE
feat(bench): ハング計装・耐性化と randomFactor のシード付き配線

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "debug:vcf": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/debug-vcf-false-positive.ts",
     "commit:bench": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/commit-bench.ts",
     "weight:bench": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/weight-bench.ts",
+    "replay:hang": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/replay-hang.ts",
     "build:wasm": "cd zig && zig build",
     "profile:review": "node --experimental-strip-types --disable-warning=ExperimentalWarning --import ./scripts/register-loader.mjs scripts/profile-review.ts"
   },

--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -119,6 +119,13 @@ interface CliOptions {
   bookA: boolean;
   bookB: boolean;
   /**
+   * 脅威プローブトグル（探索レバー A/B）。true=既定 ON（従来挙動）、
+   * false=無効化（--probe-off-a/b で false になる）。prospect 基底下で
+   * probe OFF が Elo に転換するかを commit-bench で再検証するためのレバー。
+   */
+  probeEnabledA: boolean;
+  probeEnabledB: boolean;
+  /**
    * デバッグ/スモークテスト用: タスクを先頭 N 局に切り詰める（0 なら無効）。
    * ハング計装の e2e 検証で少局数（例: 4局）を回すために追加。
    * 通常のベンチ運用では 0（無効＝全 sets を消化）。
@@ -153,6 +160,8 @@ function parseArgs(): CliOptions {
     jobs: 1,
     bookA: false,
     bookB: false,
+    probeEnabledA: true,
+    probeEnabledB: true,
     maxGames: 0,
     moveTimeoutMs: 30000,
     seed: Date.now() | 0,
@@ -216,6 +225,10 @@ function parseArgs(): CliOptions {
       options.bookA = true;
     } else if (arg === "--book-b") {
       options.bookB = true;
+    } else if (arg === "--probe-off-a") {
+      options.probeEnabledA = false;
+    } else if (arg === "--probe-off-b") {
+      options.probeEnabledB = false;
     } else if (arg.startsWith("--max-games=")) {
       const value = parseInt(arg.slice("--max-games=".length), 10);
       if (!isNaN(value) && value >= 0) {
@@ -309,6 +322,9 @@ Options:
   --eval-options-b=<json> B側 evaluationOptions オーバーライド（JSON。省略時は legacy 既定）
   --book-a               A側でオープニングブックを有効化（既定OFF）
   --book-b               B側でオープニングブックを有効化（既定OFF）
+  --probe-off-a          A側の脅威プローブを無効化（既定ON）。prospect 基底下で
+                         深度向上が Elo に転換するか検証するレバー
+  --probe-off-b          B側の脅威プローブを無効化（既定ON）
   --max-games=<n>        タスクを先頭 N 局に切り詰め（0=無効, default: 0）。
                          ハング計装のスモークテスト用
   --move-timeout-ms=<n>  1手あたりのタイムアウト (default: 30000)
@@ -652,6 +668,10 @@ async function main(): Promise<void> {
     console.log(`book A: ${options.bookA ? "ON" : "OFF"}`);
     console.log(`book B: ${options.bookB ? "ON" : "OFF"}`);
   }
+  if (!options.probeEnabledA || !options.probeEnabledB) {
+    console.log(`threatProbe A: ${options.probeEnabledA ? "ON" : "OFF"}`);
+    console.log(`threatProbe B: ${options.probeEnabledB ? "ON" : "OFF"}`);
+  }
   if (sprtConfig) {
     console.log(
       `SPRT: elo0=${sprtConfig.elo0}, elo1=${sprtConfig.elo1}, ` +
@@ -703,6 +723,7 @@ async function main(): Promise<void> {
       worktreePath: string,
       evaluationOptions: Partial<EvaluationOptions> | undefined,
       bookEnabled: boolean,
+      threatProbeEnabled: boolean,
     ): Promise<Worker> =>
       createBridgeWorker({
         workerPath,
@@ -712,14 +733,25 @@ async function main(): Promise<void> {
         randomFactor: options.randomFactor,
         evaluationOptions,
         bookEnabled,
+        threatProbeEnabled,
       });
 
     console.log(`Bridge workerを初期化中... (${options.jobs}並列)`);
     const createdPairs = await Promise.all(
       Array.from({ length: options.jobs }, async () => {
         const [a, b] = await Promise.all([
-          makeWorker(worktreePathA!, options.evalOptionsA, options.bookA),
-          makeWorker(worktreePathB!, options.evalOptionsB, options.bookB),
+          makeWorker(
+            worktreePathA!,
+            options.evalOptionsA,
+            options.bookA,
+            options.probeEnabledA,
+          ),
+          makeWorker(
+            worktreePathB!,
+            options.evalOptionsB,
+            options.bookB,
+            options.probeEnabledB,
+          ),
         ]);
         return { a, b };
       }),
@@ -763,8 +795,18 @@ async function main(): Promise<void> {
       idx: number,
     ): Promise<{ a: Worker; b: Worker }> => {
       const [a, b] = await Promise.all([
-        makeWorker(worktreePathA!, options.evalOptionsA, options.bookA),
-        makeWorker(worktreePathB!, options.evalOptionsB, options.bookB),
+        makeWorker(
+          worktreePathA!,
+          options.evalOptionsA,
+          options.bookA,
+          options.probeEnabledA,
+        ),
+        makeWorker(
+          worktreePathB!,
+          options.evalOptionsB,
+          options.bookB,
+          options.probeEnabledB,
+        ),
       ]);
       const fresh = { a, b };
       pairs[idx] = fresh;
@@ -928,6 +970,8 @@ async function main(): Promise<void> {
         evalOptionsB: options.evalOptionsB,
         bookA: options.bookA,
         bookB: options.bookB,
+        threatProbeA: options.probeEnabledA,
+        threatProbeB: options.probeEnabledB,
         seed: seedInEffect,
       },
       totalGames: completedGames,

--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -42,6 +42,7 @@ import type {
 } from "./types/commit-bench.ts";
 
 import { estimateEloDiff, formatEloDiff } from "./lib/eloDiff.ts";
+import { type HangDumpSideConfig, writeHangDump } from "./lib/hangDump.ts";
 import {
   buildJushuTasks,
   createBridgeWorker,
@@ -49,6 +50,8 @@ import {
   type HangMatchInfo,
   runMatch,
 } from "./lib/match.ts";
+import { mixSeed } from "./lib/mulberry32.ts";
+import { parseHangInjectEnv } from "./lib/parseHangInjectEnv.ts";
 import { DEFAULT_SPRT_CONFIG, formatSPRT, updateSPRT } from "./lib/sprt.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -83,181 +86,9 @@ function resolveGitCommonDir(): string {
 const WORKTREES_DIR = path.join(resolveGitCommonDir(), "worktrees-bench");
 const HANG_DUMPS_DIR = path.join(OUTPUT_DIR, "hang-dumps");
 
-/**
- * HANG_INJECT=<gameIdx>:<requestOrdinal>[:A|B] を parse する。
- * - gameIdx: 0-based の tasks 配列上の局番号
- * - requestOrdinal: 1-based の非オープニング要求番号（その局で N 番目の要求でハング）
- * - オプション A|B: 対象 side を絞る（省略時はその手番の side を対象）
- * 不正な値なら process.exit(1)。
- */
-function parseHangInjectEnv(
-  raw: string | undefined,
-): { gameIdx: number; requestOrdinal: number; side?: "A" | "B" } | null {
-  if (raw === undefined || raw === "") {
-    return null;
-  }
-  const parts = raw.split(":");
-  if (parts.length !== 2 && parts.length !== 3) {
-    console.error(
-      `Error: HANG_INJECT は "<gameIdx>:<requestOrdinal>[:A|B]" の形式で指定してください (got: ${raw})`,
-    );
-    process.exit(1);
-  }
-  const gameIdx = parseInt(parts[0]!, 10);
-  const requestOrdinal = parseInt(parts[1]!, 10);
-  if (!Number.isFinite(gameIdx) || gameIdx < 0) {
-    console.error(`Error: HANG_INJECT gameIdx が不正 (got: ${parts[0]})`);
-    process.exit(1);
-  }
-  if (!Number.isFinite(requestOrdinal) || requestOrdinal < 1) {
-    console.error(
-      `Error: HANG_INJECT requestOrdinal は 1 以上の整数 (got: ${parts[1]})`,
-    );
-    process.exit(1);
-  }
-  const sideRaw = parts.length === 3 ? parts[2]! : undefined;
-  if (sideRaw !== undefined && sideRaw !== "A" && sideRaw !== "B") {
-    console.error(`Error: HANG_INJECT side は A か B (got: ${sideRaw})`);
-    process.exit(1);
-  }
-  return {
-    gameIdx,
-    requestOrdinal,
-    side: sideRaw as "A" | "B" | undefined,
-  };
-}
-
-// ============================================================================
-// ハングダンプ書き出し
-// ============================================================================
-
-interface HangDumpSideConfig {
-  worktreePath: string;
-  evaluationOptions: Partial<EvaluationOptions> | undefined;
-  bookEnabled: boolean;
-  commit: CommitInfo;
-}
-
-interface HangDumpJson {
-  type: "hang-dump";
-  schemaVersion: 1;
-  timestamp: string;
-  bench: {
-    /** 発生元スクリプト。replay がどの構成を組めばよいか区別するため */
-    tool: "commit-bench";
-    difficulty: string;
-    randomFactor: number | undefined;
-    moveTimeoutMs: number;
-  };
-  match: {
-    gameIdx: number;
-    jushuName: string;
-    isABlack: boolean;
-    pairIdx: number;
-  };
-  hang: {
-    /** ハングした側（A/B）— この情報だけで worker 側の worktree/config を引ける */
-    side: "A" | "B";
-    color: "black" | "white";
-    requestId: number;
-    timeoutMs: number;
-    elapsedMs: number;
-    /** 何手目でハングしたか（1-based, opening 3手を含む） */
-    moveNumber: number;
-  };
-  /** ハングした側の worker 設定（replay 用の完全情報） */
-  worker: {
-    side: "A" | "B";
-    worktreePath: string;
-    commit: CommitInfo;
-    difficulty: string;
-    randomFactor: number | undefined;
-    evaluationOptions: Partial<EvaluationOptions> | undefined;
-    bookEnabled: boolean;
-    color: "black" | "white";
-  };
-  /** 相手側の worker 設定（対戦の再構築が必要な将来のため） */
-  opponent: {
-    side: "A" | "B";
-    worktreePath: string;
-    commit: CommitInfo;
-    evaluationOptions: Partial<EvaluationOptions> | undefined;
-    bookEnabled: boolean;
-  };
-  /** ハング直前の盤面（そのままリクエストとして送れる形） */
-  board: unknown;
-  /** ハング直前までの着手履歴（opening 3手を含む。row/col/isOpening/time…） */
-  moveHistory: unknown;
-}
-
-function writeHangDump(params: {
-  context: HangContext;
-  info: HangMatchInfo;
-  commonConfig: { difficulty: string; randomFactor: number | undefined };
-  workerConfigs: { A: HangDumpSideConfig; B: HangDumpSideConfig };
-}): void {
-  const { context, info, commonConfig, workerConfigs } = params;
-  const hangSide = context.side;
-  const oppSide: "A" | "B" = hangSide === "A" ? "B" : "A";
-  const hangCfg = workerConfigs[hangSide];
-  const oppCfg = workerConfigs[oppSide];
-
-  const dump: HangDumpJson = {
-    type: "hang-dump",
-    schemaVersion: 1,
-    timestamp: new Date().toISOString(),
-    bench: {
-      tool: "commit-bench",
-      difficulty: commonConfig.difficulty,
-      randomFactor: commonConfig.randomFactor,
-      moveTimeoutMs: context.timeoutMs,
-    },
-    match: {
-      gameIdx: info.gameIdx,
-      jushuName: info.jushuName,
-      isABlack: info.isABlack,
-      pairIdx: info.pairIdx,
-    },
-    hang: {
-      side: context.side,
-      color: context.color,
-      requestId: context.requestId,
-      timeoutMs: context.timeoutMs,
-      elapsedMs: context.elapsedMs,
-      moveNumber: context.moveNumber,
-    },
-    worker: {
-      side: hangSide,
-      worktreePath: hangCfg.worktreePath,
-      commit: hangCfg.commit,
-      difficulty: commonConfig.difficulty,
-      randomFactor: commonConfig.randomFactor,
-      evaluationOptions: hangCfg.evaluationOptions,
-      bookEnabled: hangCfg.bookEnabled,
-      color: context.color,
-    },
-    opponent: {
-      side: oppSide,
-      worktreePath: oppCfg.worktreePath,
-      commit: oppCfg.commit,
-      evaluationOptions: oppCfg.evaluationOptions,
-      bookEnabled: oppCfg.bookEnabled,
-    },
-    board: context.board,
-    moveHistory: context.moveHistory,
-  };
-
-  if (!fs.existsSync(HANG_DUMPS_DIR)) {
-    fs.mkdirSync(HANG_DUMPS_DIR, { recursive: true });
-  }
-  const iso = dump.timestamp.replace(/[:.]/g, "-");
-  const outPath = path.join(
-    HANG_DUMPS_DIR,
-    `hang-${iso}-g${info.gameIdx}.json`,
-  );
-  fs.writeFileSync(outPath, JSON.stringify(dump, null, 2));
-  console.warn(`⚠ hang detected g${info.gameIdx}, dumped to ${outPath}`);
-}
+// HANG_INJECT 環境変数のパーサは scripts/lib/parseHangInjectEnv.ts に SSoT 化（テスト付き）。
+// ハングダンプ書き出しの型定義と実装は scripts/lib/hangDump.ts に SSoT 化した
+// （commit-bench と replay-hang で型定義が食い違うのを防ぐため）。
 
 // ============================================================================
 // CLI引数パース
@@ -298,6 +129,12 @@ interface CliOptions {
    * 通常は 30000 で運用。ハング計装のテスト時は短くして待ち時間を減らす。
    */
   moveTimeoutMs: number;
+  /**
+   * randomFactor > 0 での対局の PRNG シード（baseSeed）。指定時、局ごとの
+   * 実効 seed は `mixSeed(baseSeed, gameIdx)` で導出され、同一 --seed なら
+   * 同一棋譜になる。未指定なら `Date.now() | 0` を使う（従来と同じく非決定的）。
+   */
+  seed: number;
 }
 
 function parseArgs(): CliOptions {
@@ -318,6 +155,7 @@ function parseArgs(): CliOptions {
     bookB: false,
     maxGames: 0,
     moveTimeoutMs: 30000,
+    seed: Date.now() | 0,
   };
 
   for (const arg of args) {
@@ -398,6 +236,15 @@ function parseArgs(): CliOptions {
         );
         process.exit(1);
       }
+    } else if (arg.startsWith("--seed=")) {
+      const raw = arg.slice("--seed=".length);
+      const value = parseInt(raw, 10);
+      if (Number.isFinite(value)) {
+        options.seed = value | 0;
+      } else {
+        console.error(`Error: --seed は整数で指定 (got: ${raw})`);
+        process.exit(1);
+      }
     } else if (arg === "--verbose" || arg === "-v") {
       options.verbose = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -465,6 +312,8 @@ Options:
   --max-games=<n>        タスクを先頭 N 局に切り詰め（0=無効, default: 0）。
                          ハング計装のスモークテスト用
   --move-timeout-ms=<n>  1手あたりのタイムアウト (default: 30000)
+  --seed=<n>             randomFactor 使用時の PRNG baseSeed（integer）。
+                         同一 seed なら同一棋譜を再現。default: Date.now()（非決定的）
   --verbose, -v          詳細ログ
   --help, -h             ヘルプを表示
 
@@ -895,7 +744,7 @@ async function main(): Promise<void> {
     }
 
     // ダンプ用の side メタ（worker 再生成にも再利用）
-    const workerConfigs = {
+    const workerConfigs: { A: HangDumpSideConfig; B: HangDumpSideConfig } = {
       A: {
         worktreePath: worktreePathA!,
         evaluationOptions: options.evalOptionsA,
@@ -908,7 +757,7 @@ async function main(): Promise<void> {
         bookEnabled: options.bookB,
         commit: commitB,
       },
-    } as const;
+    };
 
     const recreatePair = async (
       idx: number,
@@ -922,45 +771,81 @@ async function main(): Promise<void> {
       return fresh;
     };
 
+    // randomFactor 使用時は seed を明示ログ（同一シード同一棋譜の検証で使う）
+    const seedInEffect =
+      options.randomFactor === undefined ? undefined : options.seed;
+    if (seedInEffect !== undefined) {
+      console.log(
+        `PRNG seed（baseSeed）: ${seedInEffect}${process.argv.some((a) => a.startsWith("--seed=")) ? "" : " (default = Date.now())"}`,
+      );
+    }
+
     const onHang = (context: HangContext, info: HangMatchInfo): void => {
-      writeHangDump({
+      const dumpPath = writeHangDump({
+        outputDir: HANG_DUMPS_DIR,
         context,
-        info,
-        commonConfig: {
+        match: {
+          gameIdx: info.gameIdx,
+          jushuName: info.jushuName,
+          isABlack: info.isABlack,
+          pairIdx: info.pairIdx,
+          gameSeed:
+            seedInEffect === undefined
+              ? undefined
+              : mixSeed(seedInEffect, info.gameIdx),
+        },
+        bench: {
+          tool: "commit-bench",
           difficulty: options.difficulty,
           randomFactor: options.randomFactor,
+          moveTimeoutMs: context.timeoutMs,
+          jobs: options.jobs,
+          baseSeed: seedInEffect,
         },
         workerConfigs,
       });
+      console.warn(`⚠ hang detected g${info.gameIdx}, dumped to ${dumpPath}`);
     };
 
-    const hangInjectEnv = parseHangInjectEnv(process.env.HANG_INJECT);
+    const hangInjectParsed = parseHangInjectEnv(process.env.HANG_INJECT);
+    if (hangInjectParsed.kind === "error") {
+      console.error(`Error: ${hangInjectParsed.message}`);
+      process.exit(1);
+    }
+    const hangInjectEnv = hangInjectParsed.value;
     if (hangInjectEnv) {
       console.log(
         `⚠ HANG_INJECT 有効: gameIdx=${hangInjectEnv.gameIdx} requestOrdinal=${hangInjectEnv.requestOrdinal}${hangInjectEnv.side ? ` side=${hangInjectEnv.side}` : ""}`,
       );
     }
 
-    const { wdl, games, completedGames, aborts } = await runMatch({
-      pairs,
-      tasks,
-      totalGames: tasks.length,
-      sprtConfig,
-      moveTimeoutMs: options.moveTimeoutMs,
-      verbose: options.verbose,
-      startTime,
-      recreatePair,
-      onHang,
-      hangInject: hangInjectEnv
-        ? {
-            gameIdx: hangInjectEnv.gameIdx,
-            spec: {
-              requestOrdinal: hangInjectEnv.requestOrdinal,
-              side: hangInjectEnv.side,
-            },
-          }
-        : undefined,
-    });
+    const { wdl, games, completedGames, aborts, abortsBySide } = await runMatch(
+      {
+        pairs,
+        tasks,
+        totalGames: tasks.length,
+        sprtConfig,
+        moveTimeoutMs: options.moveTimeoutMs,
+        verbose: options.verbose,
+        startTime,
+        recreatePair,
+        onHang,
+        hangInject: hangInjectEnv
+          ? {
+              gameIdx: hangInjectEnv.gameIdx,
+              spec: {
+                requestOrdinal: hangInjectEnv.requestOrdinal,
+                side: hangInjectEnv.side,
+              },
+            }
+          : undefined,
+        // randomFactor 未指定なら getGameSeed を渡さない（従来と同じ Math.random）
+        getGameSeed:
+          seedInEffect === undefined
+            ? undefined
+            : (gameIdx: number): number => mixSeed(seedInEffect, gameIdx),
+      },
+    );
 
     const elapsedSeconds = (performance.now() - startTime) / 1000;
 
@@ -969,12 +854,18 @@ async function main(): Promise<void> {
     console.log(`commitA: ${commitA.shortSha} "${commitA.message}"`);
     console.log(`commitB: ${commitB.shortSha} "${commitB.message}"`);
     console.log(
-      `対局数: ${completedGames}${aborts > 0 ? ` (abort: ${aborts})` : ""}`,
+      `対局数: ${completedGames}${aborts > 0 ? ` (abort: ${aborts} = A側${abortsBySide.A} / B側${abortsBySide.B})` : ""}`,
     );
     if (aborts > 0) {
       console.log(
-        `⚠ ハング検出: ${aborts} 局を破棄しました。ダンプは ${HANG_DUMPS_DIR} を参照`,
+        `⚠ ハング検出: ${aborts} 局を破棄しました（A側=${abortsBySide.A} / B側=${abortsBySide.B}）。ダンプは ${HANG_DUMPS_DIR} を参照`,
       );
+      // 一方向バイアス（劣勢側がハングして負けが消される）を検出しやすくする
+      if (abortsBySide.A !== abortsBySide.B) {
+        console.log(
+          `  ※ side 別 abort 数が非対称です。「劣勢側だけ抜ける」バイアスの可能性を確認してください`,
+        );
+      }
     }
     console.log(`WDL (commitA視点): +${wdl.wins} =${wdl.draws} -${wdl.losses}`);
 
@@ -1037,9 +928,11 @@ async function main(): Promise<void> {
         evalOptionsB: options.evalOptionsB,
         bookA: options.bookA,
         bookB: options.bookB,
+        seed: seedInEffect,
       },
       totalGames: completedGames,
       aborts,
+      abortsBySide,
       wdl,
       eloDiff: eloDiffResult,
       sprt: sprtState,

--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -126,6 +126,14 @@ interface CliOptions {
   probeEnabledA: boolean;
   probeEnabledB: boolean;
   /**
+   * 探索の maxNodes オーバーライド（side 別）。未指定なら difficulty 既定を使う。
+   * probe OFF/深さ探索レバーが maxNodes 早期打ち切りに拘束されるのを避け、
+   * 「同じ持ち時間でノード上限が実質非拘束なら深読みが Elo に転換するか」を
+   * 測るための CLI レバー。
+   */
+  maxNodesA?: number;
+  maxNodesB?: number;
+  /**
    * デバッグ/スモークテスト用: タスクを先頭 N 局に切り詰める（0 なら無効）。
    * ハング計装の e2e 検証で少局数（例: 4局）を回すために追加。
    * 通常のベンチ運用では 0（無効＝全 sets を消化）。
@@ -229,6 +237,26 @@ function parseArgs(): CliOptions {
       options.probeEnabledA = false;
     } else if (arg === "--probe-off-b") {
       options.probeEnabledB = false;
+    } else if (arg.startsWith("--max-nodes-a=")) {
+      const value = parseInt(arg.slice("--max-nodes-a=".length), 10);
+      if (Number.isFinite(value) && value > 0) {
+        options.maxNodesA = value;
+      } else {
+        console.error(
+          `Error: --max-nodes-a は正の整数で指定 (got: ${arg.slice("--max-nodes-a=".length)})`,
+        );
+        process.exit(1);
+      }
+    } else if (arg.startsWith("--max-nodes-b=")) {
+      const value = parseInt(arg.slice("--max-nodes-b=".length), 10);
+      if (Number.isFinite(value) && value > 0) {
+        options.maxNodesB = value;
+      } else {
+        console.error(
+          `Error: --max-nodes-b は正の整数で指定 (got: ${arg.slice("--max-nodes-b=".length)})`,
+        );
+        process.exit(1);
+      }
     } else if (arg.startsWith("--max-games=")) {
       const value = parseInt(arg.slice("--max-games=".length), 10);
       if (!isNaN(value) && value >= 0) {
@@ -325,6 +353,10 @@ Options:
   --probe-off-a          A側の脅威プローブを無効化（既定ON）。prospect 基底下で
                          深度向上が Elo に転換するか検証するレバー
   --probe-off-b          B側の脅威プローブを無効化（既定ON）
+  --max-nodes-a=<n>      A側の maxNodes を上書き（既定=difficulty 既定）。
+                         probe OFF/深さレバーが maxNodes 早期打ち切りに拘束される
+                         のを避け、timeLimit ベースで測るためのレバー
+  --max-nodes-b=<n>      B側の maxNodes を上書き（既定=difficulty 既定）
   --max-games=<n>        タスクを先頭 N 局に切り詰め（0=無効, default: 0）。
                          ハング計装のスモークテスト用
   --move-timeout-ms=<n>  1手あたりのタイムアウト (default: 30000)
@@ -672,6 +704,11 @@ async function main(): Promise<void> {
     console.log(`threatProbe A: ${options.probeEnabledA ? "ON" : "OFF"}`);
     console.log(`threatProbe B: ${options.probeEnabledB ? "ON" : "OFF"}`);
   }
+  if (options.maxNodesA !== undefined || options.maxNodesB !== undefined) {
+    console.log(
+      `maxNodes A: ${options.maxNodesA ?? "(既定=difficulty)"} / B: ${options.maxNodesB ?? "(既定=difficulty)"}`,
+    );
+  }
   if (sprtConfig) {
     console.log(
       `SPRT: elo0=${sprtConfig.elo0}, elo1=${sprtConfig.elo1}, ` +
@@ -724,6 +761,7 @@ async function main(): Promise<void> {
       evaluationOptions: Partial<EvaluationOptions> | undefined,
       bookEnabled: boolean,
       threatProbeEnabled: boolean,
+      maxNodes: number | undefined,
     ): Promise<Worker> =>
       createBridgeWorker({
         workerPath,
@@ -734,6 +772,7 @@ async function main(): Promise<void> {
         evaluationOptions,
         bookEnabled,
         threatProbeEnabled,
+        maxNodes,
       });
 
     console.log(`Bridge workerを初期化中... (${options.jobs}並列)`);
@@ -745,12 +784,14 @@ async function main(): Promise<void> {
             options.evalOptionsA,
             options.bookA,
             options.probeEnabledA,
+            options.maxNodesA,
           ),
           makeWorker(
             worktreePathB!,
             options.evalOptionsB,
             options.bookB,
             options.probeEnabledB,
+            options.maxNodesB,
           ),
         ]);
         return { a, b };
@@ -800,12 +841,14 @@ async function main(): Promise<void> {
           options.evalOptionsA,
           options.bookA,
           options.probeEnabledA,
+          options.maxNodesA,
         ),
         makeWorker(
           worktreePathB!,
           options.evalOptionsB,
           options.bookB,
           options.probeEnabledB,
+          options.maxNodesB,
         ),
       ]);
       const fresh = { a, b };
@@ -972,6 +1015,8 @@ async function main(): Promise<void> {
         bookB: options.bookB,
         threatProbeA: options.probeEnabledA,
         threatProbeB: options.probeEnabledB,
+        maxNodesA: options.maxNodesA,
+        maxNodesB: options.maxNodesB,
         seed: seedInEffect,
       },
       totalGames: completedGames,

--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -32,6 +32,7 @@ import { Worker } from "node:worker_threads";
 
 import type { EvaluationOptions } from "../src/logic/cpu/evaluation/patternScores.ts";
 import type { CpuDifficulty } from "../src/types/cpu.ts";
+import type { HangContext } from "./commit-game-runner.ts";
 import type { SPRTConfig } from "./types/ab.ts";
 import type {
   CommitBenchResult,
@@ -45,6 +46,7 @@ import {
   buildJushuTasks,
   createBridgeWorker,
   gamesPerSet as computeGamesPerSet,
+  type HangMatchInfo,
   runMatch,
 } from "./lib/match.ts";
 import { DEFAULT_SPRT_CONFIG, formatSPRT, updateSPRT } from "./lib/sprt.ts";
@@ -79,6 +81,183 @@ function resolveGitCommonDir(): string {
 }
 
 const WORKTREES_DIR = path.join(resolveGitCommonDir(), "worktrees-bench");
+const HANG_DUMPS_DIR = path.join(OUTPUT_DIR, "hang-dumps");
+
+/**
+ * HANG_INJECT=<gameIdx>:<requestOrdinal>[:A|B] を parse する。
+ * - gameIdx: 0-based の tasks 配列上の局番号
+ * - requestOrdinal: 1-based の非オープニング要求番号（その局で N 番目の要求でハング）
+ * - オプション A|B: 対象 side を絞る（省略時はその手番の side を対象）
+ * 不正な値なら process.exit(1)。
+ */
+function parseHangInjectEnv(
+  raw: string | undefined,
+): { gameIdx: number; requestOrdinal: number; side?: "A" | "B" } | null {
+  if (raw === undefined || raw === "") {
+    return null;
+  }
+  const parts = raw.split(":");
+  if (parts.length !== 2 && parts.length !== 3) {
+    console.error(
+      `Error: HANG_INJECT は "<gameIdx>:<requestOrdinal>[:A|B]" の形式で指定してください (got: ${raw})`,
+    );
+    process.exit(1);
+  }
+  const gameIdx = parseInt(parts[0]!, 10);
+  const requestOrdinal = parseInt(parts[1]!, 10);
+  if (!Number.isFinite(gameIdx) || gameIdx < 0) {
+    console.error(`Error: HANG_INJECT gameIdx が不正 (got: ${parts[0]})`);
+    process.exit(1);
+  }
+  if (!Number.isFinite(requestOrdinal) || requestOrdinal < 1) {
+    console.error(
+      `Error: HANG_INJECT requestOrdinal は 1 以上の整数 (got: ${parts[1]})`,
+    );
+    process.exit(1);
+  }
+  const sideRaw = parts.length === 3 ? parts[2]! : undefined;
+  if (sideRaw !== undefined && sideRaw !== "A" && sideRaw !== "B") {
+    console.error(`Error: HANG_INJECT side は A か B (got: ${sideRaw})`);
+    process.exit(1);
+  }
+  return {
+    gameIdx,
+    requestOrdinal,
+    side: sideRaw as "A" | "B" | undefined,
+  };
+}
+
+// ============================================================================
+// ハングダンプ書き出し
+// ============================================================================
+
+interface HangDumpSideConfig {
+  worktreePath: string;
+  evaluationOptions: Partial<EvaluationOptions> | undefined;
+  bookEnabled: boolean;
+  commit: CommitInfo;
+}
+
+interface HangDumpJson {
+  type: "hang-dump";
+  schemaVersion: 1;
+  timestamp: string;
+  bench: {
+    /** 発生元スクリプト。replay がどの構成を組めばよいか区別するため */
+    tool: "commit-bench";
+    difficulty: string;
+    randomFactor: number | undefined;
+    moveTimeoutMs: number;
+  };
+  match: {
+    gameIdx: number;
+    jushuName: string;
+    isABlack: boolean;
+    pairIdx: number;
+  };
+  hang: {
+    /** ハングした側（A/B）— この情報だけで worker 側の worktree/config を引ける */
+    side: "A" | "B";
+    color: "black" | "white";
+    requestId: number;
+    timeoutMs: number;
+    elapsedMs: number;
+    /** 何手目でハングしたか（1-based, opening 3手を含む） */
+    moveNumber: number;
+  };
+  /** ハングした側の worker 設定（replay 用の完全情報） */
+  worker: {
+    side: "A" | "B";
+    worktreePath: string;
+    commit: CommitInfo;
+    difficulty: string;
+    randomFactor: number | undefined;
+    evaluationOptions: Partial<EvaluationOptions> | undefined;
+    bookEnabled: boolean;
+    color: "black" | "white";
+  };
+  /** 相手側の worker 設定（対戦の再構築が必要な将来のため） */
+  opponent: {
+    side: "A" | "B";
+    worktreePath: string;
+    commit: CommitInfo;
+    evaluationOptions: Partial<EvaluationOptions> | undefined;
+    bookEnabled: boolean;
+  };
+  /** ハング直前の盤面（そのままリクエストとして送れる形） */
+  board: unknown;
+  /** ハング直前までの着手履歴（opening 3手を含む。row/col/isOpening/time…） */
+  moveHistory: unknown;
+}
+
+function writeHangDump(params: {
+  context: HangContext;
+  info: HangMatchInfo;
+  commonConfig: { difficulty: string; randomFactor: number | undefined };
+  workerConfigs: { A: HangDumpSideConfig; B: HangDumpSideConfig };
+}): void {
+  const { context, info, commonConfig, workerConfigs } = params;
+  const hangSide = context.side;
+  const oppSide: "A" | "B" = hangSide === "A" ? "B" : "A";
+  const hangCfg = workerConfigs[hangSide];
+  const oppCfg = workerConfigs[oppSide];
+
+  const dump: HangDumpJson = {
+    type: "hang-dump",
+    schemaVersion: 1,
+    timestamp: new Date().toISOString(),
+    bench: {
+      tool: "commit-bench",
+      difficulty: commonConfig.difficulty,
+      randomFactor: commonConfig.randomFactor,
+      moveTimeoutMs: context.timeoutMs,
+    },
+    match: {
+      gameIdx: info.gameIdx,
+      jushuName: info.jushuName,
+      isABlack: info.isABlack,
+      pairIdx: info.pairIdx,
+    },
+    hang: {
+      side: context.side,
+      color: context.color,
+      requestId: context.requestId,
+      timeoutMs: context.timeoutMs,
+      elapsedMs: context.elapsedMs,
+      moveNumber: context.moveNumber,
+    },
+    worker: {
+      side: hangSide,
+      worktreePath: hangCfg.worktreePath,
+      commit: hangCfg.commit,
+      difficulty: commonConfig.difficulty,
+      randomFactor: commonConfig.randomFactor,
+      evaluationOptions: hangCfg.evaluationOptions,
+      bookEnabled: hangCfg.bookEnabled,
+      color: context.color,
+    },
+    opponent: {
+      side: oppSide,
+      worktreePath: oppCfg.worktreePath,
+      commit: oppCfg.commit,
+      evaluationOptions: oppCfg.evaluationOptions,
+      bookEnabled: oppCfg.bookEnabled,
+    },
+    board: context.board,
+    moveHistory: context.moveHistory,
+  };
+
+  if (!fs.existsSync(HANG_DUMPS_DIR)) {
+    fs.mkdirSync(HANG_DUMPS_DIR, { recursive: true });
+  }
+  const iso = dump.timestamp.replace(/[:.]/g, "-");
+  const outPath = path.join(
+    HANG_DUMPS_DIR,
+    `hang-${iso}-g${info.gameIdx}.json`,
+  );
+  fs.writeFileSync(outPath, JSON.stringify(dump, null, 2));
+  console.warn(`⚠ hang detected g${info.gameIdx}, dumped to ${outPath}`);
+}
 
 // ============================================================================
 // CLI引数パース
@@ -108,6 +287,17 @@ interface CliOptions {
    */
   bookA: boolean;
   bookB: boolean;
+  /**
+   * デバッグ/スモークテスト用: タスクを先頭 N 局に切り詰める（0 なら無効）。
+   * ハング計装の e2e 検証で少局数（例: 4局）を回すために追加。
+   * 通常のベンチ運用では 0（無効＝全 sets を消化）。
+   */
+  maxGames: number;
+  /**
+   * ハングした側 worker の 1 手あたりタイムアウト（ms）。
+   * 通常は 30000 で運用。ハング計装のテスト時は短くして待ち時間を減らす。
+   */
+  moveTimeoutMs: number;
 }
 
 function parseArgs(): CliOptions {
@@ -126,6 +316,8 @@ function parseArgs(): CliOptions {
     jobs: 1,
     bookA: false,
     bookB: false,
+    maxGames: 0,
+    moveTimeoutMs: 30000,
   };
 
   for (const arg of args) {
@@ -186,6 +378,26 @@ function parseArgs(): CliOptions {
       options.bookA = true;
     } else if (arg === "--book-b") {
       options.bookB = true;
+    } else if (arg.startsWith("--max-games=")) {
+      const value = parseInt(arg.slice("--max-games=".length), 10);
+      if (!isNaN(value) && value >= 0) {
+        options.maxGames = value;
+      } else {
+        console.error(
+          `Error: --max-games は 0 以上の整数で指定 (got: ${arg.slice("--max-games=".length)})`,
+        );
+        process.exit(1);
+      }
+    } else if (arg.startsWith("--move-timeout-ms=")) {
+      const value = parseInt(arg.slice("--move-timeout-ms=".length), 10);
+      if (!isNaN(value) && value > 0) {
+        options.moveTimeoutMs = value;
+      } else {
+        console.error(
+          `Error: --move-timeout-ms は正の整数で指定 (got: ${arg.slice("--move-timeout-ms=".length)})`,
+        );
+        process.exit(1);
+      }
     } else if (arg === "--verbose" || arg === "-v") {
       options.verbose = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -250,8 +462,17 @@ Options:
   --eval-options-b=<json> B側 evaluationOptions オーバーライド（JSON。省略時は legacy 既定）
   --book-a               A側でオープニングブックを有効化（既定OFF）
   --book-b               B側でオープニングブックを有効化（既定OFF）
+  --max-games=<n>        タスクを先頭 N 局に切り詰め（0=無効, default: 0）。
+                         ハング計装のスモークテスト用
+  --move-timeout-ms=<n>  1手あたりのタイムアウト (default: 30000)
   --verbose, -v          詳細ログ
   --help, -h             ヘルプを表示
+
+環境変数:
+  HANG_INJECT=<gameIdx>:<requestOrdinal>[:A|B]
+      指定 gameIdx の局で N 番目の非オープニング要求にハングを注入
+      （bridge worker が応答しなくなる）。ハング検出→ダンプ→worker 再生成の
+      回復パスを実際に発火させるテスト用。
 
 Examples:
   pnpm commit:bench --commitA=HEAD~1 --commitB=HEAD --sets=1
@@ -265,6 +486,10 @@ Examples:
   # （B3仕様③: コミット差の交絡を排除、worktree1本で済む）
   pnpm commit:bench --commitA=HEAD --commitB=HEAD --sets=8 --randomFactor=0.02 \\
     --book-a
+
+  # ハング計装スモークテスト（4局・jobs=2・5秒タイムアウト・g1 の 2 手目で注入）
+  HANG_INJECT=1:2 pnpm commit:bench --commitA=HEAD --commitB=HEAD \\
+    --difficulty=easy --max-games=4 --jobs=2 --move-timeout-ms=5000
 `);
 }
 
@@ -654,16 +879,87 @@ async function main(): Promise<void> {
     console.log("Bridge worker初期化完了\n");
 
     // 珠型タスクを生成し、共有の対局ループ（runMatch）で消化する。
-    // commit-bench は recreatePair を渡さない＝従来どおりエラーは伝播（出力同一）。
-    const tasks = buildJushuTasks(options.sets);
-    const { wdl, games, completedGames } = await runMatch({
+    //
+    // ハング耐性: move-request timeout（GameHangError）が起きたら、当該局を破棄しつつ
+    // 再現ダンプ（bench-results/hang-dumps/hang-*.json）を書き、当該 pair の worker を
+    // 再生成して残り局を続行する。プロセス全体を落とさない。
+    const allTasks = buildJushuTasks(options.sets);
+    const tasks =
+      options.maxGames > 0 && options.maxGames < allTasks.length
+        ? allTasks.slice(0, options.maxGames)
+        : allTasks;
+    if (options.maxGames > 0 && options.maxGames < allTasks.length) {
+      console.log(
+        `--max-games=${options.maxGames} 指定により ${allTasks.length}→${tasks.length} 局に切り詰め`,
+      );
+    }
+
+    // ダンプ用の side メタ（worker 再生成にも再利用）
+    const workerConfigs = {
+      A: {
+        worktreePath: worktreePathA!,
+        evaluationOptions: options.evalOptionsA,
+        bookEnabled: options.bookA,
+        commit: commitA,
+      },
+      B: {
+        worktreePath: worktreePathB!,
+        evaluationOptions: options.evalOptionsB,
+        bookEnabled: options.bookB,
+        commit: commitB,
+      },
+    } as const;
+
+    const recreatePair = async (
+      idx: number,
+    ): Promise<{ a: Worker; b: Worker }> => {
+      const [a, b] = await Promise.all([
+        makeWorker(worktreePathA!, options.evalOptionsA, options.bookA),
+        makeWorker(worktreePathB!, options.evalOptionsB, options.bookB),
+      ]);
+      const fresh = { a, b };
+      pairs[idx] = fresh;
+      return fresh;
+    };
+
+    const onHang = (context: HangContext, info: HangMatchInfo): void => {
+      writeHangDump({
+        context,
+        info,
+        commonConfig: {
+          difficulty: options.difficulty,
+          randomFactor: options.randomFactor,
+        },
+        workerConfigs,
+      });
+    };
+
+    const hangInjectEnv = parseHangInjectEnv(process.env.HANG_INJECT);
+    if (hangInjectEnv) {
+      console.log(
+        `⚠ HANG_INJECT 有効: gameIdx=${hangInjectEnv.gameIdx} requestOrdinal=${hangInjectEnv.requestOrdinal}${hangInjectEnv.side ? ` side=${hangInjectEnv.side}` : ""}`,
+      );
+    }
+
+    const { wdl, games, completedGames, aborts } = await runMatch({
       pairs,
       tasks,
-      totalGames,
+      totalGames: tasks.length,
       sprtConfig,
-      moveTimeoutMs: 30000,
+      moveTimeoutMs: options.moveTimeoutMs,
       verbose: options.verbose,
       startTime,
+      recreatePair,
+      onHang,
+      hangInject: hangInjectEnv
+        ? {
+            gameIdx: hangInjectEnv.gameIdx,
+            spec: {
+              requestOrdinal: hangInjectEnv.requestOrdinal,
+              side: hangInjectEnv.side,
+            },
+          }
+        : undefined,
     });
 
     const elapsedSeconds = (performance.now() - startTime) / 1000;
@@ -672,7 +968,14 @@ async function main(): Promise<void> {
     console.log(`\n=== 結果 ===`);
     console.log(`commitA: ${commitA.shortSha} "${commitA.message}"`);
     console.log(`commitB: ${commitB.shortSha} "${commitB.message}"`);
-    console.log(`対局数: ${completedGames}`);
+    console.log(
+      `対局数: ${completedGames}${aborts > 0 ? ` (abort: ${aborts})` : ""}`,
+    );
+    if (aborts > 0) {
+      console.log(
+        `⚠ ハング検出: ${aborts} 局を破棄しました。ダンプは ${HANG_DUMPS_DIR} を参照`,
+      );
+    }
     console.log(`WDL (commitA視点): +${wdl.wins} =${wdl.draws} -${wdl.losses}`);
 
     const eloDiffResult = estimateEloDiff(wdl);
@@ -736,6 +1039,7 @@ async function main(): Promise<void> {
         bookB: options.bookB,
       },
       totalGames: completedGames,
+      aborts,
       wdl,
       eloDiff: eloDiffResult,
       sprt: sprtState,

--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -134,6 +134,12 @@ interface CliOptions {
   maxNodesA?: number;
   maxNodesB?: number;
   /**
+   * 探索の depth cap オーバーライド（side 別）。未指定なら difficulty 既定を使う。
+   * probe OFF/深さレバーが depth cap で頭打ちになるのを避けるためのレバー。
+   */
+  maxDepthA?: number;
+  maxDepthB?: number;
+  /**
    * デバッグ/スモークテスト用: タスクを先頭 N 局に切り詰める（0 なら無効）。
    * ハング計装の e2e 検証で少局数（例: 4局）を回すために追加。
    * 通常のベンチ運用では 0（無効＝全 sets を消化）。
@@ -257,6 +263,26 @@ function parseArgs(): CliOptions {
         );
         process.exit(1);
       }
+    } else if (arg.startsWith("--max-depth-a=")) {
+      const value = parseInt(arg.slice("--max-depth-a=".length), 10);
+      if (Number.isFinite(value) && value > 0) {
+        options.maxDepthA = value;
+      } else {
+        console.error(
+          `Error: --max-depth-a は正の整数で指定 (got: ${arg.slice("--max-depth-a=".length)})`,
+        );
+        process.exit(1);
+      }
+    } else if (arg.startsWith("--max-depth-b=")) {
+      const value = parseInt(arg.slice("--max-depth-b=".length), 10);
+      if (Number.isFinite(value) && value > 0) {
+        options.maxDepthB = value;
+      } else {
+        console.error(
+          `Error: --max-depth-b は正の整数で指定 (got: ${arg.slice("--max-depth-b=".length)})`,
+        );
+        process.exit(1);
+      }
     } else if (arg.startsWith("--max-games=")) {
       const value = parseInt(arg.slice("--max-games=".length), 10);
       if (!isNaN(value) && value >= 0) {
@@ -357,6 +383,10 @@ Options:
                          probe OFF/深さレバーが maxNodes 早期打ち切りに拘束される
                          のを避け、timeLimit ベースで測るためのレバー
   --max-nodes-b=<n>      B側の maxNodes を上書き（既定=difficulty 既定）
+  --max-depth-a=<n>      A側の depth cap を上書き（既定=difficulty 既定）。
+                         probe OFF で深読みが伸びるかを見るとき、depth cap が
+                         binding だと差が出ないので併用する
+  --max-depth-b=<n>      B側の depth cap を上書き（既定=difficulty 既定）
   --max-games=<n>        タスクを先頭 N 局に切り詰め（0=無効, default: 0）。
                          ハング計装のスモークテスト用
   --move-timeout-ms=<n>  1手あたりのタイムアウト (default: 30000)
@@ -709,6 +739,11 @@ async function main(): Promise<void> {
       `maxNodes A: ${options.maxNodesA ?? "(既定=difficulty)"} / B: ${options.maxNodesB ?? "(既定=difficulty)"}`,
     );
   }
+  if (options.maxDepthA !== undefined || options.maxDepthB !== undefined) {
+    console.log(
+      `maxDepth A: ${options.maxDepthA ?? "(既定=difficulty)"} / B: ${options.maxDepthB ?? "(既定=difficulty)"}`,
+    );
+  }
   if (sprtConfig) {
     console.log(
       `SPRT: elo0=${sprtConfig.elo0}, elo1=${sprtConfig.elo1}, ` +
@@ -762,6 +797,7 @@ async function main(): Promise<void> {
       bookEnabled: boolean,
       threatProbeEnabled: boolean,
       maxNodes: number | undefined,
+      maxDepth: number | undefined,
     ): Promise<Worker> =>
       createBridgeWorker({
         workerPath,
@@ -773,6 +809,7 @@ async function main(): Promise<void> {
         bookEnabled,
         threatProbeEnabled,
         maxNodes,
+        maxDepth,
       });
 
     console.log(`Bridge workerを初期化中... (${options.jobs}並列)`);
@@ -785,6 +822,7 @@ async function main(): Promise<void> {
             options.bookA,
             options.probeEnabledA,
             options.maxNodesA,
+            options.maxDepthA,
           ),
           makeWorker(
             worktreePathB!,
@@ -792,6 +830,7 @@ async function main(): Promise<void> {
             options.bookB,
             options.probeEnabledB,
             options.maxNodesB,
+            options.maxDepthB,
           ),
         ]);
         return { a, b };
@@ -842,6 +881,7 @@ async function main(): Promise<void> {
           options.bookA,
           options.probeEnabledA,
           options.maxNodesA,
+          options.maxDepthA,
         ),
         makeWorker(
           worktreePathB!,
@@ -849,6 +889,7 @@ async function main(): Promise<void> {
           options.bookB,
           options.probeEnabledB,
           options.maxNodesB,
+          options.maxDepthB,
         ),
       ]);
       const fresh = { a, b };
@@ -1017,6 +1058,8 @@ async function main(): Promise<void> {
         threatProbeB: options.probeEnabledB,
         maxNodesA: options.maxNodesA,
         maxNodesB: options.maxNodesB,
+        maxDepthA: options.maxDepthA,
+        maxDepthB: options.maxDepthB,
         seed: seedInEffect,
       },
       totalGames: completedGames,

--- a/scripts/commit-game-runner.ts
+++ b/scripts/commit-game-runner.ts
@@ -10,6 +10,8 @@ import type { Worker } from "node:worker_threads";
 
 import type { BoardState, Position } from "../src/types/game.ts";
 
+import { WorkerMoveTimeoutError } from "./lib/workerMoveTimeoutError.ts";
+
 /** 着手記録 */
 export interface MoveRecord {
   row: number;
@@ -75,23 +77,59 @@ type WorkerMessage = MoveResponse | ErrorResponse;
 
 let nextRequestId = 0;
 
+export { WorkerMoveTimeoutError } from "./lib/workerMoveTimeoutError.ts";
+
 /**
- * workerに着手を要求し、レスポンスを待つ
+ * runCommitGame がハング（move-request timeout）で throw するエラー。
+ * bench ハーネス（match ループ）がこれを catch して再現ダンプを書き、
+ * worker を respawn して残り局を続行する。
+ */
+export interface HangContext {
+  requestId: number;
+  timeoutMs: number;
+  /** ハングした側（A/B）と手番色 */
+  side: "A" | "B";
+  color: "black" | "white";
+  /** ハング直前の盤面（再現の起点） */
+  board: BoardState;
+  /** ハング直前までの着手履歴（opening 3手を含む） */
+  moveHistory: MoveRecord[];
+  /** ゲーム開始からの経過ミリ秒 */
+  elapsedMs: number;
+  /** ハング時の手数（0-based, opening 3手を含む＝ハング要求は moveHistory.length 番目の手を打とうとしていた） */
+  moveNumber: number;
+}
+
+export class GameHangError extends Error {
+  readonly context: HangContext;
+
+  constructor(context: HangContext) {
+    super(
+      `Game hang: side=${context.side} color=${context.color} moveNumber=${context.moveNumber} requestId=${context.requestId} timeoutMs=${context.timeoutMs}`,
+    );
+    this.name = "GameHangError";
+    this.context = context;
+  }
+}
+
+/**
+ * workerに着手を要求し、レスポンスを待つ。
+ * timeout 時は WorkerMoveTimeoutError を throw（runCommitGame が context を付与する）。
  */
 function askWorker(
   worker: Worker,
   board: BoardState,
   color: "black" | "white",
   timeoutMs: number,
+  side: "A" | "B",
+  hangInject: boolean,
 ): Promise<MoveResponse> {
   return new Promise<MoveResponse>((resolve, reject) => {
     const requestId = nextRequestId++;
 
     const timer = setTimeout(() => {
       worker.off("message", handler);
-      reject(
-        new Error(`Worker move request timed out (requestId=${requestId})`),
-      );
+      reject(new WorkerMoveTimeoutError({ requestId, timeoutMs, color, side }));
     }, timeoutMs);
 
     const handler = (msg: WorkerMessage): void => {
@@ -109,7 +147,7 @@ function askWorker(
     };
 
     worker.on("message", handler);
-    worker.postMessage({ requestId, board, color });
+    worker.postMessage({ requestId, board, color, hangInject });
   });
 }
 
@@ -129,6 +167,53 @@ function colorToWinner(
 }
 
 /**
+ * ハング注入設定。指定した非オープニング手番号（1-based）で該当 side/color の
+ * リクエストにハングフラグを立て、bridge worker に応答させない。
+ * bench 側の回復パス（timeout → dump → worker respawn）を確実にテストするための
+ * 差し込み口で、未指定時は完全に既存挙動（後方互換）。
+ */
+export interface HangInjectSpec {
+  /** 非オープニング手番号（1-based）。この番目の要求でハングを起こす */
+  requestOrdinal: number;
+  /** どちらのプレイヤーで注入するか。未指定なら手番に来た側 */
+  side?: "A" | "B";
+}
+
+/**
+ * askWorker のラッパー。WorkerMoveTimeoutError を GameHangError に変換して throw する。
+ * ループ内クロージャで no-loop-func 警告を出さないため、ループ外の関数として切り出す。
+ */
+async function askOrHang(
+  worker: Worker,
+  board: BoardState,
+  color: "black" | "white",
+  timeoutMs: number,
+  side: "A" | "B",
+  hangInject: boolean,
+  moveHistory: MoveRecord[],
+  gameStartTime: number,
+  moveCount: number,
+): Promise<MoveResponse> {
+  try {
+    return await askWorker(worker, board, color, timeoutMs, side, hangInject);
+  } catch (err: unknown) {
+    if (err instanceof WorkerMoveTimeoutError) {
+      throw new GameHangError({
+        requestId: err.requestId,
+        timeoutMs: err.timeoutMs,
+        side: err.side,
+        color: err.color,
+        board,
+        moveHistory,
+        elapsedMs: performance.now() - gameStartTime,
+        moveNumber: moveCount + 1,
+      });
+    }
+    throw err;
+  }
+}
+
+/**
  * 1ゲームを実行
  *
  * @param workerA commitAのbridge worker
@@ -145,6 +230,8 @@ export async function runCommitGame(
     verbose?: boolean;
     moveTimeoutMs?: number;
     openingMoves?: [Position, Position, Position];
+    /** テスト用: 特定の要求番目でハングを注入する */
+    hangInject?: HangInjectSpec;
   } = {},
 ): Promise<GameResult> {
   // #43 PR-6: 禁手判定(forbidden) と脅威検出(detectOpponentThreats→threat) はどちらも
@@ -194,19 +281,37 @@ export async function runCommitGame(
     currentColor = "white";
   }
 
+  // 非オープニング手のリクエスト番号（1-based）。ハング注入の照合用。
+  let nonOpeningRequestOrdinal = 0;
+
   while (moveCount < DRAW_MOVE_LIMIT) {
     const isBlack = currentColor === "black";
     const worker = isBlack ? blackWorker : whiteWorker;
+    // どちらの side (A/B) がこの手番か
+    const currentSide: "A" | "B" =
+      (isBlack && isABlack) || (!isBlack && !isABlack) ? "A" : "B";
+
+    nonOpeningRequestOrdinal++;
+    const shouldInject =
+      options.hangInject !== undefined &&
+      options.hangInject.requestOrdinal === nonOpeningRequestOrdinal &&
+      (options.hangInject.side === undefined ||
+        options.hangInject.side === currentSide);
 
     // 着手要求（逐次実行が必要: 同じworkerを1ゲーム内で交互に使用）
 
     const moveStartTime = performance.now();
 
-    const response = await askWorker(
+    const response = await askOrHang(
       worker,
       board,
       currentColor,
       moveTimeoutMs,
+      currentSide,
+      shouldInject,
+      moveHistory,
+      startTime,
+      moveCount,
     );
     const moveTime = performance.now() - moveStartTime;
 

--- a/scripts/commit-game-runner.ts
+++ b/scripts/commit-game-runner.ts
@@ -10,6 +10,7 @@ import type { Worker } from "node:worker_threads";
 
 import type { BoardState, Position } from "../src/types/game.ts";
 
+import { mixSeed } from "./lib/mulberry32.ts";
 import { WorkerMoveTimeoutError } from "./lib/workerMoveTimeoutError.ts";
 
 /** 着手記録 */
@@ -96,7 +97,10 @@ export interface HangContext {
   moveHistory: MoveRecord[];
   /** ゲーム開始からの経過ミリ秒 */
   elapsedMs: number;
-  /** ハング時の手数（0-based, opening 3手を含む＝ハング要求は moveHistory.length 番目の手を打とうとしていた） */
+  /**
+   * ハング時の手数（1-based, opening 3手を含む）。
+   * moveHistory の直後に打とうとしていた手の番号（= moveHistory.length + 1）。
+   */
   moveNumber: number;
 }
 
@@ -112,18 +116,29 @@ export class GameHangError extends Error {
   }
 }
 
+/** askWorker のリクエストパラメータ。位置引数の膨張を避けるためオブジェクト化。 */
+interface AskWorkerParams {
+  worker: Worker;
+  board: BoardState;
+  color: "black" | "white";
+  timeoutMs: number;
+  side: "A" | "B";
+  hangInject: boolean;
+  /**
+   * この1手用の PRNG シード。bridge worker は randomFactor 適用時に
+   * `mulberry32(moveSeed)` で決定的な近傍ランダム選択を行う。
+   * 未指定なら worker 側は非決定的（Math.random）にフォールバック。
+   */
+  moveSeed?: number;
+}
+
 /**
  * workerに着手を要求し、レスポンスを待つ。
  * timeout 時は WorkerMoveTimeoutError を throw（runCommitGame が context を付与する）。
  */
-function askWorker(
-  worker: Worker,
-  board: BoardState,
-  color: "black" | "white",
-  timeoutMs: number,
-  side: "A" | "B",
-  hangInject: boolean,
-): Promise<MoveResponse> {
+function askWorker(params: AskWorkerParams): Promise<MoveResponse> {
+  const { worker, board, color, timeoutMs, side, hangInject, moveSeed } =
+    params;
   return new Promise<MoveResponse>((resolve, reject) => {
     const requestId = nextRequestId++;
 
@@ -147,7 +162,7 @@ function askWorker(
     };
 
     worker.on("message", handler);
-    worker.postMessage({ requestId, board, color, hangInject });
+    worker.postMessage({ requestId, board, color, hangInject, moveSeed });
   });
 }
 
@@ -179,23 +194,20 @@ export interface HangInjectSpec {
   side?: "A" | "B";
 }
 
+interface AskOrHangParams extends AskWorkerParams {
+  moveHistory: MoveRecord[];
+  gameStartTime: number;
+  moveCount: number;
+}
+
 /**
  * askWorker のラッパー。WorkerMoveTimeoutError を GameHangError に変換して throw する。
  * ループ内クロージャで no-loop-func 警告を出さないため、ループ外の関数として切り出す。
  */
-async function askOrHang(
-  worker: Worker,
-  board: BoardState,
-  color: "black" | "white",
-  timeoutMs: number,
-  side: "A" | "B",
-  hangInject: boolean,
-  moveHistory: MoveRecord[],
-  gameStartTime: number,
-  moveCount: number,
-): Promise<MoveResponse> {
+async function askOrHang(params: AskOrHangParams): Promise<MoveResponse> {
+  const { board, moveHistory, gameStartTime, moveCount, ...askParams } = params;
   try {
-    return await askWorker(worker, board, color, timeoutMs, side, hangInject);
+    return await askWorker({ ...askParams, board });
   } catch (err: unknown) {
     if (err instanceof WorkerMoveTimeoutError) {
       throw new GameHangError({
@@ -232,6 +244,12 @@ export async function runCommitGame(
     openingMoves?: [Position, Position, Position];
     /** テスト用: 特定の要求番目でハングを注入する */
     hangInject?: HangInjectSpec;
+    /**
+     * この局用の PRNG seed。指定時、1手ごとに `mixSeed(gameSeed, moveOrdinal)` で
+     * 導出した moveSeed を bridge worker に渡し、randomFactor 適用時の近傍ランダム
+     * 選択を決定的にする。未指定なら bridge worker は Math.random にフォールバック。
+     */
+    gameSeed?: number;
   } = {},
 ): Promise<GameResult> {
   // #43 PR-6: 禁手判定(forbidden) と脅威検出(detectOpponentThreats→threat) はどちらも
@@ -302,17 +320,22 @@ export async function runCommitGame(
 
     const moveStartTime = performance.now();
 
-    const response = await askOrHang(
+    const moveSeed =
+      options.gameSeed === undefined
+        ? undefined
+        : mixSeed(options.gameSeed, nonOpeningRequestOrdinal);
+    const response = await askOrHang({
       worker,
       board,
-      currentColor,
-      moveTimeoutMs,
-      currentSide,
-      shouldInject,
+      color: currentColor,
+      timeoutMs: moveTimeoutMs,
+      side: currentSide,
+      hangInject: shouldInject,
+      moveSeed,
       moveHistory,
-      startTime,
+      gameStartTime: startTime,
       moveCount,
-    );
+    });
     const moveTime = performance.now() - moveStartTime;
 
     const move: Position = response.position;

--- a/scripts/cpu-bridge-worker.ts
+++ b/scripts/cpu-bridge-worker.ts
@@ -27,6 +27,7 @@ import type { BoardState, Position } from "../src/types/game.ts";
 
 import { mergeDifficultyParams } from "./lib/difficultyParamsMerge.ts";
 import { EVAL_PARAM_IDS } from "./lib/evalParams.ts";
+import { mulberry32 } from "./lib/mulberry32.ts";
 import {
   countStones,
   loadOpeningBookFromWorktree,
@@ -65,6 +66,12 @@ interface MoveRequest {
    * runCommitGame の HangInjectSpec から立てられる。
    */
   hangInject?: boolean;
+  /**
+   * この1手用の PRNG seed。指定時、randomFactor 適用の近傍ランダム選択に
+   * `mulberry32(moveSeed)` を使い、同一シード同一棋譜を保証する。
+   * 未指定なら Math.random にフォールバック（従来挙動）。
+   */
+  moveSeed?: number;
 }
 
 interface WasmSearchStats {
@@ -415,6 +422,154 @@ function applyEvalWeights(
   }
 }
 
+// ============================================================================
+// randomFactor 適用（cpu.worker.ts のブラウザ側実装を鏡写しに再現）
+// ============================================================================
+
+interface RandomizationModule {
+  selectMoveWithRandomization: (opts: {
+    bestMove: Position;
+    bestMoveScore?: number;
+    criticalScoreThreshold?: number;
+    randomFactor: number;
+    pickRandomMove: () => Position | null;
+    random?: () => number;
+  }) => Position;
+  listChebyshevNeighbors: (
+    center: Position,
+    radius: number,
+    boardSize?: number,
+  ) => Position[];
+}
+
+interface ForbiddenAdapterModule {
+  isForbiddenForBlack: (board: BoardState, row: number, col: number) => boolean;
+  /** 禁手判定 wasm を事前ロード。未ロードで isForbiddenForBlack を呼ぶと throw する。 */
+  preloadForbiddenWasm: () => Promise<void>;
+}
+
+interface RandomizationBundle {
+  randomization: RandomizationModule;
+  forbidden: ForbiddenAdapterModule;
+}
+
+const RANDOM_NEIGHBOR_RADIUS = 3;
+
+/**
+ * worktree から randomization.ts と forbiddenAdapter.ts を動的 import する。
+ * 古い commit（randomization.ts が無い）では null を返し、randomFactor は
+ * 無視される（既存挙動と同等）。
+ */
+async function loadRandomizationFromWorktree(
+  worktreePath: string,
+): Promise<RandomizationBundle | null> {
+  const randomizationPath = path.join(
+    worktreePath,
+    "src",
+    "logic",
+    "cpu",
+    "randomization.ts",
+  );
+  const forbiddenPath = path.join(
+    worktreePath,
+    "src",
+    "logic",
+    "cpu",
+    "wasm",
+    "forbiddenAdapter.ts",
+  );
+  if (!fs.existsSync(randomizationPath) || !fs.existsSync(forbiddenPath)) {
+    return null;
+  }
+  try {
+    const [randomizationMod, forbiddenMod] = await Promise.all([
+      import(pathToFileURL(randomizationPath).href) as Promise<
+        Partial<RandomizationModule>
+      >,
+      import(pathToFileURL(forbiddenPath).href) as Promise<
+        Partial<ForbiddenAdapterModule>
+      >,
+    ]);
+    if (
+      typeof randomizationMod.selectMoveWithRandomization !== "function" ||
+      typeof randomizationMod.listChebyshevNeighbors !== "function" ||
+      typeof forbiddenMod.isForbiddenForBlack !== "function" ||
+      typeof forbiddenMod.preloadForbiddenWasm !== "function"
+    ) {
+      console.warn(
+        "[cpu-bridge-worker] randomization/forbidden の期待 export がありません。randomFactor を無視します。",
+      );
+      return null;
+    }
+    // 禁手判定 wasm を事前ロード（isForbiddenForBlack は未ロードで throw する）。
+    // 動的 import した forbiddenAdapter は独立モジュールインスタンスなので、
+    // 上位（commit-game-runner）の preloadForbiddenWasm() では初期化されない。
+    await forbiddenMod.preloadForbiddenWasm();
+    return {
+      randomization: randomizationMod as RandomizationModule,
+      forbidden: forbiddenMod as ForbiddenAdapterModule,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[cpu-bridge-worker] randomization ロード失敗（randomFactor 無視）: ${msg}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * bestMove とスコアから、cpu.worker.ts と同じ手順で近傍 Chebyshev≤3 の
+ * 合法空き点からランダム選択を掛ける。黒手番は禁手を除外。moveSeed が
+ * あれば `mulberry32(moveSeed)` で決定的にする。
+ */
+function applyRandomization(
+  bundle: RandomizationBundle | null,
+  bestMove: Position,
+  bestMoveScore: number,
+  board: BoardState,
+  color: "black" | "white",
+  randomFactor: number,
+  criticalScoreThreshold: number | undefined,
+  moveSeed: number | undefined,
+): Position {
+  if (!bundle || randomFactor <= 0) {
+    return bestMove;
+  }
+  const random = moveSeed === undefined ? undefined : mulberry32(moveSeed);
+  const neighbors = bundle.randomization.listChebyshevNeighbors(
+    bestMove,
+    RANDOM_NEIGHBOR_RADIUS,
+  );
+  const candidates = neighbors.filter((p) => {
+    if (board[p.row]?.[p.col] !== null) {
+      return false;
+    }
+    if (
+      color === "black" &&
+      bundle.forbidden.isForbiddenForBlack(board, p.row, p.col)
+    ) {
+      return false;
+    }
+    return true;
+  });
+  return bundle.randomization.selectMoveWithRandomization({
+    bestMove,
+    bestMoveScore,
+    criticalScoreThreshold,
+    randomFactor,
+    random,
+    pickRandomMove: () => {
+      if (candidates.length === 0) {
+        return null;
+      }
+      const draw = random ? random() : Math.random();
+      const idx = Math.floor(draw * candidates.length);
+      return candidates[idx] ?? null;
+    },
+  });
+}
+
 async function main(): Promise<void> {
   const { worktreePath } = data;
 
@@ -429,6 +584,16 @@ async function main(): Promise<void> {
   if (data.bookEnabled) {
     console.log(
       `[cpu-bridge-worker] book=${bookBridge ? "ON" : "OFF(unavailable)"} for ${worktreePath}`,
+    );
+  }
+
+  // randomFactor 用の worktree モジュール（無ければ null＝randomFactor 無視）。
+  // 既存の commit-bench では params.randomFactor は WASM パスで完全に無視されていた
+  // ため、この配線が「WASM 対局に randomFactor が効くようにする」修正の本体。
+  const randomizationBundle = await loadRandomizationFromWorktree(worktreePath);
+  if (params.randomFactor > 0) {
+    console.log(
+      `[cpu-bridge-worker] randomFactor=${params.randomFactor} randomization=${randomizationBundle ? "ON" : "OFF(unavailable)"} criticalScoreThreshold=${params.randomCriticalScoreThreshold ?? "unset"} for ${worktreePath}`,
     );
   }
 
@@ -465,7 +630,7 @@ async function main(): Promise<void> {
 
   // 着手要求を処理（同期的にCPUを呼び出す）
   parentPort?.on("message", (msg: MoveRequest) => {
-    const { requestId, board, color, hangInject } = msg;
+    const { requestId, board, color, hangInject, moveSeed } = msg;
     // テスト用: hangInject が立っていれば応答せず沈黙 → 呼び出し側が timeout する
     if (hangInject) {
       console.warn(
@@ -499,11 +664,24 @@ async function main(): Promise<void> {
         ? wasmHandler.search(board, color, params)
         : callTsFindBestMove(tsFindBestMove!, board, color, params);
 
+      // randomFactor 適用（WASM/TS どちらの探索結果にも掛かる）。
+      // cpu.worker.ts と同じ手順で近傍ランダム化 + 黒番の禁手除外。
+      const finalPosition = applyRandomization(
+        randomizationBundle,
+        result.position,
+        result.score,
+        board,
+        color,
+        params.randomFactor,
+        params.randomCriticalScoreThreshold,
+        moveSeed,
+      );
+
       const thinkingTimeMs = performance.now() - startTime;
 
       const response: MoveResponse = {
         requestId,
-        position: result.position,
+        position: finalPosition,
         score: result.score,
         depth: result.completedDepth,
         thinkingTimeMs,

--- a/scripts/cpu-bridge-worker.ts
+++ b/scripts/cpu-bridge-worker.ts
@@ -54,6 +54,15 @@ interface BridgeWorkerData {
    * worktree に存在しなければ自動的に book-OFF として続行する（クラッシュしない）。
    */
   bookEnabled?: boolean;
+  /**
+   * 脅威プローブ（threat_probe_enabled）を無効化して探索させる。
+   * 既定 true=従来挙動。false の時は WASM ロード後に `setThreatProbeEnabled(0)` を
+   * 呼び、プローブ抜きの深度を計測する。export が無い古い wasm では warn してスキップ。
+   *
+   * prospect 基底下で probe OFF（NPS×17・深度5→12 が既測）が Elo に転換するかを
+   * commit-bench で再検証するための実行時レバー。
+   */
+  threatProbeEnabled?: boolean;
 }
 
 interface MoveRequest {
@@ -158,6 +167,12 @@ interface WasmModuleExports {
   setEvalParam?: (id: number, value: number) => void;
   getEvalParam?: (id: number) => number;
   resetEvalParams?: () => void;
+  /**
+   * 脅威プローブの有効/無効を切り替える（Gate 0 計測用、zig/src/main.zig）。
+   * 1=有効（既定）、0=無効。無効化した wasm では NPS×17・深度が上がる傾向がある
+   * が Elo に転換するかは要検証。古い wasm には無い＝optional。
+   */
+  setThreatProbeEnabled?: (enabled: number) => void;
 }
 
 /** WASM探索のハンドラ */
@@ -606,6 +621,20 @@ async function main(): Promise<void> {
     wasmHandler = createWasmSearchHandler(wasm);
     // eval 形系重みを注入（baseline は weights 空＝reset のみでクリーン既定）
     applyEvalWeights(wasm, data.evalWeights);
+    // 脅威プローブトグル（Gate 0 計測用）。既定 true=従来挙動、false のときのみ
+    // 明示 off。setThreatProbeEnabled が無い古い wasm は warn してスキップ。
+    let threatProbeState = "ON(default)";
+    if (data.threatProbeEnabled === false) {
+      if (typeof wasm.setThreatProbeEnabled === "function") {
+        wasm.setThreatProbeEnabled(0);
+        threatProbeState = "OFF(runtime)";
+      } else {
+        console.warn(
+          "[cpu-bridge-worker] この wasm は setThreatProbeEnabled 非対応。--probe-off を無視して既定 ON で走ります。",
+        );
+        threatProbeState = "ON(fallback, no-export)";
+      }
+    }
     // evalBasis 配線の silent 事故防止: 実際に search に渡る evaluationOptions を
     // エンコードした flags と bit18 (eval_basis) の状態を必ず1行ログに出す。
     // worktreePath のディレクトリ名（A-<sha>/B-<sha>）で A/B 側を判別できる。
@@ -616,7 +645,7 @@ async function main(): Promise<void> {
     const basis = params.evaluationOptions?.evalBasis ?? "legacy";
     const bit18 = (evalFlags & (1 << 18)) === 0 ? "legacy" : "prospect";
     console.log(
-      `[cpu-bridge-worker] WASM engine loaded for ${worktreePath} | evalBasis=${basis} evalFlags=${evalFlags} bit18=${bit18}`,
+      `[cpu-bridge-worker] WASM engine loaded for ${worktreePath} | evalBasis=${basis} evalFlags=${evalFlags} bit18=${bit18} threatProbe=${threatProbeState}`,
     );
   } else {
     tsFindBestMove = await loadTsCpuFromWorktree(worktreePath);

--- a/scripts/cpu-bridge-worker.ts
+++ b/scripts/cpu-bridge-worker.ts
@@ -59,6 +59,12 @@ interface MoveRequest {
   requestId: number;
   board: BoardState;
   color: "black" | "white";
+  /**
+   * テスト用: true の場合、応答を返さず沈黙する（bench の timeout→dump→respawn
+   * 回復パスを実際に発火させる）。本番パスに影響しない差し込み口で、
+   * runCommitGame の HangInjectSpec から立てられる。
+   */
+  hangInject?: boolean;
 }
 
 interface WasmSearchStats {
@@ -459,7 +465,14 @@ async function main(): Promise<void> {
 
   // 着手要求を処理（同期的にCPUを呼び出す）
   parentPort?.on("message", (msg: MoveRequest) => {
-    const { requestId, board, color } = msg;
+    const { requestId, board, color, hangInject } = msg;
+    // テスト用: hangInject が立っていれば応答せず沈黙 → 呼び出し側が timeout する
+    if (hangInject) {
+      console.warn(
+        `[cpu-bridge-worker] HANG_INJECT active (requestId=${requestId}) — 応答を返しません`,
+      );
+      return;
+    }
     const startTime = performance.now();
 
     try {

--- a/scripts/lib/hangDump.ts
+++ b/scripts/lib/hangDump.ts
@@ -1,0 +1,165 @@
+/**
+ * ハングダンプ JSON の Single Source of Truth。
+ *
+ * `commit-bench.ts`（書き込み側）と `scripts/replay-hang.ts`（読み込み側）が
+ * 独立に手書き定義していたため型が食い違いはじめた（board が unknown vs
+ * BoardState 等）。両者ともこのファイルから型と writeHangDump をインポートする。
+ *
+ * ダンプは commit-bench の bench-results/hang-dumps/hang-*.json に保存され、
+ * 後日 replay-hang スクリプトで局面再現に使う。schemaVersion 変更時は
+ * replay-hang.ts の後方互換ロジックを同時に更新すること。
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { EvaluationOptions } from "../../src/logic/cpu/evaluation/patternScores.ts";
+import type { BoardState } from "../../src/types/game.ts";
+import type { HangContext, MoveRecord } from "../commit-game-runner.ts";
+import type { CommitInfo } from "../types/commit-bench.ts";
+
+/** ダンプに含める側（A/B）ごとの worker 設定 */
+export interface HangDumpSideConfig {
+  worktreePath: string;
+  evaluationOptions: Partial<EvaluationOptions> | undefined;
+  bookEnabled: boolean;
+  commit: CommitInfo;
+}
+
+/** ダンプ発生源のベンチ側情報 */
+export interface HangDumpBench {
+  /** 発生元スクリプト。replay がどの構成を組めばよいか区別するため */
+  tool: "commit-bench";
+  difficulty: string;
+  randomFactor: number | undefined;
+  moveTimeoutMs: number;
+  /** ハング当時の --jobs 値（並列ペア数。過負荷起因かの事後判断用） */
+  jobs?: number;
+  /**
+   * ハング当時の baseSeed（--seed CLI で指定した値）。指定なしなら undefined。
+   * 実効的な perGameSeed は match.gameSeed に別途保存する。
+   */
+  baseSeed?: number;
+}
+
+/** ダンプに含める対局メタ */
+export interface HangDumpMatch {
+  gameIdx: number;
+  jushuName: string;
+  isABlack: boolean;
+  pairIdx: number;
+  /**
+   * この局に注入された PRNG seed（baseSeed と gameIdx から導出）。
+   * 指定 seed なしなら undefined。replay 時にこれを worker に渡せば
+   * randomFactor 起因のばらつきを再現できる。
+   */
+  gameSeed?: number;
+}
+
+/** ハング時の状態スナップショット */
+export interface HangDumpHang {
+  /** ハングした側（A/B）— この情報だけで worker 側の worktree/config を引ける */
+  side: "A" | "B";
+  color: "black" | "white";
+  requestId: number;
+  timeoutMs: number;
+  elapsedMs: number;
+  /** 何手目でハングしたか（1-based, opening 3手を含む） */
+  moveNumber: number;
+}
+
+/** ハングした側の worker 設定（replay 用の完全情報） */
+export interface HangDumpWorker {
+  side: "A" | "B";
+  worktreePath: string;
+  commit: CommitInfo;
+  difficulty: string;
+  randomFactor: number | undefined;
+  evaluationOptions: Partial<EvaluationOptions> | undefined;
+  bookEnabled: boolean;
+  color: "black" | "white";
+}
+
+/** 相手側の worker 設定（対戦再構築が必要な将来のため） */
+export interface HangDumpOpponent {
+  side: "A" | "B";
+  worktreePath: string;
+  commit: CommitInfo;
+  evaluationOptions: Partial<EvaluationOptions> | undefined;
+  bookEnabled: boolean;
+}
+
+/** ダンプ JSON の全体スキーマ */
+export interface HangDumpJson {
+  type: "hang-dump";
+  schemaVersion: 1;
+  timestamp: string;
+  bench: HangDumpBench;
+  match: HangDumpMatch;
+  hang: HangDumpHang;
+  worker: HangDumpWorker;
+  opponent: HangDumpOpponent;
+  /** ハング直前の盤面（そのままリクエストとして送れる形） */
+  board: BoardState;
+  /** ハング直前までの着手履歴（opening 3手を含む。row/col/isOpening/time…） */
+  moveHistory: MoveRecord[];
+}
+
+export interface WriteHangDumpParams {
+  outputDir: string;
+  context: HangContext;
+  match: HangDumpMatch;
+  bench: HangDumpBench;
+  workerConfigs: { A: HangDumpSideConfig; B: HangDumpSideConfig };
+}
+
+/** 呼び出し側は match/bench の中身を組み立てて渡す。書き込んだ絶対パスを返す。 */
+export function writeHangDump(params: WriteHangDumpParams): string {
+  const { outputDir, context, match, bench, workerConfigs } = params;
+  const hangSide = context.side;
+  const oppSide: "A" | "B" = hangSide === "A" ? "B" : "A";
+  const hangCfg = workerConfigs[hangSide];
+  const oppCfg = workerConfigs[oppSide];
+
+  const dump: HangDumpJson = {
+    type: "hang-dump",
+    schemaVersion: 1,
+    timestamp: new Date().toISOString(),
+    bench,
+    match,
+    hang: {
+      side: context.side,
+      color: context.color,
+      requestId: context.requestId,
+      timeoutMs: context.timeoutMs,
+      elapsedMs: context.elapsedMs,
+      moveNumber: context.moveNumber,
+    },
+    worker: {
+      side: hangSide,
+      worktreePath: hangCfg.worktreePath,
+      commit: hangCfg.commit,
+      difficulty: bench.difficulty,
+      randomFactor: bench.randomFactor,
+      evaluationOptions: hangCfg.evaluationOptions,
+      bookEnabled: hangCfg.bookEnabled,
+      color: context.color,
+    },
+    opponent: {
+      side: oppSide,
+      worktreePath: oppCfg.worktreePath,
+      commit: oppCfg.commit,
+      evaluationOptions: oppCfg.evaluationOptions,
+      bookEnabled: oppCfg.bookEnabled,
+    },
+    board: context.board,
+    moveHistory: context.moveHistory,
+  };
+
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  const iso = dump.timestamp.replace(/[:.]/g, "-");
+  const outPath = path.join(outputDir, `hang-${iso}-g${match.gameIdx}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(dump, null, 2));
+  return outPath;
+}

--- a/scripts/lib/match.test.ts
+++ b/scripts/lib/match.test.ts
@@ -69,6 +69,39 @@ describe("buildBridgeCustomParams", () => {
     expect(merged.timeLimit).toBe(DIFFICULTY_PARAMS.hard.timeLimit);
     expect(merged.depth).toBe(DIFFICULTY_PARAMS.hard.depth);
   });
+
+  it("maxDepth のみ指定（--max-depth-a/b 経路）— DifficultyParams.depth に写る", () => {
+    expect(
+      buildBridgeCustomParams(undefined, undefined, undefined, 12),
+    ).toEqual({
+      depth: 12,
+    });
+  });
+
+  it("maxDepth は他レバーと共存する", () => {
+    expect(
+      buildBridgeCustomParams(0.02, { evalBasis: "prospect" }, 3_000_000, 12),
+    ).toEqual({
+      randomFactor: 0.02,
+      evaluationOptions: { evalBasis: "prospect" },
+      maxNodes: 3_000_000,
+      depth: 12,
+    });
+  });
+
+  it("maxDepth オーバーライドが merge 後に depth を上書きする", () => {
+    const customParams = buildBridgeCustomParams(
+      undefined,
+      undefined,
+      undefined,
+      12,
+    );
+    const merged = mergeDifficultyParams(DIFFICULTY_PARAMS.hard, customParams);
+    expect(merged.depth).toBe(12);
+    // 他フィールドは baseParams のまま
+    expect(merged.timeLimit).toBe(DIFFICULTY_PARAMS.hard.timeLimit);
+    expect(merged.maxNodes).toBe(DIFFICULTY_PARAMS.hard.maxNodes);
+  });
 });
 
 describe("evalBasis 配線の end-to-end（silent 事故防止）", () => {

--- a/scripts/lib/match.test.ts
+++ b/scripts/lib/match.test.ts
@@ -40,6 +40,35 @@ describe("buildBridgeCustomParams", () => {
       evaluationOptions: { evalBasis: "prospect" },
     });
   });
+
+  it("maxNodes のみ指定（--max-nodes-a/b 経路）", () => {
+    expect(buildBridgeCustomParams(undefined, undefined, 3_000_000)).toEqual({
+      maxNodes: 3_000_000,
+    });
+  });
+
+  it("maxNodes は他レバーと共存する", () => {
+    expect(
+      buildBridgeCustomParams(0.02, { evalBasis: "prospect" }, 3_000_000),
+    ).toEqual({
+      randomFactor: 0.02,
+      evaluationOptions: { evalBasis: "prospect" },
+      maxNodes: 3_000_000,
+    });
+  });
+
+  it("maxNodes オーバーライドが merge 後に反映される（difficulty 既定を上書き）", () => {
+    const customParams = buildBridgeCustomParams(
+      undefined,
+      undefined,
+      3_000_000,
+    );
+    const merged = mergeDifficultyParams(DIFFICULTY_PARAMS.hard, customParams);
+    expect(merged.maxNodes).toBe(3_000_000);
+    // 他フィールドは baseParams のまま
+    expect(merged.timeLimit).toBe(DIFFICULTY_PARAMS.hard.timeLimit);
+    expect(merged.depth).toBe(DIFFICULTY_PARAMS.hard.depth);
+  });
 });
 
 describe("evalBasis 配線の end-to-end（silent 事故防止）", () => {

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -159,6 +159,12 @@ export interface CreateBridgeWorkerParams {
    * として続行する。
    */
   bookEnabled?: boolean;
+  /**
+   * 脅威プローブトグル（探索レバー A/B）。未指定/true=従来挙動、false=無効化。
+   * setThreatProbeEnabled 非対応の古い wasm では bridge worker 側で warn して
+   * スキップされる（fallback で ON 相当）。
+   */
+  threatProbeEnabled?: boolean;
 }
 
 /**
@@ -196,6 +202,7 @@ export function createBridgeWorker(
     evalWeights,
     evaluationOptions,
     bookEnabled,
+    threatProbeEnabled,
   } = params;
   return new Promise<Worker>((resolve, reject) => {
     const customParams = buildBridgeCustomParams(
@@ -210,6 +217,7 @@ export function createBridgeWorker(
         customParams,
         evalWeights,
         bookEnabled,
+        threatProbeEnabled,
       },
       execArgv: [
         "--experimental-strip-types",

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -57,6 +57,12 @@ export interface RunMatchResult {
    * 未破棄なら常に 0。既存 caller が field を読まなくても影響しない。
    */
   aborts: number;
+  /**
+   * abort 局を側（A/B）別に集計したもの。
+   * 「劣勢側がハングしやすい場合に負けを消す」一方向バイアスの検出に使う。
+   * A + B = aborts の関係。
+   */
+  abortsBySide: { A: number; B: number };
 }
 
 export interface RunMatchParams {
@@ -89,6 +95,13 @@ export interface RunMatchParams {
    * gameIdx が現在の taskIdx に一致する局にだけ runCommitGame へ hangInject を渡す。
    */
   hangInject?: { gameIdx: number; spec: HangInjectSpec };
+  /**
+   * 各局に渡す PRNG シードを算出する関数。指定時、局ごとの gameSeed を
+   * `getGameSeed(gameIdx)` で決めて runCommitGame に渡す。
+   * randomFactor > 0 のとき「同一 baseSeed → 同一棋譜」を保証するのに使う。
+   * 未指定なら worker 側は Math.random にフォールバック（従来挙動）。
+   */
+  getGameSeed?: (gameIdx: number) => number;
 }
 
 // ============================================================================
@@ -281,6 +294,7 @@ export async function runMatch(
     recreatePair,
     onHang,
     hangInject,
+    getGameSeed,
   } = params;
 
   const wdl: WDLCount = { wins: 0, draws: 0, losses: 0 };
@@ -288,6 +302,7 @@ export async function runMatch(
   let completedGames = 0;
   let stoppedBySprt = false;
   let aborts = 0;
+  const abortsBySide = { A: 0, B: 0 };
 
   const cumAcc = { A: newAcc(), B: newAcc() };
 
@@ -312,12 +327,14 @@ export async function runMatch(
         hangInject !== undefined && hangInject.gameIdx === taskIdx
           ? hangInject.spec
           : undefined;
+      const gameSeed = getGameSeed ? getGameSeed(taskIdx) : undefined;
       try {
         const r = await runCommitGame(pair.a, pair.b, isABlack, {
           verbose,
           moveTimeoutMs,
           openingMoves: positions,
           hangInject: injectHere,
+          gameSeed,
         });
         result = { ...r, jushuName };
       } catch (err: unknown) {
@@ -347,6 +364,11 @@ export async function runMatch(
           }
         }
         aborts++;
+        // side 別集計: ハングした側（A/B）に加算。ハングじゃない例外（worker死等）
+        // は側が特定できないので aborts のみ加算する。
+        if (isHang) {
+          abortsBySide[err.context.side]++;
+        }
         try {
           pair.a.terminate();
           pair.b.terminate();
@@ -466,5 +488,5 @@ export async function runMatch(
 
   clearStatus();
 
-  return { wdl, games, completedGames, stoppedBySprt, aborts };
+  return { wdl, games, completedGames, stoppedBySprt, aborts, abortsBySide };
 }

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -22,7 +22,12 @@ import {
   getAllJushuNames,
   getJushuPositions,
 } from "../../src/logic/cpu/opening.ts";
-import { runCommitGame } from "../commit-game-runner.ts";
+import {
+  GameHangError,
+  type HangContext,
+  type HangInjectSpec,
+  runCommitGame,
+} from "../commit-game-runner.ts";
 import { estimateEloDiff } from "./eloDiff.ts";
 import { updateSPRT } from "./sprt.ts";
 
@@ -33,12 +38,25 @@ export interface MatchTask {
   isABlack: boolean;
 }
 
+/** ハング局のメタ情報（caller のダンプ作成用） */
+export interface HangMatchInfo {
+  gameIdx: number;
+  jushuName: string;
+  isABlack: boolean;
+  pairIdx: number;
+}
+
 /** runMatch の結果（caller が後処理＝性能統計や保存を行う）。 */
 export interface RunMatchResult {
   wdl: WDLCount;
   games: CommitGameResult[];
   completedGames: number;
   stoppedBySprt: boolean;
+  /**
+   * ハング等で破棄された局数（recreatePair 指定時のみ発生しうる）。
+   * 未破棄なら常に 0。既存 caller が field を読まなくても影響しない。
+   */
+  aborts: number;
 }
 
 export interface RunMatchParams {
@@ -59,6 +77,18 @@ export interface RunMatchParams {
    * **未指定なら旧挙動**（エラーを伝播＝commit-bench を出力同一に保つ）。
    */
   recreatePair?: (idx: number) => Promise<{ a: Worker; b: Worker }>;
+  /**
+   * ハング（GameHangError）が起きたときに呼ばれる。ダンプ書き出し等の副作用を行う。
+   * recreatePair と併用したときのみ呼ばれる（recreatePair 未指定＝旧挙動でエラーを
+   * 伝播するときは、caller にはハング固有の情報が届かず onHang が意味を持たないため）。
+   */
+  onHang?: (context: HangContext, info: HangMatchInfo) => void;
+  /**
+   * テスト用: 特定の gameIdx（0-based, tasks 配列上のインデックス）に到達した局で
+   * ハング注入を行う。ハング回復パスの手動 e2e テストに使う。
+   * gameIdx が現在の taskIdx に一致する局にだけ runCommitGame へ hangInject を渡す。
+   */
+  hangInject?: { gameIdx: number; spec: HangInjectSpec };
 }
 
 // ============================================================================
@@ -249,12 +279,15 @@ export async function runMatch(
     verbose,
     startTime,
     recreatePair,
+    onHang,
+    hangInject,
   } = params;
 
   const wdl: WDLCount = { wins: 0, draws: 0, losses: 0 };
   const games: CommitGameResult[] = [];
   let completedGames = 0;
   let stoppedBySprt = false;
+  let aborts = 0;
 
   const cumAcc = { A: newAcc(), B: newAcc() };
 
@@ -275,11 +308,16 @@ export async function runMatch(
       const { jushuName, positions, isABlack } = tasks[taskIdx]!;
 
       let result: CommitGameResult | null = null;
+      const injectHere =
+        hangInject !== undefined && hangInject.gameIdx === taskIdx
+          ? hangInject.spec
+          : undefined;
       try {
         const r = await runCommitGame(pair.a, pair.b, isABlack, {
           verbose,
           moveTimeoutMs,
           openingMoves: positions,
+          hangInject: injectHere,
         });
         result = { ...r, jushuName };
       } catch (err: unknown) {
@@ -288,16 +326,35 @@ export async function runMatch(
           throw err;
         }
         // 1局隔離: ハング/worker死。当該局は破棄し worker を再生成して続行。
+        const isHang = err instanceof GameHangError;
         const msg = err instanceof Error ? err.message : String(err);
         clearStatus();
         console.warn(
-          `\n⚠ 局 ${jushuName}(${isABlack ? "A黒" : "A白"}) を破棄: ${msg}`,
+          `\n⚠ 局 g${taskIdx} ${jushuName}(${isABlack ? "A黒" : "A白"}) を破棄: ${msg}`,
         );
+        if (isHang && onHang) {
+          try {
+            onHang(err.context, {
+              gameIdx: taskIdx,
+              jushuName,
+              isABlack,
+              pairIdx,
+            });
+          } catch (dumpErr: unknown) {
+            const dm =
+              dumpErr instanceof Error ? dumpErr.message : String(dumpErr);
+            console.error(`onHang ダンプ処理でエラー: ${dm}`);
+          }
+        }
+        aborts++;
         try {
           pair.a.terminate();
           pair.b.terminate();
           pair = await recreatePair(pairIdx);
           pairs[pairIdx] = pair;
+          console.warn(
+            `↳ worker pair (idx=${pairIdx}) 再生成完了。残り局を継続します。`,
+          );
         } catch (reErr: unknown) {
           const m = reErr instanceof Error ? reErr.message : String(reErr);
           console.error(`worker 再生成に失敗（このペアを終了）: ${m}`);
@@ -409,5 +466,5 @@ export async function runMatch(
 
   clearStatus();
 
-  return { wdl, games, completedGames, stoppedBySprt };
+  return { wdl, games, completedGames, stoppedBySprt, aborts };
 }

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -172,6 +172,12 @@ export interface CreateBridgeWorkerParams {
    * customParams 経由で mergeDifficultyParams に注入される）。
    */
   maxNodes?: number;
+  /**
+   * 探索の depth cap オーバーライド。未指定なら difficulty 既定を使う。
+   * DifficultyParams.depth に写される。iterative deepening の上限。
+   * probe OFF/深さ探索レバーが depth cap で頭打ちになるのを避けるためのレバー。
+   */
+  maxDepth?: number;
 }
 
 /**
@@ -183,11 +189,13 @@ export function buildBridgeCustomParams(
   randomFactor: number | undefined,
   evaluationOptions: Partial<EvaluationOptions> | undefined,
   maxNodes?: number,
+  maxDepth?: number,
 ): Partial<DifficultyParams> | undefined {
   if (
     randomFactor === undefined &&
     evaluationOptions === undefined &&
-    maxNodes === undefined
+    maxNodes === undefined &&
+    maxDepth === undefined
   ) {
     return undefined;
   }
@@ -200,6 +208,11 @@ export function buildBridgeCustomParams(
   }
   if (maxNodes !== undefined) {
     customParams.maxNodes = maxNodes;
+  }
+  if (maxDepth !== undefined) {
+    // DifficultyParams.depth = iterative deepening の上限。maxDepth の名前は
+    // ベンチ CLI の flag に合わせ、ここで DifficultyParams.depth に写す。
+    customParams.depth = maxDepth;
   }
   return customParams;
 }
@@ -219,12 +232,14 @@ export function createBridgeWorker(
     bookEnabled,
     threatProbeEnabled,
     maxNodes,
+    maxDepth,
   } = params;
   return new Promise<Worker>((resolve, reject) => {
     const customParams = buildBridgeCustomParams(
       randomFactor,
       evaluationOptions,
       maxNodes,
+      maxDepth,
     );
 
     const worker = new Worker(workerPath, {

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -165,18 +165,30 @@ export interface CreateBridgeWorkerParams {
    * スキップされる（fallback で ON 相当）。
    */
   threatProbeEnabled?: boolean;
+  /**
+   * 探索の maxNodes オーバーライド。未指定なら difficulty 既定を使う。
+   * 「同じ持ち時間でノード上限が実質非拘束なら深読みが Elo に転換するか」を
+   * 測るための実行時レバー（randomFactor/evaluationOptions と同じ流儀で
+   * customParams 経由で mergeDifficultyParams に注入される）。
+   */
+  maxNodes?: number;
 }
 
 /**
  * createBridgeWorker に渡す customParams を組み立てる（純粋関数・単体テスト用に export）。
- * randomFactor / evaluationOptions のいずれも未指定なら undefined を返し、
+ * randomFactor / evaluationOptions / maxNodes のいずれも未指定なら undefined を返し、
  * 既存呼び出し（weight-bench 等）の挙動を完全に保つ。
  */
 export function buildBridgeCustomParams(
   randomFactor: number | undefined,
   evaluationOptions: Partial<EvaluationOptions> | undefined,
+  maxNodes?: number,
 ): Partial<DifficultyParams> | undefined {
-  if (randomFactor === undefined && evaluationOptions === undefined) {
+  if (
+    randomFactor === undefined &&
+    evaluationOptions === undefined &&
+    maxNodes === undefined
+  ) {
     return undefined;
   }
   const customParams: Partial<DifficultyParams> = {};
@@ -185,6 +197,9 @@ export function buildBridgeCustomParams(
   }
   if (evaluationOptions !== undefined) {
     customParams.evaluationOptions = evaluationOptions as EvaluationOptions;
+  }
+  if (maxNodes !== undefined) {
+    customParams.maxNodes = maxNodes;
   }
   return customParams;
 }
@@ -203,11 +218,13 @@ export function createBridgeWorker(
     evaluationOptions,
     bookEnabled,
     threatProbeEnabled,
+    maxNodes,
   } = params;
   return new Promise<Worker>((resolve, reject) => {
     const customParams = buildBridgeCustomParams(
       randomFactor,
       evaluationOptions,
+      maxNodes,
     );
 
     const worker = new Worker(workerPath, {

--- a/scripts/lib/mulberry32.test.ts
+++ b/scripts/lib/mulberry32.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { mixSeed, mulberry32 } from "./mulberry32.ts";
+
+describe("mulberry32", () => {
+  it("同一 seed からは同一シーケンスを返す（決定性）", () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    const seqA = Array.from({ length: 20 }, () => a());
+    const seqB = Array.from({ length: 20 }, () => b());
+    expect(seqA).toEqual(seqB);
+  });
+
+  it("異なる seed からは異なるシーケンスを返す（衝突しない）", () => {
+    const a = mulberry32(42);
+    const b = mulberry32(43);
+    const va = a();
+    const vb = b();
+    expect(va).not.toBe(vb);
+  });
+
+  it("値は [0, 1) の範囲に収まる", () => {
+    const r = mulberry32(12345);
+    for (let i = 0; i < 1000; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("seed=0 でも動作する（内部加算があるため縮退しない）", () => {
+    const r = mulberry32(0);
+    const v1 = r();
+    const v2 = r();
+    expect(v1).not.toBe(v2);
+    expect(v1).toBeGreaterThanOrEqual(0);
+    expect(v1).toBeLessThan(1);
+  });
+});
+
+describe("mixSeed", () => {
+  it("同じ入力なら同じ出力（決定性）", () => {
+    expect(mixSeed(42, 0)).toBe(mixSeed(42, 0));
+    expect(mixSeed(42, 0, 3)).toBe(mixSeed(42, 0, 3));
+  });
+
+  it("引数の順序で結果が変わる（順序依存）", () => {
+    expect(mixSeed(1, 2)).not.toBe(mixSeed(2, 1));
+  });
+
+  it("gameIdx 違いで大量に衝突しない（実運用範囲を粗くチェック）", () => {
+    const baseSeed = 12345;
+    const seen = new Set<number>();
+    for (let g = 0; g < 200; g++) {
+      seen.add(mixSeed(baseSeed, g));
+    }
+    // 200 種類の gameIdx で 200 種類近い seed が出ることを要求（衝突 1〜2 は許容）
+    expect(seen.size).toBeGreaterThanOrEqual(198);
+  });
+
+  it("moveOrdinal 違いでも大量に衝突しない（1局あたり最大 ~200 手を想定）", () => {
+    const perGameSeed = mixSeed(12345, 7);
+    const seen = new Set<number>();
+    for (let m = 0; m < 200; m++) {
+      seen.add(mixSeed(perGameSeed, m));
+    }
+    expect(seen.size).toBeGreaterThanOrEqual(198);
+  });
+});

--- a/scripts/lib/mulberry32.ts
+++ b/scripts/lib/mulberry32.ts
@@ -1,0 +1,42 @@
+/**
+ * 決定的疑似乱数生成器（mulberry32）と、複合キーからシードを合成する mix 関数。
+ *
+ * ベンチマークで「同一 --seed なら同一棋譜」を保証するために使う。
+ * commit-bench の CLI --seed で baseSeed を固定し、局ごとの実効 seed は
+ * `mixSeed(baseSeed, gameIdx)`、bridge worker の 1 手ごとの seed は
+ * さらに `mixSeed(perGameSeed, moveOrdinal)` で導出する（stateless per-move）。
+ *
+ * 実装は Tommy Ettinger の mulberry32 - 32-bit 状態、周期 2^32、高速。
+ * ベンチマーク用途（脅威判定の代替ではない）なので暗号強度は不要。
+ */
+
+/**
+ * seed から (0, 1) の一様乱数を返す関数を作る。
+ * mulberry32 は seed=0 でも合法（内部で加算するため）。
+ */
+export function mulberry32(seed: number): () => number {
+  // 32-bit に切り詰めておく（負値でも動くが挙動を単純化するため）
+  let a = seed | 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * 複数の整数キーを合成して 32-bit シードを作る。
+ * `hashCombine(a, b) = (a * 31 + b) | 0` 相当を FNV っぽく混ぜたもの。
+ * 目的は「異なる (a, b) から異なる seed が高確率で得られる」だけで、
+ * 全単射でも一様性でもない。ベンチ用途には十分。
+ */
+export function mixSeed(...keys: number[]): number {
+  let h = 0x811c9dc5 | 0; // FNV-1a offset basis
+  for (const k of keys) {
+    h ^= k | 0;
+    h = Math.imul(h, 0x01000193); // FNV prime
+  }
+  return h | 0;
+}

--- a/scripts/lib/parseHangInjectEnv.test.ts
+++ b/scripts/lib/parseHangInjectEnv.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { parseHangInjectEnv } from "./parseHangInjectEnv.ts";
+
+describe("parseHangInjectEnv", () => {
+  it("undefined なら null（無効化＝正常）", () => {
+    expect(parseHangInjectEnv(undefined)).toEqual({ kind: "ok", value: null });
+  });
+
+  it("空文字列も null", () => {
+    expect(parseHangInjectEnv("")).toEqual({ kind: "ok", value: null });
+  });
+
+  it("gameIdx:requestOrdinal 2要素形式（side 省略）", () => {
+    expect(parseHangInjectEnv("3:5")).toEqual({
+      kind: "ok",
+      value: { gameIdx: 3, requestOrdinal: 5, side: undefined },
+    });
+  });
+
+  it("3要素形式で side=A", () => {
+    expect(parseHangInjectEnv("0:1:A")).toEqual({
+      kind: "ok",
+      value: { gameIdx: 0, requestOrdinal: 1, side: "A" },
+    });
+  });
+
+  it("3要素形式で side=B", () => {
+    expect(parseHangInjectEnv("7:12:B")).toEqual({
+      kind: "ok",
+      value: { gameIdx: 7, requestOrdinal: 12, side: "B" },
+    });
+  });
+
+  it("要素数が違えばエラー", () => {
+    const r = parseHangInjectEnv("1");
+    expect(r.kind).toBe("error");
+  });
+
+  it("gameIdx が数値でなければエラー", () => {
+    const r = parseHangInjectEnv("abc:1");
+    expect(r.kind).toBe("error");
+  });
+
+  it("gameIdx が負ならエラー", () => {
+    const r = parseHangInjectEnv("-1:1");
+    expect(r.kind).toBe("error");
+  });
+
+  it("requestOrdinal が 0 ならエラー（1-based）", () => {
+    const r = parseHangInjectEnv("0:0");
+    expect(r.kind).toBe("error");
+  });
+
+  it("requestOrdinal が数値でなければエラー", () => {
+    const r = parseHangInjectEnv("0:x");
+    expect(r.kind).toBe("error");
+  });
+
+  it("side が A/B 以外ならエラー", () => {
+    const r = parseHangInjectEnv("0:1:C");
+    expect(r.kind).toBe("error");
+  });
+});

--- a/scripts/lib/parseHangInjectEnv.ts
+++ b/scripts/lib/parseHangInjectEnv.ts
@@ -1,0 +1,66 @@
+/**
+ * `HANG_INJECT=<gameIdx>:<requestOrdinal>[:A|B]` 環境変数のパーサ。
+ *
+ * commit-bench でハング注入テスト用に読み取る。ハング注入自体はプロダクション
+ * パスに影響しない差し込み口で、bench の回復パス（timeout → dump → respawn）を
+ * 手動 e2e で発火させるためのもの。
+ *
+ * 呼び出し側で process.exit しやすいよう「妥当な値 or エラー」を union で返す。
+ */
+export interface HangInjectEnv {
+  gameIdx: number;
+  requestOrdinal: number;
+  side?: "A" | "B";
+}
+
+export type ParseHangInjectResult =
+  | { kind: "ok"; value: HangInjectEnv | null }
+  | { kind: "error"; message: string };
+
+/**
+ * raw が undefined/"" なら null（無効化＝正常）。値があるが不正なら error。
+ * side は "A" | "B" のみ許容、他は error。
+ */
+export function parseHangInjectEnv(
+  raw: string | undefined,
+): ParseHangInjectResult {
+  if (raw === undefined || raw === "") {
+    return { kind: "ok", value: null };
+  }
+  const parts = raw.split(":");
+  if (parts.length !== 2 && parts.length !== 3) {
+    return {
+      kind: "error",
+      message: `HANG_INJECT は "<gameIdx>:<requestOrdinal>[:A|B]" の形式で指定してください (got: ${raw})`,
+    };
+  }
+  const gameIdx = parseInt(parts[0]!, 10);
+  const requestOrdinal = parseInt(parts[1]!, 10);
+  if (!Number.isFinite(gameIdx) || gameIdx < 0) {
+    return {
+      kind: "error",
+      message: `HANG_INJECT gameIdx が不正 (got: ${parts[0]})`,
+    };
+  }
+  if (!Number.isFinite(requestOrdinal) || requestOrdinal < 1) {
+    return {
+      kind: "error",
+      message: `HANG_INJECT requestOrdinal は 1 以上の整数 (got: ${parts[1]})`,
+    };
+  }
+  const sideRaw = parts.length === 3 ? parts[2]! : undefined;
+  if (sideRaw !== undefined && sideRaw !== "A" && sideRaw !== "B") {
+    return {
+      kind: "error",
+      message: `HANG_INJECT side は A か B (got: ${sideRaw})`,
+    };
+  }
+  return {
+    kind: "ok",
+    value: {
+      gameIdx,
+      requestOrdinal,
+      side: sideRaw as "A" | "B" | undefined,
+    },
+  };
+}

--- a/scripts/lib/workerMoveTimeoutError.ts
+++ b/scripts/lib/workerMoveTimeoutError.ts
@@ -1,0 +1,31 @@
+/**
+ * askWorker（commit-game-runner）が move-request timeout を検知したときに
+ * throw する低レベルエラー。上位（runCommitGame）が catch して盤面/履歴を
+ * 添えた GameHangError に変換する。
+ *
+ * commit-game-runner.ts から切り出しているのは、max-classes-per-file lint を
+ * 満たすためと、bench 以外の caller（将来の replay 用ハーネス等）から
+ * 「単純な timeout として拾って再 raise しない」ケースにも使いたいため。
+ */
+export class WorkerMoveTimeoutError extends Error {
+  readonly requestId: number;
+  readonly timeoutMs: number;
+  readonly color: "black" | "white";
+  readonly side: "A" | "B";
+
+  constructor(params: {
+    requestId: number;
+    timeoutMs: number;
+    color: "black" | "white";
+    side: "A" | "B";
+  }) {
+    super(
+      `Worker move request timed out (requestId=${params.requestId}, side=${params.side}, color=${params.color}, timeoutMs=${params.timeoutMs})`,
+    );
+    this.name = "WorkerMoveTimeoutError";
+    this.requestId = params.requestId;
+    this.timeoutMs = params.timeoutMs;
+    this.color = params.color;
+    this.side = params.side;
+  }
+}

--- a/scripts/replay-hang.ts
+++ b/scripts/replay-hang.ts
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+/**
+ * ハングダンプ再現スクリプト
+ *
+ * commit-bench の HANG_DUMPS_DIR に書かれた `hang-*.json` を読み、ハングした側と
+ * 同じ worktree/難易度/randomFactor/evaluationOptions/bookEnabled で bridge worker
+ * を起動して、記録されていた盤面・手番色で1手だけ要求する。
+ *
+ * 使い方:
+ *   pnpm exec-script scripts/replay-hang.ts bench-results/hang-dumps/hang-XXX.json
+ *   # または直接 node で:
+ *   node --experimental-strip-types --disable-warning=ExperimentalWarning \
+ *     --import ./scripts/register-loader.mjs scripts/replay-hang.ts <dump-path>
+ *
+ * オプション:
+ *   --timeout-ms=<N>   watchdog タイムアウト（既定 60000ms）
+ *   --verbose          レスポンス JSON を出力
+ *
+ * 出力:
+ *   - dump のメタ情報（side/color/moveNumber/commit/eval options）
+ *   - watchdog タイムアウトまでに応答が返れば所要時間・返された着手・depth・score
+ *   - 返らなければ "HANG (timed out)" を表示して非0終了
+ *
+ * このスクリプトはハング局面を再現できるかを確認するためのもので、bench 全体を
+ * 走らせずに再現条件を絞り込む。
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+
+import type { EvaluationOptions } from "../src/logic/cpu/evaluation/patternScores.ts";
+import type { BoardState, Position } from "../src/types/game.ts";
+
+import { buildBridgeCustomParams } from "./lib/match.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ============================================================================
+// 型定義（ダンプ JSON の最低限のスキーマ）
+// ============================================================================
+
+interface HangDumpJson {
+  type: "hang-dump";
+  schemaVersion: number;
+  timestamp: string;
+  bench: {
+    tool: string;
+    difficulty: string;
+    randomFactor: number | undefined;
+    moveTimeoutMs: number;
+  };
+  match: {
+    gameIdx: number;
+    jushuName: string;
+    isABlack: boolean;
+    pairIdx: number;
+  };
+  hang: {
+    side: "A" | "B";
+    color: "black" | "white";
+    requestId: number;
+    timeoutMs: number;
+    elapsedMs: number;
+    moveNumber: number;
+  };
+  worker: {
+    side: "A" | "B";
+    worktreePath: string;
+    commit: { sha: string; shortSha: string; message: string; date: string };
+    difficulty: string;
+    randomFactor: number | undefined;
+    evaluationOptions: Partial<EvaluationOptions> | undefined;
+    bookEnabled: boolean;
+    color: "black" | "white";
+  };
+  opponent: unknown;
+  board: BoardState;
+  moveHistory: unknown;
+}
+
+interface CliOptions {
+  dumpPath: string;
+  timeoutMs: number;
+  verbose: boolean;
+  /**
+   * ダンプ記録時の worktree が既に消えている場合、その sha から
+   * 元と同じパスに worktree を作り直す（pnpm install / build:wasm も実施）。
+   * 既定 ON（現場運用ではダンプ後に bench の finally で消えているのが普通）。
+   */
+  recreateWorktree: boolean;
+}
+
+// ============================================================================
+// CLI
+// ============================================================================
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const options: CliOptions = {
+    dumpPath: "",
+    timeoutMs: 60000,
+    verbose: false,
+    recreateWorktree: true,
+  };
+  for (const arg of args) {
+    if (arg.startsWith("--timeout-ms=")) {
+      const v = parseInt(arg.slice("--timeout-ms=".length), 10);
+      if (!isNaN(v) && v > 0) {
+        options.timeoutMs = v;
+      }
+    } else if (arg === "--verbose" || arg === "-v") {
+      options.verbose = true;
+    } else if (arg === "--no-recreate-worktree") {
+      options.recreateWorktree = false;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: replay-hang <dump-path> [--timeout-ms=60000] [--verbose] [--no-recreate-worktree]",
+      );
+      process.exit(0);
+    } else if (arg.startsWith("--")) {
+      console.error(`Error: 不明な引数: ${arg}`);
+      process.exit(1);
+    } else {
+      options.dumpPath = arg;
+    }
+  }
+  if (options.dumpPath === "") {
+    console.error("Error: ダンプファイルのパスを指定してください");
+    console.error(
+      "Usage: replay-hang <dump-path> [--timeout-ms=60000] [--verbose] [--no-recreate-worktree]",
+    );
+    process.exit(1);
+  }
+  return options;
+}
+
+/**
+ * ダンプに書かれた worktreePath が存在しなければ、commit sha から作り直す。
+ * commit-bench の createWorktree と同等（node_modules と wasm も揃える）。
+ * 副作用で worktree を追加する。呼び出し元に removal は任せる（プロセス終了で
+ * 残るが、次回 commit-bench が同じ label で作り直すときに --force で消える）。
+ */
+function ensureWorktree(dump: HangDumpJson): void {
+  const wt = dump.worker.worktreePath;
+  if (fs.existsSync(path.join(wt, "scripts", "register-loader.mjs"))) {
+    return;
+  }
+  const { sha } = dump.worker.commit;
+  console.log(
+    `worktree が存在しないため sha=${dump.worker.commit.shortSha} から作り直します: ${wt}`,
+  );
+
+  // worktree ディレクトリの親（.git/worktrees-bench 相当）を作る
+  const parent = path.dirname(wt);
+  if (!fs.existsSync(parent)) {
+    fs.mkdirSync(parent, { recursive: true });
+  }
+
+  // 既存の git worktree レコード（壊れた prune 前のもの）を掃除
+  try {
+    execSync(`git worktree remove --force "${wt}"`, { stdio: "pipe" });
+  } catch {
+    // ignore — 元々ない可能性が高い
+  }
+
+  execSync(`git worktree add "${wt}" ${sha}`, { stdio: "inherit" });
+
+  if (!fs.existsSync(path.join(wt, "node_modules"))) {
+    console.log("pnpm install (--ignore-scripts)...");
+    execSync("pnpm install --frozen-lockfile --ignore-scripts", {
+      cwd: wt,
+      stdio: "inherit",
+    });
+  }
+
+  const wasmPath = path.join(wt, "zig", "zig-out", "bin", "cpu-engine.wasm");
+  if (
+    !fs.existsSync(wasmPath) &&
+    fs.existsSync(path.join(wt, "zig", "build.zig"))
+  ) {
+    console.log("WASM をビルド中 (pnpm build:wasm)...");
+    execSync("pnpm build:wasm", { cwd: wt, stdio: "inherit" });
+  }
+
+  // register-loader.mjs / loader.ts をコピー（commit-bench の createWorktree と同等）
+  const wtLoaderMjs = path.join(wt, "scripts", "register-loader.mjs");
+  if (!fs.existsSync(wtLoaderMjs)) {
+    fs.copyFileSync(path.join(__dirname, "register-loader.mjs"), wtLoaderMjs);
+  }
+  const wtLoaderTs = path.join(wt, "scripts", "loader.ts");
+  if (!fs.existsSync(wtLoaderTs)) {
+    fs.copyFileSync(path.join(__dirname, "loader.ts"), wtLoaderTs);
+  }
+}
+
+function loadDump(dumpPath: string): HangDumpJson {
+  const abs = path.resolve(dumpPath);
+  if (!fs.existsSync(abs)) {
+    console.error(`Error: ダンプファイルが見つかりません: ${abs}`);
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(abs, "utf-8");
+  const parsed = JSON.parse(raw) as HangDumpJson;
+  if (parsed.type !== "hang-dump") {
+    console.error(
+      `Error: type=hang-dump ではありません (got: ${parsed.type as string})`,
+    );
+    process.exit(1);
+  }
+  return parsed;
+}
+
+// ============================================================================
+// bridge worker 起動
+// ============================================================================
+
+function spawnBridgeWorker(dump: HangDumpJson): Promise<Worker> {
+  const workerPath = path.join(__dirname, "cpu-bridge-worker.ts");
+  const loaderPath = path.join(
+    dump.worker.worktreePath,
+    "scripts",
+    "register-loader.mjs",
+  );
+  if (!fs.existsSync(loaderPath)) {
+    console.error(
+      `Error: worktree の register-loader.mjs が見つかりません: ${loaderPath}\n` +
+        `  --no-recreate-worktree で明示的に無効化されているか、作り直しに失敗しています。`,
+    );
+    process.exit(1);
+  }
+
+  const customParams = buildBridgeCustomParams(
+    dump.worker.randomFactor,
+    dump.worker.evaluationOptions,
+  );
+
+  return new Promise<Worker>((resolve, reject) => {
+    const worker = new Worker(workerPath, {
+      workerData: {
+        worktreePath: dump.worker.worktreePath,
+        difficulty: dump.worker.difficulty,
+        customParams,
+        bookEnabled: dump.worker.bookEnabled,
+      },
+      execArgv: [
+        "--experimental-strip-types",
+        "--disable-warning=ExperimentalWarning",
+        "--import",
+        loaderPath,
+      ],
+    });
+
+    const initTimer = setTimeout(() => {
+      worker.terminate();
+      reject(new Error("bridge worker の初期化がタイムアウト (60s)"));
+    }, 60000);
+
+    const readyHandler = (msg: unknown): void => {
+      if (
+        typeof msg === "object" &&
+        msg !== null &&
+        "ready" in msg &&
+        (msg as { ready: unknown }).ready === true
+      ) {
+        clearTimeout(initTimer);
+        worker.off("message", readyHandler);
+        resolve(worker);
+      }
+    };
+    worker.on("message", readyHandler);
+    worker.on("error", (err) => {
+      clearTimeout(initTimer);
+      reject(err);
+    });
+  });
+}
+
+// ============================================================================
+// 1手要求（watchdog 付き）
+// ============================================================================
+
+interface MoveResponse {
+  requestId: number;
+  position: Position;
+  score: number;
+  depth: number;
+  thinkingTimeMs: number;
+  interrupted: boolean;
+  stats?: Record<string, number>;
+}
+
+interface ReplayOutcome {
+  status: "responded" | "timed-out" | "error";
+  elapsedMs: number;
+  response?: MoveResponse;
+  errorMessage?: string;
+}
+
+function requestMoveWithWatchdog(
+  worker: Worker,
+  board: BoardState,
+  color: "black" | "white",
+  timeoutMs: number,
+): Promise<ReplayOutcome> {
+  return new Promise<ReplayOutcome>((resolve) => {
+    const requestId = 1;
+    const start = performance.now();
+
+    const timer = setTimeout(() => {
+      worker.off("message", handler);
+      resolve({
+        status: "timed-out",
+        elapsedMs: performance.now() - start,
+      });
+    }, timeoutMs);
+
+    const handler = (msg: unknown): void => {
+      if (
+        typeof msg === "object" &&
+        msg !== null &&
+        "requestId" in msg &&
+        (msg as { requestId: unknown }).requestId === requestId
+      ) {
+        worker.off("message", handler);
+        clearTimeout(timer);
+        const elapsedMs = performance.now() - start;
+        if ("error" in msg) {
+          resolve({
+            status: "error",
+            elapsedMs,
+            errorMessage: String((msg as { error: unknown }).error),
+          });
+        } else {
+          resolve({
+            status: "responded",
+            elapsedMs,
+            response: msg as MoveResponse,
+          });
+        }
+      }
+    };
+    worker.on("message", handler);
+    worker.postMessage({ requestId, board, color });
+  });
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+  const dump = loadDump(options.dumpPath);
+
+  console.log(`\n=== Hang Dump Replay ===`);
+  console.log(`dump: ${path.resolve(options.dumpPath)}`);
+  console.log(`timestamp: ${dump.timestamp}`);
+  console.log(
+    `match: g${dump.match.gameIdx} ${dump.match.jushuName} (${dump.match.isABlack ? "A黒" : "A白"})`,
+  );
+  console.log(
+    `hang: side=${dump.hang.side} color=${dump.hang.color} moveNumber=${dump.hang.moveNumber} elapsedMs=${Math.round(dump.hang.elapsedMs)} original-timeoutMs=${dump.hang.timeoutMs}`,
+  );
+  console.log(
+    `worker: ${dump.worker.commit.shortSha} "${dump.worker.commit.message}"`,
+  );
+  console.log(`  worktree: ${dump.worker.worktreePath}`);
+  console.log(
+    `  difficulty=${dump.worker.difficulty} randomFactor=${dump.worker.randomFactor ?? "unset"} bookEnabled=${dump.worker.bookEnabled}`,
+  );
+  console.log(
+    `  evaluationOptions: ${dump.worker.evaluationOptions ? JSON.stringify(dump.worker.evaluationOptions) : "(未指定)"}`,
+  );
+  console.log(`watchdog: ${options.timeoutMs}ms\n`);
+
+  if (options.recreateWorktree) {
+    ensureWorktree(dump);
+  }
+
+  console.log(`bridge worker を起動中...`);
+  const worker = await spawnBridgeWorker(dump);
+  console.log(`起動完了。1手要求を送信します...\n`);
+
+  const outcome = await requestMoveWithWatchdog(
+    worker,
+    dump.board,
+    dump.hang.color,
+    options.timeoutMs,
+  );
+  worker.terminate();
+
+  const elapsedS = (outcome.elapsedMs / 1000).toFixed(2);
+  console.log(`\n=== 結果 ===`);
+  if (outcome.status === "responded") {
+    const r = outcome.response!;
+    console.log(`✓ RESPONDED in ${elapsedS}s`);
+    console.log(
+      `  move: (${r.position.row}, ${r.position.col}) score=${r.score} depth=${r.depth} thinkingTimeMs=${Math.round(r.thinkingTimeMs)}`,
+    );
+    if (options.verbose && r.stats) {
+      console.log(`  stats: ${JSON.stringify(r.stats)}`);
+    }
+    console.log(
+      `\n※ 再現せず。ダンプ時のハングは非決定的（TT/randomFactor/実行環境）か、` +
+        `wasm 側の状態依存の可能性があります。`,
+    );
+    process.exit(0);
+  }
+  if (outcome.status === "timed-out") {
+    console.log(
+      `✗ HANG REPRODUCED — worker did not respond within ${elapsedS}s`,
+    );
+    console.log(
+      `  ダンプと同じ盤面・設定でハングが再現しました。この局面が根本原因調査の対象です。`,
+    );
+    process.exit(2);
+  }
+  console.log(`⚠ ERROR: ${outcome.errorMessage}`);
+  process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+});

--- a/scripts/replay-hang.ts
+++ b/scripts/replay-hang.ts
@@ -31,55 +31,13 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 
-import type { EvaluationOptions } from "../src/logic/cpu/evaluation/patternScores.ts";
 import type { BoardState, Position } from "../src/types/game.ts";
+import type { HangDumpJson } from "./lib/hangDump.ts";
 
 import { buildBridgeCustomParams } from "./lib/match.ts";
+import { mixSeed } from "./lib/mulberry32.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-// ============================================================================
-// 型定義（ダンプ JSON の最低限のスキーマ）
-// ============================================================================
-
-interface HangDumpJson {
-  type: "hang-dump";
-  schemaVersion: number;
-  timestamp: string;
-  bench: {
-    tool: string;
-    difficulty: string;
-    randomFactor: number | undefined;
-    moveTimeoutMs: number;
-  };
-  match: {
-    gameIdx: number;
-    jushuName: string;
-    isABlack: boolean;
-    pairIdx: number;
-  };
-  hang: {
-    side: "A" | "B";
-    color: "black" | "white";
-    requestId: number;
-    timeoutMs: number;
-    elapsedMs: number;
-    moveNumber: number;
-  };
-  worker: {
-    side: "A" | "B";
-    worktreePath: string;
-    commit: { sha: string; shortSha: string; message: string; date: string };
-    difficulty: string;
-    randomFactor: number | undefined;
-    evaluationOptions: Partial<EvaluationOptions> | undefined;
-    bookEnabled: boolean;
-    color: "black" | "white";
-  };
-  opponent: unknown;
-  board: BoardState;
-  moveHistory: unknown;
-}
 
 interface CliOptions {
   dumpPath: string;
@@ -304,6 +262,7 @@ function requestMoveWithWatchdog(
   board: BoardState,
   color: "black" | "white",
   timeoutMs: number,
+  moveSeed: number | undefined,
 ): Promise<ReplayOutcome> {
   return new Promise<ReplayOutcome>((resolve) => {
     const requestId = 1;
@@ -343,7 +302,7 @@ function requestMoveWithWatchdog(
       }
     };
     worker.on("message", handler);
-    worker.postMessage({ requestId, board, color });
+    worker.postMessage({ requestId, board, color, moveSeed });
   });
 }
 
@@ -374,6 +333,17 @@ async function main(): Promise<void> {
   console.log(
     `  evaluationOptions: ${dump.worker.evaluationOptions ? JSON.stringify(dump.worker.evaluationOptions) : "(未指定)"}`,
   );
+  // gameSeed とハング時の非オープニング要求番号から moveSeed を復元。
+  // ダンプ側でこれらが両方あれば、randomFactor の近傍ランダム化まで再現できる。
+  const nonOpeningOrdinal =
+    dump.hang.moveNumber - dump.moveHistory.filter((m) => m.isOpening).length;
+  const moveSeed =
+    dump.match.gameSeed !== undefined && nonOpeningOrdinal >= 1
+      ? mixSeed(dump.match.gameSeed, nonOpeningOrdinal)
+      : undefined;
+  console.log(
+    `  seed: gameSeed=${dump.match.gameSeed ?? "unset"} → moveSeed=${moveSeed ?? "unset"} (nonOpeningOrdinal=${nonOpeningOrdinal})`,
+  );
   console.log(`watchdog: ${options.timeoutMs}ms\n`);
 
   if (options.recreateWorktree) {
@@ -389,6 +359,7 @@ async function main(): Promise<void> {
     dump.board,
     dump.hang.color,
     options.timeoutMs,
+    moveSeed,
   );
   worker.terminate();
 

--- a/scripts/types/commit-bench.ts
+++ b/scripts/types/commit-bench.ts
@@ -70,6 +70,11 @@ export interface CommitBenchResult {
     maxNodesA?: number;
     maxNodesB?: number;
     /**
+     * depth cap オーバーライド（探索レバー A/B）。未指定なら difficulty 既定。
+     */
+    maxDepthA?: number;
+    maxDepthB?: number;
+    /**
      * PRNG baseSeed。--seed 指定時は明示値、未指定時は Date.now() の下位32bit。
      * randomFactor 未指定なら undefined（seed が意味を持たないため）。
      * 局ごとの実効 seed は mixSeed(seed, gameIdx) で導出される。

--- a/scripts/types/commit-bench.ts
+++ b/scripts/types/commit-bench.ts
@@ -59,6 +59,12 @@ export interface CommitBenchResult {
     bookA?: boolean;
     bookB?: boolean;
     /**
+     * 脅威プローブトグル（探索レバー A/B）。true=ON（従来挙動）、false=OFF。
+     * 記録なし＝ON 相当（後方互換 optional）。
+     */
+    threatProbeA?: boolean;
+    threatProbeB?: boolean;
+    /**
      * PRNG baseSeed。--seed 指定時は明示値、未指定時は Date.now() の下位32bit。
      * randomFactor 未指定なら undefined（seed が意味を持たないため）。
      * 局ごとの実効 seed は mixSeed(seed, gameIdx) で導出される。

--- a/scripts/types/commit-bench.ts
+++ b/scripts/types/commit-bench.ts
@@ -65,6 +65,11 @@ export interface CommitBenchResult {
     threatProbeA?: boolean;
     threatProbeB?: boolean;
     /**
+     * maxNodes オーバーライド（探索レバー A/B）。未指定なら difficulty 既定。
+     */
+    maxNodesA?: number;
+    maxNodesB?: number;
+    /**
      * PRNG baseSeed。--seed 指定時は明示値、未指定時は Date.now() の下位32bit。
      * randomFactor 未指定なら undefined（seed が意味を持たないため）。
      * 局ごとの実効 seed は mixSeed(seed, gameIdx) で導出される。

--- a/scripts/types/commit-bench.ts
+++ b/scripts/types/commit-bench.ts
@@ -58,6 +58,12 @@ export interface CommitBenchResult {
     /** ブックゲート（★v2プラン B3）: A/B 側それぞれでオープニングブックを有効化したか。 */
     bookA?: boolean;
     bookB?: boolean;
+    /**
+     * PRNG baseSeed。--seed 指定時は明示値、未指定時は Date.now() の下位32bit。
+     * randomFactor 未指定なら undefined（seed が意味を持たないため）。
+     * 局ごとの実効 seed は mixSeed(seed, gameIdx) で導出される。
+     */
+    seed?: number;
   };
   /** 対局数（実際に完走した局のみ。中断＝abort 局は含めない） */
   totalGames: number;
@@ -66,6 +72,11 @@ export interface CommitBenchResult {
    * 既存 JSON との後方互換のため optional（未設定＝0 相当）。
    */
   aborts?: number;
+  /**
+   * abort 局を側（A/B）別に集計。「劣勢側だけハングして負けが消える」
+   * バイアスの検出に使う。後方互換のため optional。
+   */
+  abortsBySide?: { A: number; B: number };
   /** WDL（commitA視点） */
   wdl: WDLCount;
   /** Elo差推定 */

--- a/scripts/types/commit-bench.ts
+++ b/scripts/types/commit-bench.ts
@@ -59,8 +59,13 @@ export interface CommitBenchResult {
     bookA?: boolean;
     bookB?: boolean;
   };
-  /** 対局数 */
+  /** 対局数（実際に完走した局のみ。中断＝abort 局は含めない） */
   totalGames: number;
+  /**
+   * ハング等で破棄された局数。回復パスが働いた回数。
+   * 既存 JSON との後方互換のため optional（未設定＝0 相当）。
+   */
+  aborts?: number;
   /** WDL（commitA視点） */
   wdl: WDLCount;
   /** Elo差推定 */


### PR DESCRIPTION
## 概要

commit-bench で稀に発生する「Worker move request timeout」（探索ハング疑い）が長時間ベンチ全体をクラッシュさせていた問題への計装と、レビューで発覚した **randomFactor ノーオペバグ**の修正。

## 変更内容

### ハング計装・耐性化
- タイムアウト時に再現ダンプ（棋譜・盤面・side・difficulty/evalOptions・シード・コミットSHA・jobs）を `bench-results/hang-dumps/` へ自動保存
- 該当局を abort として隔離し worker ペアを再生成してベンチ続行（プロセスを落とさない）。abort は **side 別に集計**し、非対称時は Elo バイアス警告を表示
- `HANG_INJECT` 環境変数で人工ハングを注入して回復パスを e2e 検証済み
- `scripts/replay-hang.ts`（`pnpm replay:hang`）: ダンプから worktree 再作成込みで単独再現を試みる調査道具

### randomFactor 修正（レビューで発覚した既存バグ）
- **WASM 専用化（4月）以降、`--randomFactor` は探索に無効だった**（bridge worker が WASM 呼び出しに渡していない）。過去ベンチのセット間ばらつきの実体はタイムリミット依存の深度ゆらぎ
- ブラウザ側 #102 と同方式（近傍 Chebyshev≤3 ランダム化・|score|≥800 スキップ・黒番禁手除外）を bridge worker に配線
- **シード付き PRNG（mulberry32）**: `--seed=<n>` → 局ごと/手ごとに決定的導出。実走確認: 同一 seed で 6 局全て同一棋譜、seed 変更で全局変化
- 旧コミット worktree に randomization.ts が無い場合は warn してスキップ（後方互換）

## 検証

- 単体テスト +20 件（mulberry32 9・parseHangInjectEnv 11）、全 163 件緑、check-fix 0 件、lefthook 全緑
- /review 3観点: パフォーマンス LGTM / SOLID・イシューの must 3 件は本 PR 2 コミット目で反映済み

## 留意点

randomFactor 実効化により、過去の r 指定ベンチの信頼区間は額面より広く解釈すべきです（Gate 2 の +181 など大差の結論は不変）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RM5iEfn2Aq5rU8eXe89NnZ
