### PR TITLE
test: #123 のカウンターフォー耐性の疑義を検証し回帰テストを追加

### DIFF
--- a/src/logic/cpu/review/vctCounterFourResilience.wasm.test.ts
+++ b/src/logic/cpu/review/vctCounterFourResilience.wasm.test.ts
@@ -1,0 +1,77 @@
+/**
+ * 白のカウンターフォーを挟んでも黒の追い詰めが残ることの回帰テスト（issue #123）
+ *
+ * 背景:
+ * #115 の棋譜 `H8 H7 G8 G9 I10 H9 J9 J10 K8 H11 L9 K9 I11 I9`（14 石・黒番）から
+ * 振り返りが返す追い詰めの 21 手目 `M8` は四ではなく三なので、白は受けを強制されず
+ * カウンターフォー（9 行目 `E9 _ G9 H9 I9` の E9 / 6 行目 `I6 _ K6 L6 M6` の K6）で
+ * テンポを取れる。この「テンポ喪失だけのカウンターフォー」を `ResilienceMode.lenient`
+ * が棄却しないのは偽の追い詰めではないか、という疑義が #123。
+ *
+ * Rapfi（Renju ルール、mix9svqrenju 重み）で検証した結果、疑義は否定された:
+ * - 14 石の根: best=J7 / Eval **+M17**
+ * - 21 石局面（M8 後・白番）: **-M24**（白がどう指しても詰み）
+ * - +E9: 黒 +M23 → +E9 F9: 白 -M22 → +E9 F9 N8: 黒 +M11
+ * - +K6: 黒 +M23 → +K6 J6: 白 -M22 → +K6 J6 N8: 黒 +M11
+ * - +E9 F9 K6 J6 N8（両方のカウンターフォーを消化）: 黒 +M9
+ * カウンターフォーは白のテンポを稼ぐだけで、黒の追い詰めは消えない。
+ *
+ * このテストは「カウンターフォーを消化した後の各分岐でも黒に強制勝ちが残る」ことと
+ * 「白の四が盤上にある間は追い詰めを主張しない（受けが先）」ことを固定する。
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createBoardFromRecord } from "@/logic/gameRecordParser";
+
+import { loadWasmModule } from "../wasm/loader";
+import { WasmSearchEngine } from "../wasm/searchEngine";
+import {
+  detectOpponentThreats,
+  preloadThreatWasm,
+} from "../wasm/threatAdapter";
+import { detectForcedWin } from "./forcedWinDetection";
+
+/** 実戦 14 手 + 追い詰め 15..21 手目（21 石・白番） */
+const AFTER_M8 =
+  "H8 H7 G8 G9 I10 H9 J9 J10 K8 H11 L9 K9 I11 I9 L7 M6 J7 I6 L8 L6 M8";
+
+const engine = new WasmSearchEngine(await loadWasmModule());
+await preloadThreatWasm();
+
+function hasFour(record: string, color: "black" | "white"): boolean {
+  const { board } = createBoardFromRecord(record);
+  const threats = detectOpponentThreats(board, color);
+  return threats.fours.length > 0 || threats.openFours.length > 0;
+}
+
+describe("VCT: 白のカウンターフォーを挟んでも追い詰めが残る（issue #123）", () => {
+  it.each([
+    ["白 E9 の四を消化した後", `${AFTER_M8} E9 F9 N8`],
+    ["白 K6 の四を消化した後", `${AFTER_M8} K6 J6 N8`],
+    ["白が E9・K6 両方の四を消化した後", `${AFTER_M8} E9 F9 K6 J6 N8`],
+  ])(
+    "%s も黒に強制勝ちが残る",
+    (_name, record) => {
+      const { board, nextColor } = createBoardFromRecord(record);
+      expect(nextColor).toBe("black");
+      expect(hasFour(record, "white")).toBe(false);
+
+      const result = detectForcedWin(board, "black", false, false, engine);
+      expect(result.forcedWin).not.toBeNull();
+    },
+    60_000,
+  );
+
+  it("白の四が盤上にある間は追い詰めを主張せず受けを促す", () => {
+    const record = `${AFTER_M8} E9`;
+    const { board, nextColor } = createBoardFromRecord(record);
+    expect(nextColor).toBe("black");
+    // 白 E9 で 9 行目が E9 _ G9 H9 I9 となり F9 が五点（四）。
+    expect(hasFour(record, "white")).toBe(true);
+
+    const result = detectForcedWin(board, "black", true, false, engine);
+    expect(result.forcedWin).toBeNull();
+    expect(result.forcedWinType).toBeUndefined();
+  }, 60_000);
+});


### PR DESCRIPTION
## 結論: エンジンは正しい（#123 の疑義は否定）

#123 は「21.M8 は三でしかなく、白は E9 / K6 のカウンターフォーでテンポを取れるので、
`ResilienceMode.lenient` が通している追い詰めは偽ではないか」という疑義でした。

Rapfi（Renju ルール = `INFO rule 4`、mix9svqrenju 重み）で検証したところ、**黒の追い詰めは本物**でした。
#123 に記録された「best=J7 / eval +469（詰みスコアでない）」は再現せず、同じ根で **+M17** が出ます。

### Rapfi 検証（各局面。符号は手番側視点）

| 局面 | 手番 | Rapfi |
| --- | --- | --- |
| 14 石の根 | 黒 | best=**J7** / **+M17**（depth 26, 5s）|
| +J7 | 白 | -M16 |
| +J7 I6 | 黒 | +M15 |
| +J7 I6 L7 | 白 | -M14 |
| +J7 I6 L7 M6 | 黒 | +M13 |
| +… L8 | 白 | -M26 |
| +… L8 L6 | 黒 | +M25 |
| **+… M8（21 石）** | 白 | **-M24**（白は何を指しても詰み。Rapfi の最善も K6 のカウンターフォー）|
| +… M8 N8 | 黒 | +M13 |
| +… M8 N8 K10 | 白 | -M12 |
| +… N7 / L11 / L10 / M12 | — | +M5 / -M4 / +M3 / -M2 |

カウンターフォー分岐も同様に黒勝ちでした。

| 分岐 | Rapfi |
| --- | --- |
| 21 石 + **E9**（白の四）| 黒 +M23（受け F9 強制）|
| + E9 F9 | 白 -M22 |
| + E9 F9 N8 | 黒 +M11 |
| + E9 F9 N8 K10 | 白 -M10 |
| 21 石 + **K6**（白の四）| 黒 +M23（受け J6 強制）|
| + K6 J6 | 白 -M22 |
| + K6 J6 N8 | 黒 +M11 |
| 21 石 + **E9 F9 K6 J6 N8**（白が四を両方消化）| 黒 +M9 |

Renju ルールが効いていることは、`F8 G8 H8 _ J8 K8`（I8 は長連で禁手）の局面で
Rapfi が I8 で即詰みを主張しないことを確認して裏取りしています。

### なぜカウンターフォーで崩れないか

21.M8 の 8 行目は `G8 H8 _ _ K8 L8 M8`。黒 N8 で `K8 L8 M8 N8` の達四になり、
五点 J8（J-K-L-M-N の五。I8 は空きなので長連にならない）と O8 の両方が生きています。
白の E9 / K6 はテンポを稼ぐだけで、受けの F9 / J6 は黒の達四筋にも 8 行目にも触れません。
むしろ J6 は J 列に `J6 J7 _ J9` の形を残し、黒に持ち駒が増えます。
実際、カウンターフォーを両方消化した後でも黒には両ミセ（M9）や
VCF（`L11 L10 M12`＝L 列の四 → J9-K10-L11-M12 の達四）が残ります。

つまり `ResilienceMode.lenient` が「テンポ喪失だけのカウンターフォーを棄却しない」のは、
この局面では正しい判断でした。

### 変更内容

エンジンの修正は不要なので、**回帰テストのみ**を追加します
（`src/logic/cpu/review/vctCounterFourResilience.wasm.test.ts`）。

- 白 E9 / K6 / 両方のカウンターフォーを消化した各局面で、黒に強制勝ちが残ることを固定
- 白の四が盤上にある間は `detectForcedWin` が追い詰めを主張しない（受けが先）ことを固定
  - #123 本文の「エンジン側の検証」は白の四を打った直後に黒番でもう一度黒を検索させる
    手番ずれで行われていた疑いがあるため、この境界を明示的に固定しておく

### テスト

- `pnpm vitest run src/logic/cpu/review/vctCounterFourResilience.wasm.test.ts` → 4 passed
- `pnpm test` → 122 files / 1880 tests passed
- `zig build test` → pass（pre-commit hook）
- `pnpm check-fix` → clean

### 対局 CPU への影響

なし（テスト追加のみ。`ResilienceMode` の既定は lenient のまま変更していない）。

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
