### PR TITLE
refactor: 四判定・受け点を classifyFourInDirection に SSoT 統合し、VCT 受け点を 3 値化 (#134, #130)

### DIFF
--- a/src/logic/cpu/evaluation/jumpPatterns.ts
+++ b/src/logic/cpu/evaluation/jumpPatterns.ts
@@ -7,8 +7,8 @@
 import type { BoardState } from "@/types/game";
 
 import { DIRECTION_INDICES, DIRECTIONS } from "../core/constants";
-// 四判定の SSoT（issue #124）。Zig 側 `threats.isFourInDirection` と対応する。
-import { isFourInDirection } from "../search/threatMoves";
+// 四判定の SSoT（issue #124 / #134）。Zig 側 `threats.classifyFourInDirection` と対応する。
+import { type FourClass, classifyFourInDirection } from "../search/threatMoves";
 // #43 PR-3: 図形/禁手の葉プリミティブを Zig アダプタへ委譲（patterns.ts/forbiddenMoves.ts 依存を断つ）。
 // 本ファイルは vctHelpers/winningPatterns（review judgment）から live のため存続。
 import { isForbiddenForBlack } from "../wasm/forbiddenAdapter";
@@ -129,37 +129,43 @@ export function analyzeJumpPatterns(
     hasValidOpenThree: false,
   };
 
-  // まず各方向の跳び四を先にチェックして記録
+  // まず各方向の四を先にチェックして記録
   // 同じ方向に跳び四がある場合、連続三を活三としてカウントしないため
   const jumpFourDirections = new Set<number>();
+  const fourClasses: FourClass[] = [];
 
   // パターンキャッシュ（precomputed がない場合のみ計算）
   const patterns: DirectionPattern[] =
     precomputed ?? computePatterns(board, row, col, color);
 
   for (let i = 0; i < DIRECTION_INDICES.length; i++) {
-    const dirIndex = DIRECTION_INDICES[i];
-    if (dirIndex === undefined) {
-      continue;
-    }
-
     const pattern = patterns[i];
     if (!pattern) {
+      fourClasses.push({ kind: "not_four" });
       continue;
     }
 
-    // 連続四がなく、跳び四がある場合を記録
+    // 四の分類（連続四・跳び四とも `classifyFourInDirection` に一本化・issue #134）
     //
     // issue #121: `checkJumpFour` は中心 ±4 マスの窓しか見ないため、窓の外の自石で
     // ギャップ埋めが長連（6 連以上）になる黒の形も跳び四として報告する。四かどうかの
-    // 最終判断は五点の列挙（`isFourInDirection`）に委ねる。偽の跳び四を四に数えると
-    // 「四三」でない手をミセ手として生成してしまう。
-    // `isFourInDirection` が内部で `checkJumpFour`（wasm 境界の syncCells 225 回）を
-    // 呼ぶので、ここで先に呼ぶと 2 回同期することになる。足切りも含めて一本化する。
-    if (
-      pattern.count !== 4 &&
-      isFourInDirection(board, row, col, i, color, pattern.count)
-    ) {
+    // 最終判断は五点の列挙に委ねる。偽の跳び四を四に数えると「四三」でない手を
+    // ミセ手として生成してしまう。
+    // 足切り（`checkJumpFour`）も `classifyFourInDirection` の内部で行うので、
+    // ここで先に呼ぶと wasm 境界の syncCells が 2 回走ることになる。一本化する。
+    const fourClass = classifyFourInDirection(
+      board,
+      row,
+      col,
+      i,
+      color,
+      pattern.count,
+    );
+    fourClasses.push(fourClass);
+
+    // 「跳び四の方向」= 四だが連続四ではない方向。同方向の三を四三に数えないための
+    // ガードに使う（連続四の方向は count === 4 なので三のブランチに入らない）。
+    if (pattern.count !== 4 && fourClass.kind !== "not_four") {
       jumpFourDirections.add(i);
     }
   }
@@ -175,19 +181,17 @@ export function analyzeJumpPatterns(
       continue;
     }
 
-    // 連続四をチェック（少なくとも片端が空いていなければ五を作れないため除外）
+    // 四（連続四・跳び四とも 1st pass の `classifyFourInDirection` に一本化・issue #134）
     //
-    // 跳び四側は五点列挙（`isFourInDirection`）に寄せたが、**連続四側は端ベースのまま**
-    // （`analyzeDirection` が黒の長連補正済みの端を返す）。`count === 4` に限れば等価:
+    // 旧実装の連続四側は端ベース（`analyzeDirection` の黒長連補正済みの端）だったが、
+    // `count === 4` に限れば五点列挙と等価:
     //   - 偽陽性なし: 端が空きかつ長連補正を通れば、その端を埋めると必ずちょうど 5
     //   - 偽陰性なし: 連続 4 連の五点は両端のいずれかにしか存在しえない
-    // 統一（`classifyFourInDirection` への集約）は follow-up issue #134 で扱う。
-    if (
-      pattern.count === 4 &&
-      (pattern.end1 === "empty" || pattern.end2 === "empty")
-    ) {
+    // 活四（両端空き）も「五点 2 個以上 = unstoppable」と一致する。
+    const fourClass = fourClasses[i] ?? { kind: "not_four" };
+    if (fourClass.kind !== "not_four") {
       result.hasFour = true;
-      if (pattern.end1 === "empty" && pattern.end2 === "empty") {
+      if (pattern.count === 4 && fourClass.kind === "unstoppable") {
         result.hasOpenFour = true;
       }
     }
@@ -205,7 +209,6 @@ export function analyzeJumpPatterns(
 
     // 跳び四をチェック（連続四がない場合のみ）
     if (jumpFourDirections.has(i)) {
-      result.hasFour = true;
       result.jumpFourCount++;
       // 跳び四は両端開の形がないので、常に止め四扱い
     }

--- a/src/logic/cpu/evaluation/jumpPatterns.ts
+++ b/src/logic/cpu/evaluation/jumpPatterns.ts
@@ -7,8 +7,12 @@
 import type { BoardState } from "@/types/game";
 
 import { DIRECTION_INDICES, DIRECTIONS } from "../core/constants";
-// 四判定の SSoT（issue #124 / #134）。Zig 側 `threats.classifyFourInDirection` と対応する。
-import { type FourClass, classifyFourInDirection } from "../search/threatMoves";
+// 四判定の SSoT（issue #124 / #134）。Zig 側 `threats.classifyFourInDirection` /
+// `isFourInDirectionWithPattern` と対応する。
+import {
+  classifyFourInDirection,
+  isFourInDirection,
+} from "../search/threatMoves";
 // #43 PR-3: 図形/禁手の葉プリミティブを Zig アダプタへ委譲（patterns.ts/forbiddenMoves.ts 依存を断つ）。
 // 本ファイルは vctHelpers/winningPatterns（review judgment）から live のため存続。
 import { isForbiddenForBlack } from "../wasm/forbiddenAdapter";
@@ -132,7 +136,9 @@ export function analyzeJumpPatterns(
   // まず各方向の四を先にチェックして記録
   // 同じ方向に跳び四がある場合、連続三を活三としてカウントしないため
   const jumpFourDirections = new Set<number>();
-  const fourClasses: FourClass[] = [];
+  const isFourDirections: boolean[] = new Array<boolean>(
+    DIRECTION_INDICES.length,
+  ).fill(false);
 
   // パターンキャッシュ（precomputed がない場合のみ計算）
   const patterns: DirectionPattern[] =
@@ -141,19 +147,23 @@ export function analyzeJumpPatterns(
   for (let i = 0; i < DIRECTION_INDICES.length; i++) {
     const pattern = patterns[i];
     if (!pattern) {
-      fourClasses.push({ kind: "not_four" });
       continue;
     }
 
-    // 四の分類（連続四・跳び四とも `classifyFourInDirection` に一本化・issue #134）
+    // 四の判定（連続四・跳び四とも五点列挙に一本化・issue #134）
     //
     // issue #121: `checkJumpFour` は中心 ±4 マスの窓しか見ないため、窓の外の自石で
     // ギャップ埋めが長連（6 連以上）になる黒の形も跳び四として報告する。四かどうかの
     // 最終判断は五点の列挙に委ねる。偽の跳び四を四に数えると「四三」でない手を
     // ミセ手として生成してしまう。
-    // 足切り（`checkJumpFour`）も `classifyFourInDirection` の内部で行うので、
+    // 足切り（`checkJumpFour`）も `isFourInDirection` の内部で行うので、
     // ここで先に呼ぶと wasm 境界の syncCells が 2 回走ることになる。一本化する。
-    const fourClass = classifyFourInDirection(
+    //
+    // ここでは「四かどうか」の boolean しか要らないので、分類 3 値
+    // （`classifyFourInDirection`）ではなく**早期打ち切り版**を使う（活四かどうかが
+    // 必要な方向だけ下で分類する）。`analyzeJumpPatterns` は `createsFourThree` 経由で
+    // ムーブオーダリングのホットパスに乗る。
+    isFourDirections[i] = isFourInDirection(
       board,
       row,
       col,
@@ -161,11 +171,10 @@ export function analyzeJumpPatterns(
       color,
       pattern.count,
     );
-    fourClasses.push(fourClass);
 
     // 「跳び四の方向」= 四だが連続四ではない方向。同方向の三を四三に数えないための
     // ガードに使う（連続四の方向は count === 4 なので三のブランチに入らない）。
-    if (pattern.count !== 4 && fourClass.kind !== "not_four") {
+    if (pattern.count !== 4 && isFourDirections[i]) {
       jumpFourDirections.add(i);
     }
   }
@@ -181,17 +190,24 @@ export function analyzeJumpPatterns(
       continue;
     }
 
-    // 四（連続四・跳び四とも 1st pass の `classifyFourInDirection` に一本化・issue #134）
+    // 四（連続四・跳び四とも 1st pass の五点列挙に一本化・issue #134）
     //
     // 旧実装の連続四側は端ベース（`analyzeDirection` の黒長連補正済みの端）だったが、
     // `count === 4` に限れば五点列挙と等価:
     //   - 偽陽性なし: 端が空きかつ長連補正を通れば、その端を埋めると必ずちょうど 5
     //   - 偽陰性なし: 連続 4 連の五点は両端のいずれかにしか存在しえない
     // 活四（両端空き）も「五点 2 個以上 = unstoppable」と一致する。
-    const fourClass = fourClasses[i] ?? { kind: "not_four" };
-    if (fourClass.kind !== "not_four") {
+    if (isFourDirections[i]) {
       result.hasFour = true;
-      if (pattern.count === 4 && fourClass.kind === "unstoppable") {
+      // 活四かどうかが要るのは**連続四の方向だけ**なので、ここでだけ 3 値の分類を引く。
+      // `count !== 4`（跳び四）の方向で `unstoppable` を立てないのは旧実装と揃えるため
+      //（旧実装は「跳び四は両端開の形がないので常に止め四扱い」として hasOpenFour を
+      // 立てなかった。挙動不変のためこのガードを残す）。
+      if (
+        pattern.count === 4 &&
+        classifyFourInDirection(board, row, col, i, color, pattern.count)
+          .kind === "unstoppable"
+      ) {
         result.hasOpenFour = true;
       }
     }

--- a/src/logic/cpu/evaluation/threatDetection.ts
+++ b/src/logic/cpu/evaluation/threatDetection.ts
@@ -13,14 +13,16 @@ import type { LineTable } from "../lineTable/lineTable";
 
 import { includesPosition } from "../core/boardUtils";
 import { DIRECTION_INDICES, DIRECTIONS } from "../core/constants";
-import { collectLineFivePoints } from "../core/lineAnalysis";
 import { getDirectionPattern } from "../lineTable/adapter";
 import { isNearExistingStone } from "../moveGenerator";
-// 四判定の SSoT（issue #124）。Zig 側 `threats.isFourInDirection` と対応する。
-import { isFourInDirection } from "../search/threatMoves";
+// 四判定の SSoT（issue #124 / #134）。Zig 側 `threats.classifyFourInDirection` と対応する。
+import {
+  classifyFourInDirection,
+  isFourInDirection,
+} from "../search/threatMoves";
 // #43 PR-3: 跳び四/三の図形判定を Zig アダプタへ委譲（patterns.ts 依存を断つ）。
 // getOpenThreeDefensePositions が vctHelpers（review judgment）から live のため存続。
-import { checkJumpFour, checkJumpThree } from "../wasm/patternsAdapter";
+import { checkJumpThree } from "../wasm/patternsAdapter";
 import { analyzeDirection } from "./directionAnalysis";
 import { isValidConsecutiveThree, isValidJumpThree } from "./jumpPatterns";
 import { type ThreatInfo, PATTERN_SCORES } from "./patternScores";
@@ -346,30 +348,21 @@ export function detectOpponentThreats(
         // 受けを `getLineEnds` / `findJumpGapPosition` から取っていた。跳び四判定は
         // ±4 マスの窓しか見ないため、窓の外の自石でギャップ埋めが長連になる黒の形を
         // 四と誤判定し、しかも `isJumpFour` が活三の受け列挙まで抑止していた（issue #121）。
-        // NOTE: この「プリフィルタ → collectLineFivePoints → 0/1/2 個で分岐」は
-        // 5 箇所に複製されている。SSoT 統合は issue #134。
-        let isFour = false;
-        if (
-          pattern.count === 4 ||
-          (renjuDirIndex >= 0 &&
-            checkJumpFour(board, row, col, renjuDirIndex, opponentColor))
-        ) {
-          const fivePoints = collectLineFivePoints(
-            board,
-            row,
-            col,
-            dr,
-            dc,
-            opponentColor,
-          );
-          // eslint-disable-next-line max-depth
-          if (fivePoints.length >= 2) {
-            isFour = true;
-            addUniquePositions(result.openFours, fivePoints);
-          } else if (fivePoints.length === 1) {
-            isFour = true;
-            addUniquePositions(result.fours, fivePoints);
-          }
+        //
+        // issue #134: 分岐そのものは `classifyFourInDirection`（SSoT）に一本化した。
+        const fourClass = classifyFourInDirection(
+          board,
+          row,
+          col,
+          dirIdx,
+          opponentColor,
+          pattern.count,
+        );
+        const isFour = fourClass.kind !== "not_four";
+        if (fourClass.kind === "unstoppable") {
+          addUniquePositions(result.openFours, fourClass.fivePoints);
+        } else if (fourClass.kind === "block") {
+          addUniquePositions(result.fours, [fourClass.position]);
         }
 
         // 活三をチェック（両端が空いている3連）

--- a/src/logic/cpu/evaluation/threatDetection.ts
+++ b/src/logic/cpu/evaluation/threatDetection.ts
@@ -359,10 +359,22 @@ export function detectOpponentThreats(
           pattern.count,
         );
         const isFour = fourClass.kind !== "not_four";
-        if (fourClass.kind === "unstoppable") {
-          addUniquePositions(result.openFours, fourClass.fivePoints);
-        } else if (fourClass.kind === "block") {
-          addUniquePositions(result.fours, [fourClass.position]);
+        switch (fourClass.kind) {
+          case "unstoppable":
+            // classifyFourInDirection は unstoppable なら必ず fivePoints を埋める
+            // （optional なのは受け点を持たない畳み込み結果 FourDefense と型を共有するため）
+            addUniquePositions(result.openFours, fourClass.fivePoints ?? []);
+            break;
+          case "block":
+            addUniquePositions(result.fours, [fourClass.position]);
+            break;
+          case "not_four":
+            // この方向は四ではない → 下の活三ブランチへ落とす
+            break;
+          default: {
+            const exhaustive: never = fourClass;
+            return exhaustive;
+          }
         }
 
         // 活三をチェック（両端が空いている3連）

--- a/src/logic/cpu/evaluation/winningPatterns.ts
+++ b/src/logic/cpu/evaluation/winningPatterns.ts
@@ -8,16 +8,7 @@
 
 import type { BoardState } from "@/types/game";
 
-import type { DirectionPattern } from "./patternScores";
-
 import { DIRECTION_INDICES, DIRECTIONS } from "../core/constants";
-import { CELL_LINES_FLAT } from "../lineTable/lineMapping";
-import { analyzeLinePattern } from "../lineTable/linePatterns";
-import {
-  placeStone,
-  removeStone,
-  type LineTable,
-} from "../lineTable/lineTable";
 // #43 PR-3: 跳び四/三の図形判定を Zig アダプタへ委譲（patterns.ts 依存を断つ）。
 // detectWhiteWinningPattern は forcedLossCheck から live なため本ファイルは存続。
 import { checkJumpFour, checkJumpThree } from "../wasm/patternsAdapter";
@@ -273,66 +264,8 @@ export function createsFourThree(
   return result;
 }
 
-/**
- * createsFourThree のハイブリッド版
- *
- * 連続パターン検出を LineTable 版 (analyzeLinePattern) に置換し、
- * board 走査の ~80 reads を 4× ビットマスク演算に削減。
- *
- * 跳びパターン検出 (checkJumpFour/checkJumpThree) は
- * renjuRules.ts の board ベース実装をそのまま使用（board place/remove が必要）。
- *
- * analyzeJumpPatterns の precomputed パラメータ経由で
- * LineTable から得た DirectionPattern[] を渡す。
- */
-export function createsFourThreeBit(
-  board: BoardState,
-  lineTable: LineTable,
-  row: number,
-  col: number,
-  color: "black" | "white",
-): boolean {
-  // 盤面 + LineTable 両方に仮置き
-  const targetRow = board[row];
-  if (targetRow) {
-    targetRow[col] = color;
-  }
-  placeStone(lineTable, row, col, color);
-
-  // LineTable から4方向の DirectionPattern を取得（board 走査を回避）
-  const patterns: DirectionPattern[] = [];
-  const base = (row * 15 + col) * 4;
-  for (let d = 0; d < 4; d++) {
-    const packed = CELL_LINES_FLAT[base + d] ?? 0xffff;
-    if (packed === 0xffff) {
-      patterns.push({ count: 1, end1: "edge", end2: "edge" });
-      continue;
-    }
-    const lineId = packed >> 8;
-    const bitPos = packed & 0xff;
-    patterns.push(
-      analyzeLinePattern(
-        lineTable.blacks,
-        lineTable.whites,
-        lineId,
-        bitPos,
-        color,
-        d === 3,
-      ),
-    );
-  }
-
-  // analyzeJumpPatterns に precomputed patterns を渡す
-  // → 内部の computePatterns (= 4× analyzeDirection board走査) をスキップ
-  // → checkJumpFour/checkJumpThree は board を使用（仮置き済み）
-  const jumpResult = analyzeJumpPatterns(board, row, col, color, patterns);
-  const result = jumpResult.hasFour && jumpResult.hasValidOpenThree;
-
-  // 復元
-  if (targetRow) {
-    targetRow[col] = null;
-  }
-  removeStone(lineTable, row, col, color);
-
-  return result;
-}
+// issue #134 / #43: `createsFourThreeBit`（createsFourThree の LineTable ハイブリッド版）は
+// 削除した。参照ゼロ（本番経路は Zig `evaluate.createsFourThree`）で、`analyzeJumpPatterns` の
+// `precomputed` 経路を使う唯一の呼び出し元だったため、四判定を五点列挙へ統一した #134 の
+// 新旧等価性が検証されないまま残るのは害のほうが大きい。
+// 必要になったら `analyzeJumpPatterns(board, row, col, color, precomputed)` から作り直すこと。

--- a/src/logic/cpu/search/fourDefenseParity.wasm.test.ts
+++ b/src/logic/cpu/search/fourDefenseParity.wasm.test.ts
@@ -23,9 +23,10 @@ import { BOARD_SIZE } from "@/constants";
 import { createEmptyBoard } from "@/logic/renjuRules";
 
 import { collectLineFivePoints } from "../core/lineAnalysis";
+import { analyzeDirection } from "../evaluation/directionAnalysis";
 import { getThreatWasm, preloadThreatWasm } from "../wasm/threatLoader";
 import { CELL } from "../wasm/types";
-import { createsFour } from "./threatMoves";
+import { classifyFourInDirection, createsFour } from "./threatMoves";
 import { type FourDefense, getFourDefensePosition } from "./threatPatterns";
 
 await preloadThreatWasm();
@@ -223,6 +224,90 @@ describe("受け点の TS⇄Zig パリティ（1ライン全列挙・issue #115�
 
     // 比較が実際に行われていること（ループ条件のミスで 0 件になる事故を防ぐ）
     expect(comparisons).toBeGreaterThan(30_000);
+    expect(mismatches.slice(0, 10)).toEqual([]);
+  }, 120_000);
+});
+
+/**
+ * `analyzeJumpPatterns` / `evaluate.createsFourThree` が #134 以前に使っていた
+ * 連続四の判定（`analyzeDirection` の端ベース・黒の長連補正込み）。
+ *
+ * 新実装（`classifyFourInDirection`）との差分が 0 であることを全列挙で固定する。
+ */
+function legacyConsecutiveFour(
+  board: BoardState,
+  row: number,
+  col: number,
+  color: PlayerColor,
+): { hasFour: boolean; openFour: boolean } {
+  const pattern = analyzeDirection(board, row, col, 0, 1, color);
+  if (pattern.count !== 4) {
+    return { hasFour: false, openFour: false };
+  }
+  return {
+    hasFour: pattern.end1 === "empty" || pattern.end2 === "empty",
+    openFour: pattern.end1 === "empty" && pattern.end2 === "empty",
+  };
+}
+
+describe("連続四の端ベース旧基準と classifyFourInDirection の等価性（issue #134）", () => {
+  it("count === 4 の方向で新旧の四判定・活四判定が全パターンで一致する", () => {
+    const total = 3 ** LINE_LEN;
+    const cells: (PlayerColor | null)[] = new Array<PlayerColor | null>(
+      LINE_LEN,
+    ).fill(null);
+
+    const mismatches: string[] = [];
+    let comparisons = 0;
+
+    for (let code = 0; code < total; code++) {
+      let rest = code;
+      for (let i = 0; i < LINE_LEN; i++) {
+        cells[i] = CELL_VALUES[rest % 3] ?? null;
+        rest = Math.floor(rest / 3);
+      }
+
+      for (const lineStart of LINE_STARTS) {
+        const board = buildBoard(cells, lineStart);
+
+        for (const color of ["black", "white"] as const) {
+          for (let i = 0; i < LINE_LEN; i++) {
+            if (cells[i] !== color) {
+              continue;
+            }
+            const col = lineStart + i;
+            const pattern = analyzeDirection(board, LINE_ROW, col, 0, 1, color);
+            // 旧実装が連続四を見ていたのは count === 4 の方向だけ
+            if (pattern.count !== 4) {
+              continue;
+            }
+            comparisons++;
+
+            const legacy = legacyConsecutiveFour(board, LINE_ROW, col, color);
+            const cls = classifyFourInDirection(
+              board,
+              LINE_ROW,
+              col,
+              DIR_INDEX,
+              color,
+              pattern.count,
+            );
+            if (legacy.hasFour !== (cls.kind !== "not_four")) {
+              mismatches.push(
+                `四判定 code=${code} color=${color} col=${col}: legacy=${legacy.hasFour} classify=${cls.kind}`,
+              );
+            }
+            if (legacy.openFour !== (cls.kind === "unstoppable")) {
+              mismatches.push(
+                `活四判定 code=${code} color=${color} col=${col}: legacy=${legacy.openFour} classify=${cls.kind}`,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    expect(comparisons).toBeGreaterThan(1_000);
     expect(mismatches.slice(0, 10)).toEqual([]);
   }, 120_000);
 });

--- a/src/logic/cpu/search/fourDefenseParity.wasm.test.ts
+++ b/src/logic/cpu/search/fourDefenseParity.wasm.test.ts
@@ -22,6 +22,8 @@ import type { BoardState, Position } from "@/types/game";
 import { BOARD_SIZE } from "@/constants";
 import { createEmptyBoard } from "@/logic/renjuRules";
 
+import type { DirectionPattern } from "../evaluation/patternScores";
+
 import { collectLineFivePoints } from "../core/lineAnalysis";
 import { analyzeDirection } from "../evaluation/directionAnalysis";
 import { getThreatWasm, preloadThreatWasm } from "../wasm/threatLoader";
@@ -143,6 +145,26 @@ function key(points: Position[]): string[] {
   return points.map((p) => `${p.row},${p.col}`).sort();
 }
 
+/**
+ * `analyzeJumpPatterns` / `evaluate.createsFourThree` が #134 以前に使っていた
+ * 連続四の判定（`analyzeDirection` の端ベース・黒の長連補正込み）の参照実装。
+ *
+ * 新実装（`classifyFourInDirection`）との差分が 0 であることを全列挙で固定する。
+ * `pattern` は呼び出し側が計算済みのものを受け取る（`count === 4` の方向のみ有効）。
+ */
+function legacyConsecutiveFour(pattern: DirectionPattern): {
+  hasFour: boolean;
+  openFour: boolean;
+} {
+  if (pattern.count !== 4) {
+    return { hasFour: false, openFour: false };
+  }
+  return {
+    hasFour: pattern.end1 === "empty" || pattern.end2 === "empty",
+    openFour: pattern.end1 === "empty" && pattern.end2 === "empty",
+  };
+}
+
 describe("受け点の TS⇄Zig パリティ（1ライン全列挙・issue #115）", () => {
   it("collectLineFivePoints と getFourDefensePosition が全パターンで一致する", () => {
     const total = 3 ** LINE_LEN;
@@ -152,6 +174,8 @@ describe("受け点の TS⇄Zig パリティ（1ライン全列挙・issue #115�
 
     const mismatches: string[] = [];
     let comparisons = 0;
+    /** 連続四の新旧比較（#134）が実際に行われた回数 */
+    let legacyComparisons = 0;
 
     for (let code = 0; code < total; code++) {
       let rest = code;
@@ -217,6 +241,36 @@ describe("受け点の TS⇄Zig パリティ（1ライン全列挙・issue #115�
                 `createsFour code=${code} color=${color} col=${col}: ts=${tsFour} zig=${zigFour}`,
               );
             }
+
+            // #134: `createsFourThree` / `analyzeJumpPatterns` の連続四側を端ベースから
+            // 五点列挙（classifyFourInDirection）へ統一したので、`count === 4` の方向で
+            // 新旧の四判定・活四判定に差分が無いことを凍結する。
+            const pattern = analyzeDirection(board, LINE_ROW, col, 0, 1, color);
+            // eslint-disable-next-line max-depth
+            if (pattern.count === 4) {
+              legacyComparisons++;
+              const legacy = legacyConsecutiveFour(pattern);
+              const cls = classifyFourInDirection(
+                board,
+                LINE_ROW,
+                col,
+                DIR_INDEX,
+                color,
+                pattern.count,
+              );
+              // eslint-disable-next-line max-depth
+              if (legacy.hasFour !== (cls.kind !== "not_four")) {
+                mismatches.push(
+                  `連続四の四判定 code=${code} color=${color} col=${col}: legacy=${legacy.hasFour} classify=${cls.kind}`,
+                );
+              }
+              // eslint-disable-next-line max-depth
+              if (legacy.openFour !== (cls.kind === "unstoppable")) {
+                mismatches.push(
+                  `連続四の活四判定 code=${code} color=${color} col=${col}: legacy=${legacy.openFour} classify=${cls.kind}`,
+                );
+              }
+            }
           }
         }
       }
@@ -224,90 +278,7 @@ describe("受け点の TS⇄Zig パリティ（1ライン全列挙・issue #115�
 
     // 比較が実際に行われていること（ループ条件のミスで 0 件になる事故を防ぐ）
     expect(comparisons).toBeGreaterThan(30_000);
-    expect(mismatches.slice(0, 10)).toEqual([]);
-  }, 120_000);
-});
-
-/**
- * `analyzeJumpPatterns` / `evaluate.createsFourThree` が #134 以前に使っていた
- * 連続四の判定（`analyzeDirection` の端ベース・黒の長連補正込み）。
- *
- * 新実装（`classifyFourInDirection`）との差分が 0 であることを全列挙で固定する。
- */
-function legacyConsecutiveFour(
-  board: BoardState,
-  row: number,
-  col: number,
-  color: PlayerColor,
-): { hasFour: boolean; openFour: boolean } {
-  const pattern = analyzeDirection(board, row, col, 0, 1, color);
-  if (pattern.count !== 4) {
-    return { hasFour: false, openFour: false };
-  }
-  return {
-    hasFour: pattern.end1 === "empty" || pattern.end2 === "empty",
-    openFour: pattern.end1 === "empty" && pattern.end2 === "empty",
-  };
-}
-
-describe("連続四の端ベース旧基準と classifyFourInDirection の等価性（issue #134）", () => {
-  it("count === 4 の方向で新旧の四判定・活四判定が全パターンで一致する", () => {
-    const total = 3 ** LINE_LEN;
-    const cells: (PlayerColor | null)[] = new Array<PlayerColor | null>(
-      LINE_LEN,
-    ).fill(null);
-
-    const mismatches: string[] = [];
-    let comparisons = 0;
-
-    for (let code = 0; code < total; code++) {
-      let rest = code;
-      for (let i = 0; i < LINE_LEN; i++) {
-        cells[i] = CELL_VALUES[rest % 3] ?? null;
-        rest = Math.floor(rest / 3);
-      }
-
-      for (const lineStart of LINE_STARTS) {
-        const board = buildBoard(cells, lineStart);
-
-        for (const color of ["black", "white"] as const) {
-          for (let i = 0; i < LINE_LEN; i++) {
-            if (cells[i] !== color) {
-              continue;
-            }
-            const col = lineStart + i;
-            const pattern = analyzeDirection(board, LINE_ROW, col, 0, 1, color);
-            // 旧実装が連続四を見ていたのは count === 4 の方向だけ
-            if (pattern.count !== 4) {
-              continue;
-            }
-            comparisons++;
-
-            const legacy = legacyConsecutiveFour(board, LINE_ROW, col, color);
-            const cls = classifyFourInDirection(
-              board,
-              LINE_ROW,
-              col,
-              DIR_INDEX,
-              color,
-              pattern.count,
-            );
-            if (legacy.hasFour !== (cls.kind !== "not_four")) {
-              mismatches.push(
-                `四判定 code=${code} color=${color} col=${col}: legacy=${legacy.hasFour} classify=${cls.kind}`,
-              );
-            }
-            if (legacy.openFour !== (cls.kind === "unstoppable")) {
-              mismatches.push(
-                `活四判定 code=${code} color=${color} col=${col}: legacy=${legacy.openFour} classify=${cls.kind}`,
-              );
-            }
-          }
-        }
-      }
-    }
-
-    expect(comparisons).toBeGreaterThan(1_000);
+    expect(legacyComparisons).toBeGreaterThan(1_000);
     expect(mismatches.slice(0, 10)).toEqual([]);
   }, 120_000);
 });

--- a/src/logic/cpu/search/threatMoves.ts
+++ b/src/logic/cpu/search/threatMoves.ts
@@ -60,8 +60,10 @@ export function createsFour(
  * 意味論は `classifyFourInDirection(...).kind !== "not_four"` と同値（issue #134）。
  * ただし分類には「五点が 1 個か 2 個以上か」の確定が要るのでライン全体の走査が必要
  * なのに対し、boolean 用途は最初の 1 点で打ち切れる。ホットパス向けにこちらは
- * 早期打ち切り版（`hasLineFivePoint`）を維持する。**五点走査の定義は共有**しており、
- * 両者の同値性は `fourDefenseParity.wasm.test.ts` で全列挙固定している。
+ * 早期打ち切り版（`hasLineFivePoint`）を維持する。同値性は**足切り条件が同一で、
+ * 五点走査の定義（`scanLineFivePoints`）を共有している**ことによる構造的な保証
+ * （`hasLineFivePoint` = 五点 >= 1、`not_four` = 五点 0）。
+ * Zig 側は同じ不変条件を `threats.zig` の全列挙テストで固定している。
  *
  * @param i DIRECTIONS / DIRECTION_INDICES のインデックス（0..3）
  */
@@ -107,16 +109,25 @@ export function isFourInDirection(
  *
  * Zig 側 `threats.FourClass` と対応する（脅威系は二重実装。どちらかを変えたら
  * 必ず両方直し、`fourDefenseParity.wasm.test.ts` で確認すること）。
+ *
+ * 4 方向の畳み込み結果（`threatPatterns.FourDefense`）も**この型のエイリアス**。
+ * Zig 側の `quiescence.FourDefense = threats.FourClass` と対称。
+ * `unstoppable.fivePoints` が optional なのはそのため（畳み込み後は「どの方向の
+ * 五点か」が意味を持たないので持たない）。**`classifyFourInDirection` が返す
+ * `unstoppable` では必ず埋まっている。**
  */
 export type FourClass =
   /** 五点 0 個。四ではない（黒の長連にしかならない形を含む） */
   | { kind: "not_four" }
   /** 五点 2 個以上 ＝ 活四。1 手では止められない */
-  | { kind: "unstoppable"; fivePoints: Position[] }
+  | { kind: "unstoppable"; fivePoints?: Position[] }
   /** 五点 1 個 ＝ 止め四。その 1 点が受け */
   | { kind: "block"; position: Position };
 
-const FOUR_CLASS_NOT_FOUR: FourClass = Object.freeze({ kind: "not_four" });
+/** `not_four` の共有インスタンス（分類のたびにオブジェクトを作らないため） */
+export const FOUR_CLASS_NOT_FOUR: FourClass = Object.freeze({
+  kind: "not_four",
+});
 
 /**
  * その方向の四を分類する（四判定・受け点の SSoT・issue #134）

--- a/src/logic/cpu/search/threatMoves.ts
+++ b/src/logic/cpu/search/threatMoves.ts
@@ -4,10 +4,15 @@
  * VCF/VCT探索で使用する四・活三の判定関数を共通化（DRY）
  */
 
-import type { BoardState } from "@/types/game";
+import type { BoardState, Position } from "@/types/game";
 
 import { DIRECTION_INDICES, DIRECTIONS } from "../core/constants";
-import { checkEnds, countLine, hasLineFivePoint } from "../core/lineAnalysis";
+import {
+  checkEnds,
+  collectLineFivePoints,
+  countLine,
+  hasLineFivePoint,
+} from "../core/lineAnalysis";
 // 夏止め済み判定（受け点の基準と活三判定を一致させる SSoT）
 import { getOpenThreeDefensePositions } from "../evaluation/threatDetection";
 // #43 PR-3: 跳び四/三の図形判定を Zig アダプタへ委譲（patterns.ts 依存を断つ）。
@@ -52,6 +57,12 @@ export function createsFour(
  * `countLine` / `checkJumpFour` による四パターン判定は候補の足切りにのみ使う。
  * 最終判断は必ず五点の列挙で行う。Zig 側 `threats.isFourInDirection` と対応する。
  *
+ * 意味論は `classifyFourInDirection(...).kind !== "not_four"` と同値（issue #134）。
+ * ただし分類には「五点が 1 個か 2 個以上か」の確定が要るのでライン全体の走査が必要
+ * なのに対し、boolean 用途は最初の 1 点で打ち切れる。ホットパス向けにこちらは
+ * 早期打ち切り版（`hasLineFivePoint`）を維持する。**五点走査の定義は共有**しており、
+ * 両者の同値性は `fourDefenseParity.wasm.test.ts` で全列挙固定している。
+ *
  * @param i DIRECTIONS / DIRECTION_INDICES のインデックス（0..3）
  */
 export function isFourInDirection(
@@ -84,6 +95,69 @@ export function isFourInDirection(
 
   // boolean 用途なので早期打ち切り版（定義は collectLineFivePoints と共有）を使う。
   return hasLineFivePoint(board, row, col, dr, dc, color);
+}
+
+/**
+ * その方向の四の分類（issue #134 の SSoT）
+ *
+ * 「プリフィルタ → `collectLineFivePoints` → 五点 0 / 1 / 2 個以上で分岐」という
+ * パターンは以前 5 箇所（Zig 3 + TS 2）に複製されていた。その分岐の定義はこの型
+ * ただ 1 つとし、方向ごとの分類と 4 方向の畳み込み（`getFourDefensePosition` の
+ * `FourDefense`）で共有する。
+ *
+ * Zig 側 `threats.FourClass` と対応する（脅威系は二重実装。どちらかを変えたら
+ * 必ず両方直し、`fourDefenseParity.wasm.test.ts` で確認すること）。
+ */
+export type FourClass =
+  /** 五点 0 個。四ではない（黒の長連にしかならない形を含む） */
+  | { kind: "not_four" }
+  /** 五点 2 個以上 ＝ 活四。1 手では止められない */
+  | { kind: "unstoppable"; fivePoints: Position[] }
+  /** 五点 1 個 ＝ 止め四。その 1 点が受け */
+  | { kind: "block"; position: Position };
+
+const FOUR_CLASS_NOT_FOUR: FourClass = Object.freeze({ kind: "not_four" });
+
+/**
+ * その方向の四を分類する（四判定・受け点の SSoT・issue #134）
+ *
+ * `countLine` / `checkJumpFour` による四パターン判定は候補の足切りにのみ使い、
+ * 最終判断は必ず五点の列挙（`collectLineFivePoints`）で行う。跳び四判定は
+ * 中心 ±4 マスの窓しか見ないため、窓の外の自石でギャップ埋めが長連になる黒の形も
+ * 「跳び四」と報告するが、五点列挙はそれを 0 個と数える（issue #121）。
+ *
+ * @param i DIRECTIONS / DIRECTION_INDICES のインデックス（0..3）
+ * @param knownCount 呼び出し側が計算済みのその方向の連続自石数（`isFourInDirection` と同じ）
+ */
+export function classifyFourInDirection(
+  board: BoardState,
+  row: number,
+  col: number,
+  i: number,
+  color: "black" | "white",
+  knownCount?: number,
+): FourClass {
+  const dirIndex = DIRECTION_INDICES[i];
+  const direction = DIRECTIONS[i];
+  if (dirIndex === undefined || !direction) {
+    return FOUR_CLASS_NOT_FOUR;
+  }
+  const [dr, dc] = direction;
+
+  const count = knownCount ?? countLine(board, row, col, dr, dc, color);
+  if (count !== 4 && !checkJumpFour(board, row, col, dirIndex, color)) {
+    return FOUR_CLASS_NOT_FOUR;
+  }
+
+  const fivePoints = collectLineFivePoints(board, row, col, dr, dc, color);
+  if (fivePoints.length === 0) {
+    return FOUR_CLASS_NOT_FOUR;
+  }
+  if (fivePoints.length >= 2) {
+    return { kind: "unstoppable", fivePoints };
+  }
+  const [position] = fivePoints;
+  return position ? { kind: "block", position } : FOUR_CLASS_NOT_FOUR;
 }
 
 /**

--- a/src/logic/cpu/search/threatPatterns.ts
+++ b/src/logic/cpu/search/threatPatterns.ts
@@ -20,6 +20,8 @@ import { isNearExistingStone } from "../moveGenerator";
 import { isForbiddenForBlack } from "../wasm/forbiddenAdapter";
 import { checkJumpThree } from "../wasm/patternsAdapter";
 import {
+  type FourClass,
+  FOUR_CLASS_NOT_FOUR,
   classifyFourInDirection,
   createsFour,
   isFourInDirection,
@@ -128,19 +130,16 @@ export function findFourMoves(
  * 以前は `Position | null` で、`null` が「防御不可（活四）」と「そもそも四ではない」の
  * 両方を意味していた。VCF 経路は `null` を即勝ちとして扱うため、四の判定側が
  * 偽陽性を出すと「四ですらない手」で VCF が成立してしまっていた。
- * Zig 側 `quiescence.FourDefense` と対応する。
+ *
+ * issue #134: 方向ごとの分類（`threatMoves.FourClass`）と**同じ型**にした。
+ * 3 値の意味も一致する（`not_four` = 五点 0 個 / `unstoppable` = 活四で 1 手では
+ * 止められない / `block` = 止め四でその 1 点が受け）。畳み込み後は「どの方向の
+ * 五点か」が意味を持たないので `unstoppable.fivePoints` は付けない（optional）。
+ * Zig 側の `quiescence.FourDefense = threats.FourClass` と対称。
  */
-export type FourDefense =
-  /** どの方向でも四になっていない（五点 0 個）。脅威ではない。 */
-  | { kind: "not_four" }
-  /** 四だが受け点が 2 つ以上ある ＝ 活四。1 手では止められない。 */
-  | { kind: "unstoppable" }
-  /** 止め四。この 1 点で受かる。 */
-  | { kind: "block"; position: Position };
+export type FourDefense = FourClass;
 
-export const FOUR_DEFENSE_NOT_FOUR: FourDefense = Object.freeze({
-  kind: "not_four",
-});
+export const FOUR_DEFENSE_NOT_FOUR: FourDefense = FOUR_CLASS_NOT_FOUR;
 export const FOUR_DEFENSE_UNSTOPPABLE: FourDefense = Object.freeze({
   kind: "unstoppable",
 });
@@ -196,9 +195,14 @@ export function getFourDefensePosition(
       case "block":
         firstDefense ??= fourClass.position;
         break;
-      default:
-        // not_four: この方向は四ではない（黒の長連にしかならない四）
+      case "not_four":
+        // この方向は四ではない（黒の長連にしかならない四）
         break;
+      default: {
+        // 網羅チェック（FourClass に値が増えたらここで型エラーになる）
+        const exhaustive: never = fourClass;
+        return exhaustive;
+      }
     }
   }
 

--- a/src/logic/cpu/search/threatPatterns.ts
+++ b/src/logic/cpu/search/threatPatterns.ts
@@ -12,18 +12,18 @@ import { BOARD_SIZE } from "@/constants";
 import { checkFive } from "@/logic/renjuRules";
 
 import { DIRECTION_INDICES, DIRECTIONS } from "../core/constants";
-import {
-  checkEnds,
-  collectLineFivePoints,
-  countLine,
-} from "../core/lineAnalysis";
+import { checkEnds, countLine } from "../core/lineAnalysis";
 // 夏止め済み判定（受け点の基準と活三判定を一致させる SSoT）
 import { getOpenThreeDefensePositions } from "../evaluation/threatDetection";
 import { isNearExistingStone } from "../moveGenerator";
 // #43 PR-3: 図形/禁手の葉プリミティブを Zig アダプタへ委譲（patterns.ts/forbiddenMoves.ts 依存を断つ）。
 import { isForbiddenForBlack } from "../wasm/forbiddenAdapter";
-import { checkJumpFour, checkJumpThree } from "../wasm/patternsAdapter";
-import { createsFour, isFourInDirection } from "./threatMoves";
+import { checkJumpThree } from "../wasm/patternsAdapter";
+import {
+  classifyFourInDirection,
+  createsFour,
+  isFourInDirection,
+} from "./threatMoves";
 
 /**
  * 即勝ち手を探す（五連を完成できる位置）
@@ -159,11 +159,11 @@ export function fourDefenseBlock(defense: FourDefense): Position | null {
  * 四に対する防御位置を取得
  * 四は1点でしか止められないので、その位置を返す
  *
- * 方向ごとに `collectLineFivePoints` で「その方向で埋めると五になる点」を列挙する
- * （受け点の SSoT。Zig 側 `quiescence.getFourDefensePosition` と同じ基準）。
- * - 五点 0 個: この方向は四ではない（黒の長連にしかならない四）→ 無視
- * - 五点 2 個以上: 両方は塞げない ＝ 活四（防御不可）→ `unstoppable`
- * - 五点 1 個: 止め四。その点が受け → `block`
+ * 方向ごとの分類（`classifyFourInDirection` ＝ 四判定・受け点の SSoT・issue #134）を
+ * 4 方向で畳み込む（Zig 側 `quiescence.getFourDefensePosition` と同じ基準）。
+ * - `not_four`: この方向は四ではない（黒の長連にしかならない四）→ 無視
+ * - `unstoppable`: 両方は塞げない ＝ 活四（防御不可）→ 即返す
+ * - `block`: 止め四。その点が受け（複数方向あれば最初の 1 点）
  * - どの方向も四でなかった → `not_four`
  *
  * issue #115: 以前は跳び四で `findJumpGapPosition` の返り値を検証せずに使っており、
@@ -184,42 +184,21 @@ export function getFourDefensePosition(
   color: "black" | "white",
 ): FourDefense {
   const { row, col } = lastMove;
-  // NOTE: この「プリフィルタ → collectLineFivePoints → 0/1/2 個で分岐」は
-  // 5 箇所に複製されている。SSoT 統合は issue #134。
   let firstDefense: Position | null = null;
 
   for (let i = 0; i < DIRECTION_INDICES.length; i++) {
-    const dirIndex = DIRECTION_INDICES[i];
-    if (dirIndex === undefined) {
-      continue;
-    }
-
-    const direction = DIRECTIONS[i];
-    if (!direction) {
-      continue;
-    }
-    const [dr, dc] = direction;
-
-    const isConsecutiveFour = countLine(board, row, col, dr, dc, color) === 4;
-    if (
-      !isConsecutiveFour &&
-      !checkJumpFour(board, row, col, dirIndex, color)
-    ) {
-      continue;
-    }
-
-    // 連続四・跳び四を区別せず、その方向で「埋めると五になる点」を列挙して判定する。
-    const fivePoints = collectLineFivePoints(board, row, col, dr, dc, color);
-    if (fivePoints.length === 0) {
-      // この方向は四ではない（黒の長連にしかならない四）
-      continue;
-    }
-    if (fivePoints.length >= 2) {
-      // 両方は塞げない = 活四（防御不可能）
-      return FOUR_DEFENSE_UNSTOPPABLE;
-    }
-    if (!firstDefense) {
-      firstDefense = fivePoints[0] ?? null;
+    // 方向ごとの分類は `classifyFourInDirection`（四判定・受け点の SSoT・issue #134）。
+    const fourClass = classifyFourInDirection(board, row, col, i, color);
+    switch (fourClass.kind) {
+      case "unstoppable":
+        // 両方は塞げない = 活四（防御不可能）
+        return FOUR_DEFENSE_UNSTOPPABLE;
+      case "block":
+        firstDefense ??= fourClass.position;
+        break;
+      default:
+        // not_four: この方向は四ではない（黒の長連にしかならない四）
+        break;
     }
   }
 

--- a/src/logic/cpu/search/vctHelpers.ts
+++ b/src/logic/cpu/search/vctHelpers.ts
@@ -345,18 +345,11 @@ function findThreatMovesFast(
 
 /* eslint-enable no-bitwise */
 
-/**
- * 脅威が成立しているかチェック（四または活三）
- */
-export function isThreat(
-  board: BoardState,
-  row: number,
-  col: number,
-  color: "black" | "white",
-): boolean {
-  const result = classifyThreat(board, row, col, color);
-  return result.createsFour || result.createsOpenThree;
-}
+// issue #130 / #43: TS 版 `isThreat` は削除した。Zig 側の `vct.isThreat` は
+// `getThreatDefensePositions` の `len == 0` を切り分けるガード専用で、
+// 戻り値の 3 値化（`ThreatDefense`）に吸収されて呼び出し元がゼロになった。
+// TS 側も参照ゼロだったため、二重実装を残さないよう同時に削除する。
+// 脅威の有無が要るなら `threatMoves.classifyThreat` を直接使うこと。
 
 // issue #121 / #43: TS 版 `getThreatDefensePositions` は削除した。
 // 本番経路は Zig の `vct.getThreatDefensePositions`（`threats.collectLineFivePoints` が

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -148,29 +148,36 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
 
     // 各方向のLUT結果をキャッシュ
     var dir_luts: [4]ll.PatternResult = undefined;
-    var four_classes: [4]threats.FourClass = [_]threats.FourClass{.not_four} ** 4;
+    var is_four_dirs: [4]bool = [_]bool{false} ** 4;
     var jump_four_dirs: [4]bool = [_]bool{false} ** 4;
 
     // 1st pass: 連続パターン + 四検出 (LUT版)
     //
     // issue #121: LUT の `has_jump_four` は盤面を見ないため、窓（中心 ±4）の外の自石で
     // ギャップ埋めが長連（6 連以上）になる黒の形も跳び四として報告する。四かどうかの
-    // 最終判断は五点の列挙（`threats.classifyFourInDirection`）に委ねる。偽の跳び四を
-    // 四に数えると「四三」でない手をミセ手として生成してしまう。
+    // 最終判断は五点の列挙に委ねる。偽の跳び四を四に数えると「四三」でない手を
+    // ミセ手として生成してしまう。
     //
     // issue #134: 連続四側も端ベース（`blackOverlineEnd`）をやめ、跳び四と同じ
-    // `classifyFourInDirection` に統一した（`count == 4` に限れば両者は等価。
-    // TS `evaluation/jumpPatterns.ts` と `fourDefenseParity.wasm.test.ts` で固定）。
+    // 五点列挙に統一した（`count == 4` に限れば両者は等価。
+    // `test "issue #134: 四分類の不変条件"`（threats.zig）で全列挙固定）。
+    //
+    // ここで要るのは「四かどうか」の boolean だけなので、分類 3 値
+    // （`classifyFourInDirection`）ではなく**早期打ち切り版**の
+    // `isFourInDirectionWithPattern` を使う（同じ SSoT の存在判定版。定義は
+    // `scanLineFivePoints` で共有）。`createsFourThree` は
+    // `position_eval.computeMiseBonus → countMiseTargets` からムーブオーダリング
+    // 経路に乗る最ホットパスで、五点をライン全走査すると純損になる。
     for (0..4) |i| {
         const lut = ll.queryPatternByCell(row, col, i, color);
         dir_luts[i] = lut;
 
-        // `classifyFourInDirection` が LUT の足切り（count==4 or has_jump_four）を
+        // `isFourInDirectionWithPattern` が LUT の足切り（count==4 or has_jump_four）を
         // 内部で行うので、ここで重ねてチェックする必要はない。
-        four_classes[i] = threats.classifyFourInDirection(cells, row, col, i, color, lut, null);
+        is_four_dirs[i] = threats.isFourInDirectionWithPattern(cells, row, col, i, color, lut);
         // 「跳び四の方向」= 四だが連続四ではない方向。同方向の三を四三に数えないための
         // ガードに使う（連続四の方向は `lut.count == 4` なので三のブランチに入らない）。
-        if (lut.count != 4 and four_classes[i] != .not_four) {
+        if (lut.count != 4 and is_four_dirs[i]) {
             jump_four_dirs[i] = true;
         }
     }
@@ -182,14 +189,14 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
         const end1 = lutEnd(lut.end1);
         const end2 = lutEnd(lut.end2);
 
-        // 四（連続四・跳び四とも 1st pass の `classifyFourInDirection` に一本化・issue #134）。
+        // 四（連続四・跳び四とも 1st pass の五点列挙に一本化・issue #134）。
         //
         // 旧実装の連続四側は端ベース（`blackOverlineEnd` による長連補正込み）だったが、
         // `count == 4` に限れば五点列挙と等価である:
         //   - 偽陽性なし: 端が空きかつ長連補正を通れば、その端を埋めると必ずちょうど 5
         //   - 偽陰性なし: 連続 4 連の五点は両端のいずれかにしか存在しえない
         //     （離れた空点を埋めても 4 連と繋がらない）
-        if (four_classes[i] != .not_four) {
+        if (is_four_dirs[i]) {
             has_four = true;
         }
 
@@ -760,54 +767,7 @@ test "createsFourThree: 同じ形でも白なら本物の四三（回帰・白�
     try std.testing.expect(createsFourThree(&cells, 7, 7, .white));
 }
 
-// === issue #134: 連続四の旧基準（端ベース）と classifyFourInDirection の等価性 ===
-
-/// `createsFourThree` が #134 以前に使っていた連続四の判定（端ベース・黒の長連補正込み）。
-/// 新実装（`threats.classifyFourInDirection`）との差分が 0 であることを全列挙で固定する。
-fn legacyConsecutiveFour(cells: []const Cell, row: u8, col: u8, dir_idx: usize, color: Cell) struct {
-    has_four: bool,
-    open_four: bool,
-} {
-    const dir = board_mod.DIRECTIONS[dir_idx];
-    const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
-    const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
-    var e1 = pos.end_state;
-    var e2 = neg.end_state;
-    if (color == .black) {
-        if (e1 == .empty and blackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
-            e1 = .opponent;
-        }
-        if (e2 == .empty and blackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
-            e2 = .opponent;
-        }
-    }
-    return .{
-        .has_four = e1 == .empty or e2 == .empty,
-        .open_four = e1 == .empty and e2 == .empty,
-    };
-}
-
-fn assertLegacyConsecutiveFourMatches(cells: *[CELL_COUNT]Cell, line_start: u8) anyerror!void {
-    for (0..9) |i| {
-        const col: u8 = line_start + @as(u8, @intCast(i));
-        const color = cells[7 * BOARD_SIZE + col];
-        if (color == .empty) continue;
-
-        const lut = ll.queryPatternByCell(7, col, 0, color);
-        // 旧実装が連続四を見ていたのは `lut.count == 4` の方向だけ
-        if (lut.count != 4) continue;
-
-        const legacy = legacyConsecutiveFour(cells, 7, col, 0, color);
-        const cls = threats.classifyFourInDirection(cells, 7, col, 0, color, lut, null);
-
-        // 「四かどうか」が一致（偽陽性・偽陰性ともゼロ）
-        try std.testing.expectEqual(legacy.has_four, cls != .not_four);
-        // 「活四かどうか」（両端空き ⇔ 五点 2 個以上）も一致
-        try std.testing.expectEqual(legacy.open_four, cls == .unstoppable);
-    }
-}
-
-test "issue #134: 連続四の端ベース旧基準と classifyFourInDirection は等価（1ライン全列挙）" {
-    ll.init();
-    try threats.forEachLinePattern(assertLegacyConsecutiveFourMatches);
-}
+// issue #134 の全列挙テスト（連続四の端ベース旧基準 ⇔ 五点列挙の等価性）は
+// `threats.zig` の `test "issue #134: 四分類の不変条件（1ライン全列挙）"` に集約した。
+// 盤面の敷き直し（3^9 × 3 窓）を 2 つのテストで二重に回さないため
+// （`createsFourThree` が使う判定は `threats` 側の SSoT なので置き場としても自然）。

--- a/zig/src/evaluate.zig
+++ b/zig/src/evaluate.zig
@@ -148,23 +148,29 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
 
     // 各方向のLUT結果をキャッシュ
     var dir_luts: [4]ll.PatternResult = undefined;
+    var four_classes: [4]threats.FourClass = [_]threats.FourClass{.not_four} ** 4;
     var jump_four_dirs: [4]bool = [_]bool{false} ** 4;
 
-    // 1st pass: 連続パターン + 跳び四検出 (LUT版)
+    // 1st pass: 連続パターン + 四検出 (LUT版)
     //
     // issue #121: LUT の `has_jump_four` は盤面を見ないため、窓（中心 ±4）の外の自石で
     // ギャップ埋めが長連（6 連以上）になる黒の形も跳び四として報告する。四かどうかの
-    // 最終判断は五点の列挙（`threats.isFourInDirection`）に委ねる。偽の跳び四を四に
-    // 数えると「四三」でない手をミセ手として生成してしまう。
+    // 最終判断は五点の列挙（`threats.classifyFourInDirection`）に委ねる。偽の跳び四を
+    // 四に数えると「四三」でない手をミセ手として生成してしまう。
+    //
+    // issue #134: 連続四側も端ベース（`blackOverlineEnd`）をやめ、跳び四と同じ
+    // `classifyFourInDirection` に統一した（`count == 4` に限れば両者は等価。
+    // TS `evaluation/jumpPatterns.ts` と `fourDefenseParity.wasm.test.ts` で固定）。
     for (0..4) |i| {
         const lut = ll.queryPatternByCell(row, col, i, color);
         dir_luts[i] = lut;
 
-        // `isFourInDirectionWithPattern` が LUT の足切り（count==4 or has_jump_four）を
+        // `classifyFourInDirection` が LUT の足切り（count==4 or has_jump_four）を
         // 内部で行うので、ここで重ねてチェックする必要はない。
-        if (lut.count != 4 and
-            threats.isFourInDirectionWithPattern(cells, row, col, i, color, lut))
-        {
+        four_classes[i] = threats.classifyFourInDirection(cells, row, col, i, color, lut, null);
+        // 「跳び四の方向」= 四だが連続四ではない方向。同方向の三を四三に数えないための
+        // ガードに使う（連続四の方向は `lut.count == 4` なので三のブランチに入らない）。
+        if (lut.count != 4 and four_classes[i] != .not_four) {
             jump_four_dirs[i] = true;
         }
     }
@@ -176,32 +182,15 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
         const end1 = lutEnd(lut.end1);
         const end2 = lutEnd(lut.end2);
 
-        // 連続四（片端以上が空き）。端はセル走査で求め、黒は長連補正を適用する
-        // （TS analyzeDirection と一致。LUT 端は黒長連補正を持たないため使わない）。
+        // 四（連続四・跳び四とも 1st pass の `classifyFourInDirection` に一本化・issue #134）。
         //
-        // 跳び四側（1st pass）は五点列挙（`isFourInDirection`）に寄せたが、**連続四側は
-        // 端ベースのまま**。`count == 4` に限れば両者は等価である:
+        // 旧実装の連続四側は端ベース（`blackOverlineEnd` による長連補正込み）だったが、
+        // `count == 4` に限れば五点列挙と等価である:
         //   - 偽陽性なし: 端が空きかつ長連補正を通れば、その端を埋めると必ずちょうど 5
         //   - 偽陰性なし: 連続 4 連の五点は両端のいずれかにしか存在しえない
         //     （離れた空点を埋めても 4 連と繋がらない）
-        // 統一（`classifyFourInDirection` への集約）は follow-up issue #134 で扱う。
-        if (lut.count == 4) {
-            const dir = board_mod.DIRECTIONS[i];
-            const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
-            const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
-            var e1 = pos.end_state;
-            var e2 = neg.end_state;
-            if (color == .black) {
-                if (e1 == .empty and blackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
-                    e1 = .opponent;
-                }
-                if (e2 == .empty and blackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
-                    e2 = .opponent;
-                }
-            }
-            if (e1 == .empty or e2 == .empty) {
-                has_four = true;
-            }
+        if (four_classes[i] != .not_four) {
+            has_four = true;
         }
 
         // 連続三の有効性チェック（跳び四方向でなければ）
@@ -211,11 +200,6 @@ pub fn createsFourThree(cells: []Cell, row: u8, col: u8, color: Cell) bool {
                     has_valid_open_three = true;
                 }
             }
-        }
-
-        // 跳び四
-        if (jump_four_dirs[i]) {
-            has_four = true;
         }
 
         // 跳び三 (LUT版: 連続三がなく、跳び四もない場合のみ)
@@ -774,4 +758,56 @@ test "createsFourThree: 同じ形でも白なら本物の四三（回帰・白�
     bitboard.initFromCells(&cells);
 
     try std.testing.expect(createsFourThree(&cells, 7, 7, .white));
+}
+
+// === issue #134: 連続四の旧基準（端ベース）と classifyFourInDirection の等価性 ===
+
+/// `createsFourThree` が #134 以前に使っていた連続四の判定（端ベース・黒の長連補正込み）。
+/// 新実装（`threats.classifyFourInDirection`）との差分が 0 であることを全列挙で固定する。
+fn legacyConsecutiveFour(cells: []const Cell, row: u8, col: u8, dir_idx: usize, color: Cell) struct {
+    has_four: bool,
+    open_four: bool,
+} {
+    const dir = board_mod.DIRECTIONS[dir_idx];
+    const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
+    const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
+    var e1 = pos.end_state;
+    var e2 = neg.end_state;
+    if (color == .black) {
+        if (e1 == .empty and blackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
+            e1 = .opponent;
+        }
+        if (e2 == .empty and blackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
+            e2 = .opponent;
+        }
+    }
+    return .{
+        .has_four = e1 == .empty or e2 == .empty,
+        .open_four = e1 == .empty and e2 == .empty,
+    };
+}
+
+fn assertLegacyConsecutiveFourMatches(cells: *[CELL_COUNT]Cell, line_start: u8) anyerror!void {
+    for (0..9) |i| {
+        const col: u8 = line_start + @as(u8, @intCast(i));
+        const color = cells[7 * BOARD_SIZE + col];
+        if (color == .empty) continue;
+
+        const lut = ll.queryPatternByCell(7, col, 0, color);
+        // 旧実装が連続四を見ていたのは `lut.count == 4` の方向だけ
+        if (lut.count != 4) continue;
+
+        const legacy = legacyConsecutiveFour(cells, 7, col, 0, color);
+        const cls = threats.classifyFourInDirection(cells, 7, col, 0, color, lut, null);
+
+        // 「四かどうか」が一致（偽陽性・偽陰性ともゼロ）
+        try std.testing.expectEqual(legacy.has_four, cls != .not_four);
+        // 「活四かどうか」（両端空き ⇔ 五点 2 個以上）も一致
+        try std.testing.expectEqual(legacy.open_four, cls == .unstoppable);
+    }
+}
+
+test "issue #134: 連続四の端ベース旧基準と classifyFourInDirection は等価（1ライン全列挙）" {
+    ll.init();
+    try threats.forEachLinePattern(assertLegacyConsecutiveFourMatches);
 }

--- a/zig/src/quiescence.zig
+++ b/zig/src/quiescence.zig
@@ -91,34 +91,22 @@ pub fn createsFour(cells: []const Cell, row: u8, col: u8, color: Cell) bool {
 pub const FOUR_DEFENSE_NOT_FOUR: u8 = 254;
 pub const FOUR_DEFENSE_UNSTOPPABLE: u8 = 255;
 
-pub const FourDefense = union(enum) {
-    /// どの方向でも四になっていない（五点 0 個）。脅威ではない。
-    not_four,
-    /// 四だが受け点が 2 つ以上ある ＝ 活四。1 手では止められない。
-    unstoppable,
-    /// 止め四。この 1 点で受かる。
-    block: Position,
-
-    /// 受け点があればそれを返す。`not_four` / `unstoppable` はどちらも `null`。
-    /// 「四なら必ず受ける／それ以外は保守的に打ち切る」呼び出し側（vct.zig）向け。
-    pub fn blockPos(self: FourDefense) ?Position {
-        return switch (self) {
-            .block => |p| p,
-            else => null,
-        };
-    }
-};
+/// 方向ごとの分類（`threats.FourClass`）と同じ 3 値。issue #134 で 1 つの型に統一した。
+/// - `not_four`: どの方向でも四になっていない（五点 0 個）。脅威ではない。
+/// - `unstoppable`: 四だが受け点が 2 つ以上ある ＝ 活四。1 手では止められない。
+/// - `block`: 止め四。この 1 点で受かる。
+pub const FourDefense = threats.FourClass;
 
 /// 四に対する防御位置を取得
 /// 四は1点でしか止められないのでその位置を返す
 /// 石配置済み前提、bitboard も同期済み前提。
 /// TS版 threatPatterns.ts の getFourDefensePosition に対応
 ///
-/// 連続四・跳び四を区別せず、方向ごとに「その方向で埋めると五になる点」を
-/// `threats.collectLineFivePoints` で列挙して判定する（受け点の SSoT）。
-/// - 五点 0 個: この方向は四ではない（黒の長連にしかならない四）→ 無視
-/// - 五点 2 個以上: 両方は塞げない ＝ 活四（防御不可）→ `.unstoppable`
-/// - 五点 1 個: 止め四。その点が受け → `.block`
+/// 連続四・跳び四を区別せず、方向ごとの分類（`threats.classifyFourInDirection`
+/// ＝ 四判定・受け点の SSoT・issue #134）を 4 方向で畳み込む。
+/// - `.not_four`: この方向は四ではない（黒の長連にしかならない四）→ 無視
+/// - `.unstoppable`: 両方は塞げない ＝ 活四（防御不可）→ 即返す
+/// - `.block`: 止め四。その点が受け（複数方向あれば最初の 1 点）
 /// - どの方向も四でなかった → `.not_four`
 ///
 /// issue #115: 以前は跳び四で `findJumpGapPosition` の返り値を検証せずに
@@ -131,17 +119,15 @@ pub const FourDefense = union(enum) {
 pub fn getFourDefensePosition(cells: []const Cell, last_row: u8, last_col: u8, color: Cell) FourDefense {
     var first_defense: ?Position = null;
 
-    for (DIRECTIONS, 0..) |dir, i| {
-        // NOTE: この分岐は 5 箇所に複製されている。SSoT 統合は issue #134。
+    for (0..DIRECTIONS.len) |i| {
         const result = ll.queryPatternByCell(last_row, last_col, i, color);
-        if (result.count != 4 and !result.has_jump_four) continue;
-
-        var five_points = threats.PositionList.init();
-        _ = threats.collectLineFivePoints(cells, last_row, last_col, dir.dr, dir.dc, color, &five_points);
-
-        if (five_points.len == 0) continue;
-        if (five_points.len >= 2) return .unstoppable;
-        if (first_defense == null) first_defense = five_points.items[0];
+        switch (threats.classifyFourInDirection(cells, last_row, last_col, i, color, result, null)) {
+            .not_four => {},
+            .unstoppable => return .unstoppable,
+            .block => |p| if (first_defense == null) {
+                first_defense = p;
+            },
+        }
     }
 
     if (first_defense) |p| return .{ .block = p };

--- a/zig/src/threats.zig
+++ b/zig/src/threats.zig
@@ -1137,10 +1137,13 @@ test "issue #121: 白なら同じ形は本物の跳び四（長連が禁じら�
 
 // === issue #134: classifyFourInDirection（四判定・受け点の SSoT）の全列挙固定 ===
 
-/// row 7 の連続 9 マスに 3^9 通りの空/黒/白を敷いて全列挙する。
+/// **テスト専用**。row 7 の連続 9 マスに 3^9 通りの空/黒/白を敷いて全列挙する。
 /// 盤端で切れる形も含めるため開始列を 3 通り回す
 /// （TS `search/fourDefenseParity.wasm.test.ts` と同形式）。
-pub fn forEachLinePattern(
+///
+/// 盤面の敷き直しは 3^9 × 3 = 59,049 回と重いので、確認したい不変条件は
+/// **1 つの body にまとめて 1 周で**回すこと（pre-commit で毎回走る）。
+fn forEachLinePattern(
     comptime body: fn (cells: *[CELL_COUNT]Cell, line_start: u8) anyerror!void,
 ) !void {
     const LINE_LEN: usize = 9;
@@ -1167,7 +1170,48 @@ pub fn forEachLinePattern(
     }
 }
 
-fn assertClassifyMatchesIsFour(cells: *[CELL_COUNT]Cell, line_start: u8) anyerror!void {
+/// **テスト専用**。`evaluate.createsFourThree` / TS `analyzeJumpPatterns` が #134 以前に
+/// 使っていた**連続四の旧基準**（端ベース・黒の長連補正込み）の参照実装。
+///
+/// 長連補正（`evaluate.blackOverlineEnd` と同じ規則）もここに写して自己完結させてある。
+/// 本体側の実装が変わってもこの参照実装は変わらないので、新旧差分 0 の固定に使える。
+/// `open_four`（両端空き）は旧 Zig には無く TS `analyzeJumpPatterns.hasOpenFour` に
+/// 対応する項目で、統一後は「五点 2 個以上 ＝ `.unstoppable`」と一致すべきもの。
+fn legacyConsecutiveFour(cells: []const Cell, row: u8, col: u8, dir_idx: usize, color: Cell) struct {
+    has_four: bool,
+    open_four: bool,
+} {
+    const dir = DIRECTIONS[dir_idx];
+    const pos = board_mod.countInDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
+    const neg = board_mod.countInDirectionOnCells(cells, row, col, -dir.dr, -dir.dc, color);
+    var e1 = pos.end_state;
+    var e2 = neg.end_state;
+    if (color == .black) {
+        if (e1 == .empty and legacyBlackOverlineEnd(cells, row, col, dir.dr, dir.dc, pos.count)) {
+            e1 = .opponent;
+        }
+        if (e2 == .empty and legacyBlackOverlineEnd(cells, row, col, -dir.dr, -dir.dc, neg.count)) {
+            e2 = .opponent;
+        }
+    }
+    return .{
+        .has_four = e1 == .empty or e2 == .empty,
+        .open_four = e1 == .empty and e2 == .empty,
+    };
+}
+
+/// **テスト専用**。`evaluate.blackOverlineEnd` の写し（旧基準の参照実装の一部）。
+/// empty 端の「gap の 1 つ先」が黒なら、その端へ伸ばすと 6 連＝長連なので塞がり扱い。
+fn legacyBlackOverlineEnd(cells: []const Cell, row: u8, col: u8, dr: i8, dc: i8, run: u8) bool {
+    const steps: i16 = @as(i16, run) + 2;
+    const r: i16 = @as(i16, row) + dr * steps;
+    const c: i16 = @as(i16, col) + dc * steps;
+    if (!board_mod.isValid(r, c)) return false;
+    const idx: u16 = @intCast(@as(u16, @intCast(r)) * BOARD_SIZE + @as(u16, @intCast(c)));
+    return cells[idx] == .black;
+}
+
+fn assertFourClassInvariants(cells: *[CELL_COUNT]Cell, line_start: u8) anyerror!void {
     for (0..9) |i| {
         const col: u8 = line_start + @as(u8, @intCast(i));
         const color = cells[7 * BOARD_SIZE + col];
@@ -1201,9 +1245,21 @@ fn assertClassifyMatchesIsFour(cells: *[CELL_COUNT]Cell, line_start: u8) anyerro
 
         // 3. `out` に渡した五点は列挙結果と一致する
         try std.testing.expectEqual(five_count, five_points.len);
+
+        // 4. 連続四の旧基準（端ベース）との差分が 0（`evaluate.createsFourThree` /
+        //    TS `analyzeJumpPatterns` の連続四側を五点列挙に統一した根拠・issue #134）。
+        //    旧実装が連続四を見ていたのは `lut.count == 4` の方向だけ。
+        if (lut.count == 4) {
+            const legacy = legacyConsecutiveFour(cells, 7, col, 0, color);
+            // 「四かどうか」が一致（偽陽性・偽陰性ともゼロ）
+            try std.testing.expectEqual(legacy.has_four, cls != .not_four);
+            // 「活四かどうか」（両端空き ⇔ 五点 2 個以上）も一致
+            try std.testing.expectEqual(legacy.open_four, cls == .unstoppable);
+        }
     }
 }
 
-test "issue #134: classifyFourInDirection は isFourInDirection と同値（1ライン全列挙）" {
-    try forEachLinePattern(assertClassifyMatchesIsFour);
+test "issue #134: 四分類の不変条件（1ライン全列挙）" {
+    ll.init();
+    try forEachLinePattern(assertFourClassInvariants);
 }

--- a/zig/src/threats.zig
+++ b/zig/src/threats.zig
@@ -415,10 +415,74 @@ pub fn isFourInDirection(cells: []const Cell, row: u8, col: u8, dir_idx: usize, 
     return isFourInDirectionWithPattern(cells, row, col, dir_idx, color, ll.queryPatternByCell(row, col, dir_idx, color));
 }
 
+/// 四の分類（issue #134 の SSoT）
+///
+/// 「プリフィルタ → `collectLineFivePoints` → 五点 0 / 1 / 2 個以上で分岐」という
+/// パターンは以前 5 箇所（Zig 3 + TS 2）に複製されていた。その分岐の定義はこの型
+/// ただ 1 つとし、方向ごとの分類（`classifyFourInDirection`）と 4 方向の畳み込み
+/// （`quiescence.getFourDefensePosition` = `FourDefense` エイリアス）で共有する。
+///
+/// TS 側は `search/threatMoves.ts` の `FourClass` が対応する（脅威系は二重実装。
+/// どちらかを変えたら必ず両方直し、`fourDefenseParity.wasm.test.ts` で確認すること）。
+pub const FourClass = union(enum) {
+    /// 五点 0 個。四ではない（黒の長連にしかならない形を含む）。
+    not_four,
+    /// 五点 2 個以上 ＝ 活四。1 手では止められない。
+    unstoppable,
+    /// 五点 1 個 ＝ 止め四。その 1 点が受け。
+    block: Position,
+
+    /// 受け点があればそれを返す。`not_four` / `unstoppable` はどちらも `null`。
+    /// 「四なら必ず受ける／それ以外は保守的に打ち切る」呼び出し側（vct.zig）向け。
+    pub fn blockPos(self: FourClass) ?Position {
+        return switch (self) {
+            .block => |p| p,
+            else => null,
+        };
+    }
+};
+
+/// その方向の四を分類する（四判定・受け点の SSoT・issue #134）
+///
+/// LUT (`result`) の四パターン判定は候補の絞り込み（高速な足切り）にのみ使い、
+/// 最終判断は必ず五点の列挙（`collectLineFivePoints`）で行う。
+/// LUT は中心 ±4 マスの窓しか見ないため、窓の外の自石でギャップ埋めが長連になる
+/// 黒の形も「跳び四」と報告するが、五点列挙はそれを 0 個と数える（issue #121）。
+///
+/// `out` に非 null を渡すと、見つかった五点をすべて追加する（`addUnique`）。
+/// 受け点そのものが要らない呼び出し側は null を渡してよい。
+pub fn classifyFourInDirection(
+    cells: []const Cell,
+    row: u8,
+    col: u8,
+    dir_idx: usize,
+    color: Cell,
+    result: ll.PatternResult,
+    out: ?*PositionList,
+) FourClass {
+    if (result.count != 4 and !result.has_jump_four) return .not_four;
+
+    const dir = DIRECTIONS[dir_idx];
+    var five_points = PositionList.init();
+    const five_count = collectLineFivePoints(cells, row, col, dir.dr, dir.dc, color, &five_points);
+    if (five_count == 0) return .not_four;
+
+    if (out) |list| list.addUniqueList(&five_points);
+    if (five_count >= 2) return .unstoppable;
+    return .{ .block = five_points.items[0] };
+}
+
 /// `isFourInDirection` の LUT 結果を呼び出し側から渡す版。
 ///
 /// 呼び出し側が既に `queryPatternByCell` を引いている場合（`classifyThreat` /
 /// `checkDefenseCounterThreat`）に同じクエリを二重に走らせないため。
+///
+/// 意味論は `classifyFourInDirection(...) != .not_four` と同値（issue #134）。
+/// ただし分類には「五点が 1 個か 2 個以上か」の確定が要るのでライン全体の走査が
+/// 必要なのに対し、boolean 用途は最初の 1 点で打ち切れる。`countThreatDirections`
+/// などのホットパス向けにこちらは早期打ち切り版（`hasLineFivePoint`）を維持する。
+/// **五点走査の定義は `scanLineFivePoints` で共有**しており、両者の同値性は
+/// `test "classifyFourInDirection と isFourInDirection は同値"` で全列挙固定している。
 pub fn isFourInDirectionWithPattern(
     cells: []const Cell,
     row: u8,
@@ -586,15 +650,12 @@ fn detectThreatsCore(cells: []Cell, opponent_color: Cell, comptime use_cells_que
                 const end1 = lutEnd(lut.end1);
                 const end2 = lutEnd(lut.end2);
 
-                // 四（連続四・跳び四とも五点の列挙に一本化・issue #121 / #124）
+                // 四（連続四・跳び四とも五点の列挙に一本化・issue #121 / #124 / #134）
                 //
-                // 「四の受け＝そのラインで埋めると本当に五になる点」という一つの基準
-                // （`collectLineFivePoints`。`quiescence.getFourDefensePosition` /
-                // `vct.getThreatDefensePositions` と同じ SSoT）で判定する。
-                //
-                // - 五点 2 個以上: どちらを塞いでも五にされる ＝ 活四
-                // - 五点 1 個: 止め四。その 1 点が受け
-                // - 五点 0 個: この方向は四ではない（黒の長連にしかならない）
+                // 分類は `classifyFourInDirection`（四判定・受け点の SSoT）に委ねる。
+                // - `.unstoppable`（五点 2 個以上）: どちらを塞いでも五にされる ＝ 活四
+                // - `.block`（五点 1 個）: 止め四。その 1 点が受け
+                // - `.not_four`（五点 0 個）: この方向は四ではない（黒の長連にしかならない）
                 //   → 四扱いをやめ、下の活三ブランチで受けを列挙する
                 //
                 // 旧実装は LUT の `count == 4` / `has_jump_four` をそのまま四とみなし、
@@ -602,19 +663,13 @@ fn detectThreatsCore(cells: []Cell, opponent_color: Cell, comptime use_cells_que
                 // ±4 マスの窓しか見ないため、窓の外の自石でギャップ埋めが長連になる
                 // 黒の形を四と誤判定し、しかも `is_jump_four` が活三の受け列挙まで
                 // 抑止していた（issue #121）。
-                // NOTE: この「プリフィルタ → collectLineFivePoints → 0/1/2 個で分岐」は
-                // 5 箇所に複製されている。SSoT 統合は issue #134。
-                var is_four = false;
-                if (lut.count == 4 or lut.has_jump_four) {
-                    var five_points = PositionList.init();
-                    const five_count = collectLineFivePoints(cells, row, col, dir.dr, dir.dc, opponent_color, &five_points);
-                    if (five_count >= 2) {
-                        is_four = true;
-                        result.open_fours.addUniqueList(&five_points);
-                    } else if (five_count == 1) {
-                        is_four = true;
-                        result.fours.addUniqueList(&five_points);
-                    }
+                var five_points = PositionList.init();
+                const four_class = classifyFourInDirection(cells, row, col, dir_idx, opponent_color, lut, &five_points);
+                const is_four = four_class != .not_four;
+                switch (four_class) {
+                    .unstoppable => result.open_fours.addUniqueList(&five_points),
+                    .block => result.fours.addUniqueList(&five_points),
+                    .not_four => {},
                 }
 
                 // 活三: 両端が空いている3連（四が成立している方向は四の受けが優先）
@@ -1078,4 +1133,77 @@ test "issue #121: 白なら同じ形は本物の跳び四（長連が禁じら�
     const result = detectOpponentThreats(&cells, .white);
     try std.testing.expect(result.fours.contains(7, 4));
     try std.testing.expectEqual(@as(u8, 1), countThreatDirections(&cells, 7, 6, .white));
+}
+
+// === issue #134: classifyFourInDirection（四判定・受け点の SSoT）の全列挙固定 ===
+
+/// row 7 の連続 9 マスに 3^9 通りの空/黒/白を敷いて全列挙する。
+/// 盤端で切れる形も含めるため開始列を 3 通り回す
+/// （TS `search/fourDefenseParity.wasm.test.ts` と同形式）。
+pub fn forEachLinePattern(
+    comptime body: fn (cells: *[CELL_COUNT]Cell, line_start: u8) anyerror!void,
+) !void {
+    const LINE_LEN: usize = 9;
+    const LINE_STARTS = [_]u8{ 0, 3, 6 };
+    const total: u32 = std.math.pow(u32, 3, @intCast(LINE_LEN));
+    var code: u32 = 0;
+    while (code < total) : (code += 1) {
+        for (LINE_STARTS) |line_start| {
+            var cells = [_]Cell{.empty} ** CELL_COUNT;
+            var rest = code;
+            for (0..LINE_LEN) |i| {
+                const v = rest % 3;
+                rest /= 3;
+                const idx = 7 * BOARD_SIZE + line_start + i;
+                if (v == 1) {
+                    cells[idx] = .black;
+                } else if (v == 2) {
+                    cells[idx] = .white;
+                }
+            }
+            bitboard.initFromCells(&cells);
+            try body(&cells, line_start);
+        }
+    }
+}
+
+fn assertClassifyMatchesIsFour(cells: *[CELL_COUNT]Cell, line_start: u8) anyerror!void {
+    for (0..9) |i| {
+        const col: u8 = line_start + @as(u8, @intCast(i));
+        const color = cells[7 * BOARD_SIZE + col];
+        if (color == .empty) continue;
+
+        const lut = ll.queryPatternByCell(7, col, 0, color);
+        var five_points = PositionList.init();
+        const cls = classifyFourInDirection(cells, 7, col, 0, color, lut, &five_points);
+
+        // 1. boolean 版（早期打ち切り）と 3 値版は同値
+        try std.testing.expectEqual(
+            cls != .not_four,
+            isFourInDirectionWithPattern(cells, 7, col, 0, color, lut),
+        );
+
+        // 2. 分類は五点の個数そのもの
+        var expected = PositionList.init();
+        const five_count = if (lut.count == 4 or lut.has_jump_four)
+            collectLineFivePoints(cells, 7, col, 0, 1, color, &expected)
+        else
+            0;
+        switch (cls) {
+            .not_four => try std.testing.expectEqual(@as(u8, 0), five_count),
+            .unstoppable => try std.testing.expect(five_count >= 2),
+            .block => |p| {
+                try std.testing.expectEqual(@as(u8, 1), five_count);
+                try std.testing.expectEqual(expected.items[0].row, p.row);
+                try std.testing.expectEqual(expected.items[0].col, p.col);
+            },
+        }
+
+        // 3. `out` に渡した五点は列挙結果と一致する
+        try std.testing.expectEqual(five_count, five_points.len);
+    }
+}
+
+test "issue #134: classifyFourInDirection は isFourInDirection と同値（1ライン全列挙）" {
+    try forEachLinePattern(assertClassifyMatchesIsFour);
 }

--- a/zig/src/vct.zig
+++ b/zig/src/vct.zig
@@ -341,42 +341,26 @@ pub fn findThreatMovesCounted(cells: []Cell, color: Cell, buf: *[225]Position) T
 // getThreatDefensePositions（TS版 vctHelpers.ts に対応）
 // =============================================================================
 
-/// 脅威に対する防御位置を取得
-/// 跳び四の受け点（＝そのラインで「埋めると本当に五になる」空点）を列挙する
-///
-/// 実体は `threats.collectLineFivePoints`（受け点の SSoT。
-/// `quiescence.getFourDefensePosition` も同じ関数を使う）。
-///
-/// 戻り値: 受け点を 1 つ以上追加できたか（false なら四として扱わず、
-/// 呼び出し側で三として受けを広く列挙する＝防御側に有利な健全側に倒す）
-fn addJumpFourDefensePositions(
-    cells: []const Cell,
-    row: u8,
-    col: u8,
-    dr: i8,
-    dc: i8,
-    color: Cell,
-    defense_positions: *PositionList,
-) bool {
-    return threats.collectLineFivePoints(cells, row, col, dr, dc, color, defense_positions) > 0;
-}
+// issue #134: `addJumpFourDefensePositions`（`collectLineFivePoints` の薄いラッパ）は
+// 呼び出し元ゼロだったため削除した。四の分類・受け点は
+// `threats.classifyFourInDirection`（SSoT）に一本化されている。
 
+/// 脅威（四・活三・跳び三）に対する防御位置を列挙する
 pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: Cell) PositionList {
     var defense_positions = PositionList.init();
 
     for (DIRECTIONS, 0..) |dir, i| {
         const result = ll.queryPatternByCell(row, col, i, color);
 
-        // 四（連続四・跳び四）の受け点（issue #115 / #124）
+        // 四（連続四・跳び四）の受け点（issue #115 / #124 / #134）
         //
-        // 「四の受け＝そのラインで埋めると本当に五になる点」という一つの基準
-        // （`threats.collectLineFivePoints`）に統一する。分類側
-        // （`classifyThreat` / `checkDefenseCounterThreat` = `isFourInDirection`）と
-        // 同じ関数を見るので、「四と分類したのに受け 0 点」が構造的に起きない。
+        // 分類は `threats.classifyFourInDirection`（四判定・受け点の SSoT）に委ねる。
+        // 分類側（`classifyThreat` / `checkDefenseCounterThreat` = `isFourInDirection`）と
+        // 同じ定義を見るので、「四と分類したのに受け 0 点」が構造的に起きない。
         //
-        // - 五点 2 個以上: 両方は塞げない＝活四 → 防御不可（空リスト）
-        // - 五点 1 個: 止め四。その 1 点が受け
-        // - 五点 0 個: この方向は四ではない（黒の長連にしかならない）
+        // - `.unstoppable`（五点 2 個以上）: 両方は塞げない＝活四 → 防御不可
+        // - `.block`（五点 1 個）: 止め四。その 1 点が受け
+        // - `.not_four`（五点 0 個）: この方向は四ではない（黒の長連にしかならない）
         //   → 四扱いをやめ、下の活三/跳び三ブランチで受けを広く列挙する
         //     （受けが広がる＝防御側に有利な健全側に倒す）
         //
@@ -384,19 +368,15 @@ pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: C
         // 「最も近いギャップ 1 つ」（`isJumpFourOverline`）で見ており、
         // 同一ライン上に長連ギャップと本物の五点が併存すると四ブランチごと落ちて
         // 受け 0 点になっていた（#124 レビュー指摘）。
-        // NOTE: この分岐は 5 箇所に複製されている。SSoT 統合は issue #134。
         var has_four = false;
-        if (result.count == 4 or result.has_jump_four) {
-            var five_points = PositionList.init();
-            const five_count = threats.collectLineFivePoints(cells, row, col, dir.dr, dir.dc, color, &five_points);
-            if (five_count >= 2) {
-                // 活四 = 防御不可
-                return PositionList.init();
-            }
-            if (five_count == 1) {
-                defense_positions.addUnique(five_points.items[0]);
+        switch (threats.classifyFourInDirection(cells, row, col, i, color, result, null)) {
+            // 活四 = 防御不可
+            .unstoppable => return PositionList.init(),
+            .block => |p| {
+                defense_positions.addUnique(p);
                 has_four = true;
-            }
+            },
+            .not_four => {},
         }
 
         // 活三をチェック（同方向に四がある場合は不要：四の防御が優先）

--- a/zig/src/vct.zig
+++ b/zig/src/vct.zig
@@ -429,8 +429,11 @@ pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: C
     }
 
     if (!has_threat) return .no_threat;
-    // 脅威はあるのに受け点が 1 つも出せなかったケース（跳び三の受けが空など）は
-    // 従来どおり「防御不可」に倒す（旧実装の `len == 0` + `isThreat` ガードと同値）。
+    // 「脅威はあるのに受け点が 1 つも出せない」ケースは、4 方向 × 88 ライン × 3 オフセット ×
+    // 3^9 × 両色の全列挙で**到達不能**であることを確認済み（PR #139 レビュー）。
+    // ここに到達したら跳び三の判定（LUT の `has_jump_three`）と受け列挙
+    // （`getJumpThreeDefensePositions`）が食い違っているということなので、
+    // 保守側（＝旧実装の `len == 0` + `isThreat` ガードと同じ「防御不可」）に倒す。
     if (defense_positions.len == 0) return .unstoppable;
     return .{ .positions = defense_positions };
 }
@@ -908,6 +911,8 @@ fn processBlockDefenses(
     // 呼び出し元（`evaluateCounterThreat` の ct=four 分岐）は `blockThreatContinues` で
     // `block_ct != .none` を確認済みなので、ここに来る `no_threat` は
     // 「ブロック石が五を作った（`block_ct == .win`）」ケースだけ。どちらも攻撃側の勝ち。
+    // なお `.win` を呼び出し元で早期 return しないため、五を作ったブロック石が別方向にも
+    // 脅威を持つと `.positions` に落ちて勝ちを取りこぼしうる（偽陰性・issue #140）。
     const block_def_positions = switch (getThreatDefensePositions(cells, block_pos.row, block_pos.col, color)) {
         // 防御不可 → ブロックの脅威で勝ち
         .unstoppable, .no_threat => return true,
@@ -1778,7 +1783,8 @@ fn processBlockDefensesSeq(
 
     const opponent = color.opposite();
     // `processBlockDefenses` と同じく、呼び出し元が `blockThreatContinues` で
-    // `block_ct != .none` を確認済みなので `no_threat` はブロック石が五を作った場合だけ。
+    // `block_ct != .none` を確認済みなので `no_threat` はブロック石が五を作った場合だけ
+    // （`.win` を早期 return しないことによる偽陰性は issue #140）。
     const block_def_positions = switch (getThreatDefensePositions(cells, block_pos.row, block_pos.col, color)) {
         // 防御不可 → ブロックの脅威で勝ち
         .unstoppable, .no_threat => {

--- a/zig/src/vct.zig
+++ b/zig/src/vct.zig
@@ -98,11 +98,11 @@ pub fn createsOpenThree(cells: []const Cell, row: u8, col: u8, color: Cell) bool
     return false;
 }
 
-/// 脅威が成立しているか（四または活三）
-pub fn isThreat(cells: []const Cell, row: u8, col: u8, color: Cell) bool {
-    const result = classifyThreat(cells, row, col, color);
-    return result.creates_four or result.creates_open_three;
-}
+// issue #130: `isThreat`（= `classifyThreat` の四 or 活三）は削除した。
+// 唯一の用途が `getThreatDefensePositions` の `len == 0` を「防御不可」と
+// 「そもそも脅威でない」に切り分けるガードで、その分岐は戻り値の 3 値化
+// （`ThreatDefense`）に吸収されたため、呼び出し元がゼロになった。
+// 脅威の有無が要るなら `classifyThreat` を直接使うこと。
 
 // =============================================================================
 // hasOpenThree（TS版 vctHelpers.ts に対応）
@@ -345,9 +345,35 @@ pub fn findThreatMovesCounted(cells: []Cell, color: Cell, buf: *[225]Position) T
 // 呼び出し元ゼロだったため削除した。四の分類・受け点は
 // `threats.classifyFourInDirection`（SSoT）に一本化されている。
 
+/// `getThreatDefensePositions` の結果（issue #130 で 3 値化）
+///
+/// 以前は `PositionList` を返し、`len == 0` が
+/// 「防御不可（活四）＝攻撃側の勝ち」と「そもそも脅威ではない」の両方を意味していた。
+/// 呼び出し側はいずれも `isThreat`（= `classifyThreat` 4 方向）を**もう一度**走らせて
+/// 前者だけを勝ちに倒していたが、ガードを付け忘れると静かに偽 VCT になる形だった
+/// （#124 のレビューで 2 箇所の付け忘れが見つかっている）。
+///
+/// 3 値にしたことで
+/// - 呼び出し側は網羅 switch で `no_threat` を必ず明示的に扱う（勝ちにできない）
+/// - `isThreat` の再計算が不要（脅威の有無は列挙の過程で分かっている）
+///
+/// `quiescence.FourDefense`（= `threats.FourClass`）の VCT 版にあたる。
+pub const ThreatDefense = union(enum) {
+    /// 四でも活三でもない ＝ そもそも脅威が成立していない。
+    /// `isThreat(cells, row, col, color) == false` と同値。
+    no_threat,
+    /// 脅威はあるが 1 手では受からない（活四など）＝ 攻撃側の勝ち。
+    unstoppable,
+    /// 受け点（1 点以上）。
+    positions: PositionList,
+};
+
 /// 脅威（四・活三・跳び三）に対する防御位置を列挙する
-pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: Cell) PositionList {
+pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: Cell) ThreatDefense {
     var defense_positions = PositionList.init();
+    // 脅威（四 or 活三 or 跳び三）が成立したか。判定基準は `classifyThreat`（= `isThreat`）と
+    // 同一（四: `classifyFourInDirection`、連続三: 受け点が 1 点以上、跳び三: LUT）。
+    var has_threat = false;
 
     for (DIRECTIONS, 0..) |dir, i| {
         const result = ll.queryPatternByCell(row, col, i, color);
@@ -371,18 +397,22 @@ pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: C
         var has_four = false;
         switch (threats.classifyFourInDirection(cells, row, col, i, color, result, null)) {
             // 活四 = 防御不可
-            .unstoppable => return PositionList.init(),
+            .unstoppable => return .unstoppable,
             .block => |p| {
                 defense_positions.addUnique(p);
                 has_four = true;
+                has_threat = true;
             },
             .not_four => {},
         }
 
         // 活三をチェック（同方向に四がある場合は不要：四の防御が優先）
         // 両端＋夏止め位置を返す getOpenThreeDefensePositions を使用（getLineEnds は両端のみで不足）
+        // 空リスト = 夏止め済み（活四にできない）＝ 脅威ではない、という基準は
+        // `classifyThreat` / `checkDefenseCounterThreat` と共有している。
         if (!has_four and result.count == 3 and result.end1 == 0 and result.end2 == 0) {
             const open_three_def = threats.getOpenThreeDefensePositions(cells, row, col, dir.dr, dir.dc, color);
+            if (open_three_def.len > 0) has_threat = true;
             for (0..open_three_def.len) |j| {
                 defense_positions.addUnique(open_three_def.items[j]);
             }
@@ -390,6 +420,7 @@ pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: C
 
         // 跳び三をチェック
         if (result.count != 3 and result.has_jump_three) {
+            has_threat = true;
             const jump_defense = threats.getJumpThreeDefensePositions(cells, row, col, dir.dr, dir.dc, color);
             for (0..jump_defense.len) |j| {
                 defense_positions.addUnique(jump_defense.items[j]);
@@ -397,7 +428,11 @@ pub fn getThreatDefensePositions(cells: []const Cell, row: u8, col: u8, color: C
         }
     }
 
-    return defense_positions;
+    if (!has_threat) return .no_threat;
+    // 脅威はあるのに受け点が 1 つも出せなかったケース（跳び三の受けが空など）は
+    // 従来どおり「防御不可」に倒す（旧実装の `len == 0` + `isThreat` ガードと同値）。
+    if (defense_positions.len == 0) return .unstoppable;
+    return .{ .positions = defense_positions };
 }
 
 // =============================================================================
@@ -870,12 +905,14 @@ fn processBlockDefenses(
 ) bool {
     const opponent = color.opposite();
 
-    const block_def_positions = getThreatDefensePositions(cells, block_pos.row, block_pos.col, color);
-
-    // 防御不可 → ブロックの脅威で勝ち
-    if (block_def_positions.len == 0) {
-        return true;
-    }
+    // 呼び出し元（`evaluateCounterThreat` の ct=four 分岐）は `blockThreatContinues` で
+    // `block_ct != .none` を確認済みなので、ここに来る `no_threat` は
+    // 「ブロック石が五を作った（`block_ct == .win`）」ケースだけ。どちらも攻撃側の勝ち。
+    const block_def_positions = switch (getThreatDefensePositions(cells, block_pos.row, block_pos.col, color)) {
+        // 防御不可 → ブロックの脅威で勝ち
+        .unstoppable, .no_threat => return true,
+        .positions => |p| p,
+    };
 
     for (0..block_def_positions.len) |i| {
         const bd_pos = block_def_positions.items[i];
@@ -961,19 +998,22 @@ pub fn hasVCT(
             return true;
         }
 
-        const defense_positions = getThreatDefensePositions(cells, move.row, move.col, color);
-
-        if (defense_positions.len == 0) {
-            // 防御不可 → 脅威が成立していれば勝ち
-            if (isThreat(cells, move.row, move.col, color)) {
+        // issue #130: 3 値なので「脅威でない手」を勝ちにできない（`isThreat` の再計算も不要）
+        const defense_positions = switch (getThreatDefensePositions(cells, move.row, move.col, color)) {
+            .unstoppable => {
+                // 防御不可 → 勝ち
                 cells[move_idx] = .empty;
                 bitboard.removeStone(move.row, move.col);
                 return true;
-            }
-            cells[move_idx] = .empty;
-            bitboard.removeStone(move.row, move.col);
-            continue;
-        }
+            },
+            .no_threat => {
+                // 四でも活三でもない ＝ 追い詰めの手ではない
+                cells[move_idx] = .empty;
+                bitboard.removeStone(move.row, move.col);
+                continue;
+            },
+            .positions => |p| p,
+        };
 
         // 全防御に対してVCTが継続するかチェック
         var all_defense_leads_to_vct = true;
@@ -1398,10 +1438,9 @@ fn findVCTSequenceRecursive(
             return true;
         }
 
-        const defense_positions = getThreatDefensePositions(cells, move.row, move.col, color);
-
-        if (defense_positions.len == 0) {
-            if (isThreat(cells, move.row, move.col, color)) {
+        // issue #130: 3 値なので「脅威でない手」を勝ちにできない（`isThreat` の再計算も不要）
+        const defense_positions = switch (getThreatDefensePositions(cells, move.row, move.col, color)) {
+            .unstoppable => {
                 cells[move_idx] = .empty;
                 bitboard.removeStone(move.row, move.col);
                 // 1手で終わるので即返却
@@ -1410,11 +1449,14 @@ fn findVCTSequenceRecursive(
                 // 受け不能の脅威で終端
                 if (context.collect_branches) context.out_node = g_tree_arena.addNode(move, 0, 0);
                 return true;
-            }
-            cells[move_idx] = .empty;
-            bitboard.removeStone(move.row, move.col);
-            continue;
-        }
+            },
+            .no_threat => {
+                cells[move_idx] = .empty;
+                bitboard.removeStone(move.row, move.col);
+                continue;
+            },
+            .positions => |p| p,
+        };
 
         // 全防御に対してVCTが継続するかチェック
         var all_defense_leads_to_vct = true;
@@ -1735,14 +1777,17 @@ fn processBlockDefensesSeq(
     };
 
     const opponent = color.opposite();
-    const block_def_positions = getThreatDefensePositions(cells, block_pos.row, block_pos.col, color);
-
-    // 防御不可 → ブロックの脅威で勝ち
-    if (block_def_positions.len == 0) {
-        result.found = true;
-        result.seq_len_valid = true;
-        return result;
-    }
+    // `processBlockDefenses` と同じく、呼び出し元が `blockThreatContinues` で
+    // `block_ct != .none` を確認済みなので `no_threat` はブロック石が五を作った場合だけ。
+    const block_def_positions = switch (getThreatDefensePositions(cells, block_pos.row, block_pos.col, color)) {
+        // 防御不可 → ブロックの脅威で勝ち
+        .unstoppable, .no_threat => {
+            result.found = true;
+            result.seq_len_valid = true;
+            return result;
+        },
+        .positions => |p| p,
+    };
 
     var longest_seq: [64]Position = undefined;
     var longest_len: u8 = 0;
@@ -2040,30 +2085,25 @@ pub fn findVCTSequenceFromFirstMove(
         return result;
     }
 
-    // 脅威かチェック
-    if (!isThreat(cells, first_move.row, first_move.col, color)) {
-        cells[idx] = .empty;
-        bitboard.removeStone(first_move.row, first_move.col);
-        return result;
-    }
-
-    // 防御位置を列挙
-    const defense_positions = getThreatDefensePositions(cells, first_move.row, first_move.col, color);
-
-    if (defense_positions.len == 0) {
-        // len==0 は「防御不可」と「そもそも脅威でない」の両方を表す（#124 レビュー）。
-        // 脅威が成立している場合だけ勝ちにする（hasVCT / findVCTSequenceRecursive と同じガード）。
-        const is_threat = isThreat(cells, first_move.row, first_move.col, color);
-        cells[idx] = .empty;
-        bitboard.removeStone(first_move.row, first_move.col);
-        if (!is_threat) {
+    // 防御位置を列挙（issue #130: 脅威判定は列挙と同時に返るので `isThreat` は不要）
+    const defense_positions = switch (getThreatDefensePositions(cells, first_move.row, first_move.col, color)) {
+        .no_threat => {
+            // 四でも活三でもない ＝ 追い詰めの初手ではない
+            cells[idx] = .empty;
+            bitboard.removeStone(first_move.row, first_move.col);
             return result;
-        }
-        result.sequence[0] = first_move;
-        result.len = 1;
-        result.found = true;
-        return result;
-    }
+        },
+        .unstoppable => {
+            // 防御不可の脅威 → 1 手で勝ち
+            cells[idx] = .empty;
+            bitboard.removeStone(first_move.row, first_move.col);
+            result.sequence[0] = first_move;
+            result.len = 1;
+            result.found = true;
+            return result;
+        },
+        .positions => |p| p,
+    };
 
     // 全防御に対してVCT継続＆最短継続を記録（攻撃側の最短勝ちライン）
     var main_defense: ?Position = null;
@@ -2297,24 +2337,22 @@ pub fn isVCTFirstMove(
         return true;
     }
 
-    // 脅威かチェック
-    if (!isThreat(cells, move_pos.row, move_pos.col, color)) {
-        cells[idx] = .empty;
-        bitboard.removeStone(move_pos.row, move_pos.col);
-        return false;
-    }
-
-    // 防御位置を列挙
-    const defense_positions = getThreatDefensePositions(cells, move_pos.row, move_pos.col, color);
-
-    if (defense_positions.len == 0) {
-        // len==0 は「防御不可」と「そもそも脅威でない」の両方を表す（#124 レビュー）。
-        // 脅威が成立している場合だけ勝ちにする（hasVCT と同じガード）。
-        const is_threat = isThreat(cells, move_pos.row, move_pos.col, color);
-        cells[idx] = .empty;
-        bitboard.removeStone(move_pos.row, move_pos.col);
-        return is_threat;
-    }
+    // 防御位置を列挙（issue #130: 脅威判定は列挙と同時に返るので `isThreat` は不要）
+    const defense_positions = switch (getThreatDefensePositions(cells, move_pos.row, move_pos.col, color)) {
+        .no_threat => {
+            // 四でも活三でもない ＝ 追い詰めの手ではない
+            cells[idx] = .empty;
+            bitboard.removeStone(move_pos.row, move_pos.col);
+            return false;
+        },
+        .unstoppable => {
+            // 防御不可の脅威 → 勝ち
+            cells[idx] = .empty;
+            bitboard.removeStone(move_pos.row, move_pos.col);
+            return true;
+        },
+        .positions => |p| p,
+    };
 
     // 全防御に対してVCTが継続するか
     for (0..defense_positions.len) |j| {
@@ -2372,6 +2410,16 @@ fn getTimestampMs() u32 {
 
 const testing = std.testing;
 
+/// テスト用: 受け点が列挙されていることを確認して一覧を取り出す。
+/// `no_threat` / `unstoppable` ならテスト失敗（意図した分岐かを明示させる）。
+fn expectPositions(defense: ThreatDefense) !PositionList {
+    return switch (defense) {
+        .positions => |p| p,
+        .no_threat => error.UnexpectedNoThreat,
+        .unstoppable => error.UnexpectedUnstoppable,
+    };
+}
+
 test "classifyThreat: four detection" {
     ll.init();
     var cells = [_]Cell{.empty} ** CELL_COUNT;
@@ -2423,7 +2471,7 @@ test "getThreatDefensePositions: four" {
     cells[7 * BOARD_SIZE + 8] = .black;
     bitboard.initFromCells(&cells);
 
-    const defense = getThreatDefensePositions(&cells, 7, 8, .black);
+    const defense = try expectPositions(getThreatDefensePositions(&cells, 7, 8, .black));
     // 止め四: (7,9) の1点で防御
     try testing.expect(defense.len == 1);
     try testing.expectEqual(defense.items[0].col, 9);
@@ -2440,8 +2488,8 @@ test "getThreatDefensePositions: open four" {
     bitboard.initFromCells(&cells);
 
     const defense = getThreatDefensePositions(&cells, 7, 8, .black);
-    // 活四: 防御不可
-    try testing.expectEqual(defense.len, 0);
+    // 活四: 防御不可（issue #130 で「脅威なし」と区別）
+    try testing.expectEqual(ThreatDefense.unstoppable, defense);
 }
 
 test "checkDefenseCounterThreat: basic" {
@@ -2631,7 +2679,7 @@ test "getThreatDefensePositions: black four with overline should not be undefend
 
     // E8を基準に脅威防御判定: G8方向はoverlineで塞がり
     // → 防御不可（空リスト）ではなく、B8を含む防御位置を返すべき
-    const defense = getThreatDefensePositions(&cells, 7, 4, .black);
+    const defense = try expectPositions(getThreatDefensePositions(&cells, 7, 4, .black));
     try testing.expect(defense.len > 0); // 防御可能
     try testing.expectEqual(defense.items[0].row, 7);
     try testing.expectEqual(defense.items[0].col, 1); // B8
@@ -2767,7 +2815,7 @@ test "getThreatDefensePositions: 活三の受けに夏止め位置を含む（�
     cells[7 * BOARD_SIZE + 3] = .white; // 負方向外側をブロック → 正方向(7,9)に夏止めが発生
     bitboard.initFromCells(&cells);
 
-    const defense = getThreatDefensePositions(&cells, 7, 6, .black);
+    const defense = try expectPositions(getThreatDefensePositions(&cells, 7, 6, .black));
     // 端 (7,4) と (7,8) は必ず含む
     var has_end1 = false;
     var has_end2 = false;
@@ -2798,9 +2846,9 @@ test "getThreatDefensePositions: 夏止め済みの活三は緊急の受け不�
 
     // getOpenThreeDefensePositions は空リストを返す（夏止め済み）
     // → この方向から受け点が追加されないことを確認
-    // 他方向（縦・斜め）に活三がないため defense.len == 0
+    // 他方向（縦・斜め）にも脅威がないので「脅威なし」（issue #130 で活四と区別）
     const defense = getThreatDefensePositions(&cells, 7, 6, .black);
-    try testing.expectEqual(@as(u8, 0), defense.len);
+    try testing.expectEqual(ThreatDefense.no_threat, defense);
 }
 
 test "checkDefenseCounterThreat: 夏止め済みの三のみを作る石は .none" {
@@ -3015,7 +3063,7 @@ test "getThreatDefensePositions: 長連にしかならない跳び四は受け�
     try testing.expect(classification.creates_open_three);
 
     // 受け点も同基準でなければならない: I8 の 1 点強制ではなく M8 / I8 / N8
-    const defense = getThreatDefensePositions(&cells, 7, 9, .black);
+    const defense = try expectPositions(getThreatDefensePositions(&cells, 7, 9, .black));
     try testing.expectEqual(@as(usize, 3), defense.len);
 
     var has_m8 = false;
@@ -3054,7 +3102,7 @@ test "getThreatDefensePositions: 同一ラインに長連ギャップと正当�
     try testing.expect(classifyThreat(&cells, 7, 9, .black).creates_four);
 
     // 受けは M8 の 1 点のみ（I8 は埋めると長連なので五点ではない）
-    const defense = getThreatDefensePositions(&cells, 7, 9, .black);
+    const defense = try expectPositions(getThreatDefensePositions(&cells, 7, 9, .black));
     try testing.expectEqual(@as(usize, 1), defense.len);
     try testing.expectEqual(@as(u8, 7), defense.items[0].row);
     try testing.expectEqual(@as(u8, 12), defense.items[0].col); // M8
@@ -3092,7 +3140,7 @@ test "getThreatDefensePositions: 最も近いギャップが長連でも遠い�
     try testing.expect(classifyThreat(&cells, 7, 7, .black).creates_four);
 
     // 受け点は G8 を含むこと（0 点＝防御不可にしてはならない）
-    const defense = getThreatDefensePositions(&cells, 7, 7, .black);
+    const defense = try expectPositions(getThreatDefensePositions(&cells, 7, 7, .black));
     try testing.expect(defense.len > 0);
     var has_g8 = false;
     for (0..defense.len) |i| {
@@ -3179,7 +3227,7 @@ test "issue #117 前提: カウンター四のブロック石は三しか作ら�
     // 白の四 (3,7) の受けは (3,8) 一点
     cells[3 * BOARD_SIZE + 7] = .white;
     bitboard.placeStone(3, 7, .white);
-    const def = getThreatDefensePositions(&cells, 3, 7, .white);
+    const def = try expectPositions(getThreatDefensePositions(&cells, 3, 7, .white));
     try testing.expectEqual(@as(usize, 1), def.len);
     try testing.expectEqual(@as(u8, 3), def.items[0].row);
     try testing.expectEqual(@as(u8, 8), def.items[0].col);
@@ -3584,4 +3632,86 @@ test "VCT探索は委譲した VCF のノードも予算に計上する（issue 
     try testing.expect(vcf_only2.nodes > 0);
     const vct2 = findVCTSequence(&cells2, .white, 6, 0, 0, false, .lenient);
     try testing.expect(vct2.nodes >= vcf_only2.nodes);
+}
+
+// === issue #130: getThreatDefensePositions の 3 値化 ===
+
+test "issue #130: 脅威でない手は no_threat（活四の防御不可と区別する）" {
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    // 孤立した黒石: 四でも三でもない
+    cells[7 * BOARD_SIZE + 7] = .black;
+    bitboard.initFromCells(&cells);
+
+    try testing.expectEqual(ThreatDefense.no_threat, getThreatDefensePositions(&cells, 7, 7, .black));
+    // 分類側とも一致（脅威ゼロ）
+    const c = classifyThreat(&cells, 7, 7, .black);
+    try testing.expect(!c.creates_four and !c.creates_open_three);
+}
+
+test "issue #130: 偽跳び四の裏のウソ三も no_threat（issue #121 の形）" {
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    // 8 行目に黒 C8 D8 _ F8 G8 H8。E8 を埋めると 6 連＝長連なので四ではなく、
+    // F8 G8 H8 も達四にできないウソ三。つまり脅威が成立していない。
+    for ([_]u8{ 2, 3, 5, 6, 7 }) |c| {
+        cells[7 * BOARD_SIZE + c] = .black;
+    }
+    bitboard.initFromCells(&cells);
+
+    // 旧実装ではこの手の受け点は「G8 の連続三の受け」が出るので positions になるが、
+    // 四としては成立していない（受けが広い＝防御側有利の健全側）。
+    // 少なくとも「受け 0 点 ＝ 防御不可（＝攻撃側の勝ち）」にはならないことを固定する。
+    switch (getThreatDefensePositions(&cells, 7, 6, .black)) {
+        .unstoppable => return error.FalseUnstoppable,
+        .no_threat, .positions => {},
+    }
+}
+
+test "issue #130: 活四は unstoppable・止め四は positions（#129 レビューの再現形）" {
+    // 8 行目（row=7）: C8白 D8黒 E8黒 F8黒 G8空 H8黒 I8空 J8黒 K8黒 L8黒 M8黒 N8白
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 2] = .white; // C8
+    cells[7 * BOARD_SIZE + 3] = .black; // D8
+    cells[7 * BOARD_SIZE + 4] = .black; // E8
+    cells[7 * BOARD_SIZE + 5] = .black; // F8
+    cells[7 * BOARD_SIZE + 7] = .black; // H8
+    cells[7 * BOARD_SIZE + 9] = .black; // J8
+    cells[7 * BOARD_SIZE + 10] = .black; // K8
+    cells[7 * BOARD_SIZE + 11] = .black; // L8
+    cells[7 * BOARD_SIZE + 12] = .black; // M8
+    cells[7 * BOARD_SIZE + 13] = .white; // N8
+    bitboard.initFromCells(&cells);
+
+    // H8 は止め四（受けは G8。I8 は埋めると長連なので五点ではない）
+    const h8 = try expectPositions(getThreatDefensePositions(&cells, 7, 7, .black));
+    try testing.expect(h8.contains(7, 6));
+
+    // N8 の白石は孤立（黒に挟まれているだけ）＝脅威なし
+    try testing.expectEqual(ThreatDefense.no_threat, getThreatDefensePositions(&cells, 7, 13, .white));
+
+    // 白の活四は unstoppable
+    var open4 = [_]Cell{.empty} ** CELL_COUNT;
+    for ([_]u8{ 5, 6, 7, 8 }) |c| {
+        open4[7 * BOARD_SIZE + c] = .white;
+    }
+    bitboard.initFromCells(&open4);
+    try testing.expectEqual(ThreatDefense.unstoppable, getThreatDefensePositions(&open4, 7, 8, .white));
+}
+
+test "issue #130: 脅威でない初手から VCT は成立しない（isVCTFirstMove / findVCTSequenceFromFirstMove）" {
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 7] = .black;
+    cells[9 * BOARD_SIZE + 9] = .white;
+    bitboard.initFromCells(&cells);
+
+    // (0,0) は孤立点＝四でも活三でもないので VCT の初手になり得ない
+    // （3 値化前は `getThreatDefensePositions` の空リストを「防御不可」と読み違えると
+    //   ここが true になった。ガードではなく型で防いでいることの固定）
+    try testing.expect(!isVCTFirstMove(&cells, .{ .row = 0, .col = 0 }, .black, 4, 0, 0));
+
+    const seq = findVCTSequenceFromFirstMove(&cells, .{ .row = 0, .col = 0 }, .black, 4, 0, 0, false);
+    try testing.expect(!seq.found);
 }


### PR DESCRIPTION
四判定・受け点の分岐（#134）と `getThreatDefensePositions` の `len == 0` 多義性（#130）を、SSoT 統合と型による分岐の強制でまとめて解消します。base は development。

コミットは 2 本:

| | 内容 |
|---|---|
| `62b186e` | #134: 四判定・受け点の 3 分岐を `classifyFourInDirection` に統合 |
| `9e86ec4` | #130: `getThreatDefensePositions` を 3 値化し `len == 0` の多義性を解消 |
| `e22e6f2` | **レビュー反映**: 四判定のホットパスを早期打ち切り版に戻す・型と網羅性の整理・全列挙テストの重複解消 |

---

## #134: 「プリフィルタ → collectLineFivePoints → 0/1/2 個で分岐」の SSoT 化

### 新設した SSoT

```zig
// zig/src/threats.zig
pub const FourClass = union(enum) { not_four, unstoppable, block: Position };
pub fn classifyFourInDirection(cells, row, col, dir_idx, color, lut, out: ?*PositionList) FourClass
```

```ts
// src/logic/cpu/search/threatMoves.ts
export type FourClass =
  | { kind: "not_four" }
  | { kind: "unstoppable"; fivePoints: Position[] }
  | { kind: "block"; position: Position };
export function classifyFourInDirection(board, row, col, i, color, knownCount?): FourClass
```

`quiescence.FourDefense` は **`threats.FourClass` のエイリアス**にして 1 つの型に統一しました（タグ名・wasm 番兵・TS の `FourDefense` はそのままなので呼び出し側とテストの churn はゼロ）。TS 側も同様に **`threatPatterns.FourDefense = threatMoves.FourClass`** のエイリアスにして型の二重定義を解消しています（レビュー指摘）。TS は `Position[]` を返すのが自然なので `unstoppable` に五点を持たせ（畳み込み結果では意味を持たないので optional）、Zig は `out` ポインタで受け取る形にしています（`PositionList` を戻り値に持たせると 129B のコピーがホットパスに乗るため）。

### 統合前後の対応表

| 実装 | 変更前 | 変更後 |
|---|---|---|
| Zig `threats.detectThreatsCore` | LUT 足切り + `collectLineFivePoints` + 0/1/2 分岐をインライン | `classifyFourInDirection(..., &five_points)` の網羅 switch |
| Zig `vct.getThreatDefensePositions` | 同上（活四なら空リスト） | `classifyFourInDirection` の switch（活四は `.unstoppable`、#130） |
| Zig `quiescence.getFourDefensePosition` | 同上（4 方向を畳む） | `classifyFourInDirection` を 4 方向で畳むだけ |
| Zig `evaluate.createsFourThree` | 跳び四=五点列挙 / **連続四=端ベース（`blackOverlineEnd`）** の 2 基準 | 1st pass で `isFourInDirectionWithPattern`（同じ SSoT の早期打ち切り版）に一本化 |
| TS `search/threatPatterns.getFourDefensePosition` | インライン 3 分岐 | `classifyFourInDirection` の網羅 switch |
| TS `evaluation/threatDetection.detectOpponentThreats` | インライン 3 分岐 | `classifyFourInDirection` |
| TS `evaluation/jumpPatterns.analyzeJumpPatterns` | 跳び四=五点列挙 / **連続四=端ベース（`analyzeDirection`）** | `isFourInDirection` に一本化（活四が要る `count === 4` の方向だけ `classifyFourInDirection`） |

`isFourInDirection` / `isFourInDirectionWithPattern`（Zig / TS）は**薄いラッパにせず、早期打ち切り版のまま残しました**。分類には「五点が 1 個か 2 個以上か」の確定が要るのでライン全体の走査が必要ですが、boolean 用途は最初の 1 点で打ち切れます（#133 should-5 で `countThreatDirections` 向けに入れた最適化）。五点走査の定義（`scanLineFivePoints` / `collectLineFivePoints`）は共有したままで、**同値性は全列挙テストで固定**しています。

同じ理由で、**四かどうかの boolean しか要らない呼び出し側は 3 値の分類を引きません**（レビュー指摘）。`createsFourThree`（Zig）と `analyzeJumpPatterns`（TS）は `position_eval.computeMiseBonus → countMiseTargets` からムーブオーダリングのホットパスに乗るため、4 方向を無条件に分類すると純損になります。`analyzeJumpPatterns` は `hasOpenFour` の判定に活四かどうかが要るので、**`count === 4` かつ四だった方向に限って**分類を引きます。

### 死蔵の削除

- Zig `vct.addJumpFourDefensePositions`（`collectLineFivePoints` の薄いラッパ、呼び出し元ゼロ）
- TS `winningPatterns.createsFourThreeBit`（参照ゼロ。`analyzeJumpPatterns` の `precomputed` 経路の唯一の呼び出し元で、新旧等価性が検証されないまま残るため。レビュー指摘）
- `evaluate.blackOverlineEnd` は `hasPotentialMiseTarget`（count>=2 のプリフィルタ）で live なので存続

---

## #130: `getThreatDefensePositions` の 3 値化

```zig
pub const ThreatDefense = union(enum) {
    no_threat,               // 四でも活三でもない
    unstoppable,             // 防御不可（活四など）
    positions: PositionList, // 受け点（1 点以上）
};
```

呼び出し 6 箇所すべてを**網羅 switch**（else フォールスルーなし）に置き換えました。

| 呼び出し元 | 変更前 | 変更後 |
|---|---|---|
| `hasVCT` | `len==0` + `isThreat` ガード | `.unstoppable` → 勝ち / `.no_threat` → continue |
| `findVCTSequenceRecursive` | 同上 | 同上（勝ちは 1 手手順で即返却） |
| `findVCTSequenceFromFirstMove` | 事前 `isThreat` + `len==0` 時に再度 `isThreat`（#124 で追加） | `.no_threat` → 不成立 / `.unstoppable` → 1 手勝ち。**事前 `isThreat` も削除**（列挙と同時に分かるため） |
| `isVCTFirstMove` | 同上 | 同上 |
| `processBlockDefenses` | **ガードなし**で `len==0` → 勝ち | `.unstoppable, .no_threat => 勝ち`。`no_threat` に到達するのは呼び出し元が `blockThreatContinues` で `block_ct != .none` を確認済みのため **`block_ct == .win`（ブロック石が五）だけ**、という根拠をコメントで明示 |
| `processBlockDefensesSeq` | 同上 | 同上 |

### `isThreat` の削除

`vct.isThreat`（Zig）は唯一の用途がこのガードだったので呼び出し元ゼロになり、削除しました。TS `vctHelpers.isThreat` も参照ゼロ（Zig と対になる二重実装）だったので同時に削除しています（#43 の流れ）。脅威の有無が要るなら `classifyThreat` を直接使います。

### `no_threat` の定義が `isThreat` と一致していること

`getThreatDefensePositions` 内の `has_threat` は
四 = `classifyFourInDirection != .not_four`、連続三 = `getOpenThreeDefensePositions().len > 0`（夏止め済みは脅威でない）、跳び三 = `count != 3 && has_jump_three`
で立てており、これは `classifyThreat`（= 旧 `isThreat`）の 3 条件と**同一基準**です。したがって旧「`len == 0` かつ `isThreat`」→ 勝ち、は新「`.unstoppable`」に、旧「`len == 0` かつ `!isThreat`」→ 不成立、は新「`.no_threat`」に 1 対 1 対応します。

「脅威はあるが受け点が 0 個」は、レビュワーによる全列挙（4 方向 × 88 ライン × 3 オフセット × 3^9 × 両色）で**到達不能**であることが確認されました。到達したら跳び三の判定（LUT）と受け列挙（`getJumpThreeDefensePositions`）が食い違っているということなので、保守側（旧挙動と同じ `.unstoppable`）に倒す旨をコメントに明記しています。

---

## 挙動不変の根拠

リファクタ中心ですが対局 CPU 経路（VCT / 脅威検出 / ミセ生成）に触るので、同値性を機械的に固定しました。

1. **四分類の不変条件**（Zig, 新規・`threats.zig` の 1 テストに集約）
   row 7 の 9 マスに 3^9 × 開始列 3 通りを敷いた全列挙で、
   (a) `cls != .not_four == isFourInDirectionWithPattern`（早期打ち切り版との同値）、
   (b) 分類が五点の個数そのもの、(c) `out` の内容が列挙結果と一致、
   (d) **連続四の端ベース旧基準（`blackOverlineEnd` 込みの参照実装）との差分 0** を固定。
2. **連続四の端ベース旧基準 ⇔ 五点列挙**（TS、`fourDefenseParity.wasm.test.ts`・#134 の核心）
   **旧実装（`analyzeDirection` 端ベース）を参照実装として残した**うえで、`count === 4` の全方向で「四かどうか」「活四かどうか」の**新旧差分 0** を既存の全列挙ループ内で固定。#133 のコメントにあった等価性の主張がテストになりました。
   （Zig / TS とも全列挙ループは 1 本にまとめてあります＝盤面の敷き直しを二重に回さない。レビュー指摘）
3. **既存の TS⇄Zig パリティ**: `fourDefenseParity.wasm.test.ts`（3 窓 × 3^9）、`threatAdapter.test.ts`（`detectOpponentThreats` / `createsFourThree` の実戦棋譜パリティ）とも緑のまま。
4. **`reviewSnapshot.test.ts` のスナップショット無変更**。
5. `pnpm test` **122 files / 1880 tests 全緑**、`zig build test` / **`zig build test-slow` 全緑**、`pnpm check-fix` クリーン。

### 追加した #130 のテスト（Zig）

- 孤立石は `.no_threat`（活四の `.unstoppable` と区別されること）
- #121 の偽跳び四＋ウソ三の形が `.unstoppable`（＝偽の勝ち）にならないこと
- #129 レビューの再現形（`C8白 D8E8F8黒 G8空 H8黒 I8空 J8K8L8M8黒 N8白`）で H8 が `.positions`（受けに G8 を含む）／孤立白石が `.no_threat`／白の活四が `.unstoppable`
- 脅威でない初手から `isVCTFirstMove` / `findVCTSequenceFromFirstMove` が VCT を主張しないこと

## 対局 CPU への影響

**挙動不変を意図しています**（上記 1〜4 が根拠）。触れたのは分岐の書き方であって基準ではなく、唯一「基準が 2 つあった」`createsFourThree` / `analyzeJumpPatterns` の連続四側も、`count == 4` で新旧差分 0 を全列挙で確認しています。#130 も 6 箇所すべてが旧ガードと 1 対 1 対応です。

副次的に、`getThreatDefensePositions` を呼ぶたびに走っていた `isThreat`（= `classifyThreat` 4 方向）の**再計算が 6 箇所から消える**ので VCT 経路は少し軽くなるはずですが、bench 併走中のため計測はしていません。

四判定側はレビュー指摘を受けて、ホットパス（`createsFourThree` / `analyzeJumpPatterns`）を早期打ち切り版に戻したので、走査コストは #134 前と同等です。

## レビュー指摘への対応（`e22e6f2`）

must なし。should / nit を以下のとおり反映しました。

| # | 指摘 | 対応 |
|---|---|---|
| should 1 | **性能**: `createsFourThree` の 1st pass が boolean 用途なのに 4 方向とも全走査の分類を引いている（ムーブオーダリング経路に乗る純損） | `isFourInDirectionWithPattern`（同じ SSoT の早期打ち切り版）に変更。同値性は全列挙テストで凍結済み |
| should 2 | TS `analyzeJumpPatterns` も同型 | `isFourInDirection` に変更。活四が要る `count === 4` かつ四の方向でだけ `classifyFourInDirection` を引く。`count === 4` ガードの理由（跳び四方向は旧実装も `hasOpenFour` を立てなかった＝挙動不変）をコメントに明記 |
| should 3 | TS の網羅性 | `threatPatterns` の `default:` → `case "not_four":` + `never` 網羅チェック。`threatDetection` の if-else チェーン → switch（CLAUDE.md 規約） |
| should 4 | TS の型二重定義（`FourClass` / `FourDefense`） | `unstoppable.fivePoints` を optional にして **`export type FourDefense = FourClass`**（Zig の `FourDefense = threats.FourClass` と対称）。`FOUR_CLASS_NOT_FOUR` も共有 |
| should 5 | `vct.zig` の「脅威あり・受け点 0」コメント | 全列挙で**到達不能**を確認済みである旨と、到達したら跳び三判定と受け列挙の不整合を意味する旨に書き換え |
| should 6 | 全列挙ループの重複 | Zig: `evaluate.zig` のテストを `threats.zig` の 1 body に統合（旧基準の参照実装は長連補正込みで自己完結）。TS: 新 describe を廃し既存ループ内にアサーションを追加、`legacyConsecutiveFour` は計算済み `pattern` を受け取る |
| nit | `forEachLinePattern` の doc | 「テスト専用」＋「不変条件は 1 body にまとめる」旨を明記、`pub` をやめて private に |
| nit | TS `isFourInDirection` の同値性コメントが存在しないテストを指していた | 「足切り条件が同一 + 五点走査の定義共有による構造的保証」に訂正 |
| nit | `legacyConsecutiveFour.open_four` は旧 Zig に無い項目 | doc に「TS `hasOpenFour` に対応する項目」と明記 |
| nit | `fourClasses` の push | 固定長配列 + 添字代入（`isFourDirections`）に変更 |
| nit | `createsFourThreeBit` が死蔵 | 削除（未使用の import も整理） |
| nit | follow-up issue | **#140** を起票（`evaluateCounterThreat` の ct=four で `block_ct == .win` を即勝ちにしていない偽陰性）。該当箇所 2 つにコメントで参照 |

`classify` の temp → out 二重コピーと `vct.zig` の `.positions => |p| p` 値コピー（いずれも「任意」）は、どちらも 129B のスタックコピー 1 回で、ホットパスは早期打ち切り版に戻ったため見送りました。

Closes #130
Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
