### PR TITLE
fix: 評価・move ordering の五判定を色対応にし黒の長連を五から外す (#132)

### DIFF
--- a/src/logic/cpu/evaluation/directionAnalysis.test.ts
+++ b/src/logic/cpu/evaluation/directionAnalysis.test.ts
@@ -93,86 +93,136 @@ describe("analyzeDirection", () => {
 
 describe("getPatternScore", () => {
   it("五連はFIVEスコア", () => {
-    const score = getPatternScore({ count: 5, end1: "empty", end2: "empty" });
+    const score = getPatternScore(
+      { count: 5, end1: "empty", end2: "empty" },
+      "black",
+    );
     expect(score).toBe(PATTERN_SCORES.FIVE);
   });
 
   it("活四はOPEN_FOURスコア", () => {
-    const score = getPatternScore({ count: 4, end1: "empty", end2: "empty" });
+    const score = getPatternScore(
+      { count: 4, end1: "empty", end2: "empty" },
+      "black",
+    );
     expect(score).toBe(PATTERN_SCORES.OPEN_FOUR);
   });
 
   it("止め四はFOURスコア", () => {
-    const score = getPatternScore({
-      count: 4,
-      end1: "empty",
-      end2: "opponent",
-    });
+    const score = getPatternScore(
+      { count: 4, end1: "empty", end2: "opponent" },
+      "black",
+    );
     expect(score).toBe(PATTERN_SCORES.FOUR);
   });
 
   it("両端塞がりの四は0", () => {
-    const score = getPatternScore({
-      count: 4,
-      end1: "opponent",
-      end2: "opponent",
-    });
+    const score = getPatternScore(
+      { count: 4, end1: "opponent", end2: "opponent" },
+      "black",
+    );
     expect(score).toBe(0);
   });
 
   it("活三はOPEN_THREEスコア", () => {
-    const score = getPatternScore({ count: 3, end1: "empty", end2: "empty" });
+    const score = getPatternScore(
+      { count: 3, end1: "empty", end2: "empty" },
+      "black",
+    );
     expect(score).toBe(PATTERN_SCORES.OPEN_THREE);
   });
 
   it("止め三はTHREEスコア", () => {
-    const score = getPatternScore({ count: 3, end1: "empty", end2: "edge" });
+    const score = getPatternScore(
+      { count: 3, end1: "empty", end2: "edge" },
+      "black",
+    );
     expect(score).toBe(PATTERN_SCORES.THREE);
   });
 
   it("活二はOPEN_TWOスコア", () => {
-    const score = getPatternScore({ count: 2, end1: "empty", end2: "empty" });
+    const score = getPatternScore(
+      { count: 2, end1: "empty", end2: "empty" },
+      "black",
+    );
     expect(score).toBe(PATTERN_SCORES.OPEN_TWO);
   });
 
   it("止め二はTWOスコア", () => {
-    const score = getPatternScore({
-      count: 2,
-      end1: "empty",
-      end2: "opponent",
-    });
+    const score = getPatternScore(
+      { count: 2, end1: "empty", end2: "opponent" },
+      "black",
+    );
     expect(score).toBe(PATTERN_SCORES.TWO);
   });
 
-  it("長連（6以上）はFIVEスコア", () => {
-    const score = getPatternScore({ count: 6, end1: "empty", end2: "empty" });
-    expect(score).toBe(PATTERN_SCORES.FIVE);
+  // #132: 黒の長連は禁手なので五でも四でもない。白の長連は五（#125）。
+  it("黒の長連（6以上）は0点", () => {
+    for (let count = 6; count <= 10; count++) {
+      expect(
+        getPatternScore({ count, end1: "empty", end2: "empty" }, "black"),
+        `count=${count} bothOpen`,
+      ).toBe(0);
+      expect(
+        getPatternScore({ count, end1: "opponent", end2: "opponent" }, "black"),
+        `count=${count} blocked`,
+      ).toBe(0);
+    }
+  });
+
+  it("白の長連（6以上）はFIVEスコア", () => {
+    for (let count = 6; count <= 10; count++) {
+      expect(
+        getPatternScore({ count, end1: "empty", end2: "empty" }, "white"),
+        `count=${count}`,
+      ).toBe(PATTERN_SCORES.FIVE);
+    }
+  });
+
+  it("ちょうど五連は黒白ともFIVEスコア", () => {
+    expect(
+      getPatternScore({ count: 5, end1: "empty", end2: "empty" }, "white"),
+    ).toBe(PATTERN_SCORES.FIVE);
   });
 });
 
 describe("getPatternType", () => {
   it("五連はfive", () => {
-    expect(getPatternType({ count: 5, end1: "empty", end2: "empty" })).toBe(
-      "five",
-    );
+    expect(
+      getPatternType({ count: 5, end1: "empty", end2: "empty" }, "black"),
+    ).toBe("five");
   });
 
   it("活四はopenFour", () => {
-    expect(getPatternType({ count: 4, end1: "empty", end2: "empty" })).toBe(
-      "openFour",
-    );
+    expect(
+      getPatternType({ count: 4, end1: "empty", end2: "empty" }, "black"),
+    ).toBe("openFour");
   });
 
   it("止め四はfour", () => {
-    expect(getPatternType({ count: 4, end1: "empty", end2: "opponent" })).toBe(
-      "four",
-    );
+    expect(
+      getPatternType({ count: 4, end1: "empty", end2: "opponent" }, "black"),
+    ).toBe("four");
   });
 
   it("両端塞がりはnull", () => {
     expect(
-      getPatternType({ count: 4, end1: "opponent", end2: "opponent" }),
+      getPatternType({ count: 4, end1: "opponent", end2: "opponent" }, "black"),
     ).toBeNull();
+  });
+
+  // #132: 黒の長連は五でも四でもない
+  it("黒の長連（6以上）はnull・白の長連はfive", () => {
+    for (let count = 6; count <= 10; count++) {
+      expect(
+        getPatternType({ count, end1: "empty", end2: "empty" }, "black"),
+        `black count=${count}`,
+      ).toBeNull();
+      expect(
+        getPatternType({ count, end1: "empty", end2: "empty" }, "white"),
+        `white count=${count}`,
+      ).toBe("five");
+    }
   });
 });
 

--- a/src/logic/cpu/evaluation/directionAnalysis.ts
+++ b/src/logic/cpu/evaluation/directionAnalysis.ts
@@ -114,10 +114,15 @@ export function analyzeDirection(
  * パターンからスコアを計算
  *
  * 五の判定は `renjuRules.isFiveLength` に委ねる（SSoT・#125）。黒はちょうど 5 連、
- * 白は 5 連以上が五。**黒の 6 連以上は長連＝禁手なので五でも四でもなく 0 点**（#132）。
+ * 白は 5 連以上が五。**黒の 6 連以上は長連＝禁手なので五でも四でもなく 0 点**（#132、
+ * `renjuRules.isOverlineLength` と同値）。
  *
  * Zig 側の対は `zig/src/patterns.zig` の `getPatternScore`。
  * パリティテスト: `patternScoreParity.wasm.test.ts`
+ *
+ * ⚠️ **本番探索からの消費者はゼロ**（探索は WASM 専用）。live な呼び出し元は
+ * `lineTable/lineScan.ts` のテーブル構築とテストのみで、実質 Zig 実装のパリティ用
+ * 参照実装として残っている（#43 の死蔵棚卸し候補）。
  *
  * @param pattern パターン分析結果
  * @param color 石の色（黒の長連を五から除外するために必要）
@@ -128,12 +133,11 @@ export function getPatternScore(
   color: PlayerColor,
 ): number {
   const { count, end1, end2 } = pattern;
-  if (isFiveLength(count, color)) {
-    return PATTERN_SCORES.FIVE;
-  }
-  // ここに来る count >= 5 は黒の長連のみ（count === 5 は黒白とも五）
+  // count >= 5 は「五」か「黒の長連」のいずれか。isFiveLength が false なら
+  // 残るのは黒の長連だけ（= isOverlineLength(count, color)）。
+  // count 0..4 を 1 比較で switch に落とすためにこの形にしている。
   if (count >= 5) {
-    return 0;
+    return isFiveLength(count, color) ? PATTERN_SCORES.FIVE : 0;
   }
 
   const bothOpen = end1 === "empty" && end2 === "empty";
@@ -194,11 +198,8 @@ export function getPatternType(
   color: PlayerColor,
 ): PatternType {
   const { count, end1, end2 } = pattern;
-  if (isFiveLength(count, color)) {
-    return "five";
-  }
   if (count >= 5) {
-    return null;
+    return isFiveLength(count, color) ? "five" : null;
   }
 
   const bothOpen = end1 === "empty" && end2 === "empty";

--- a/src/logic/cpu/evaluation/directionAnalysis.ts
+++ b/src/logic/cpu/evaluation/directionAnalysis.ts
@@ -6,7 +6,11 @@
 
 import type { BoardState } from "@/types/game";
 
-import { isValidPosition } from "@/logic/renjuRules";
+import {
+  isFiveLength,
+  isValidPosition,
+  type PlayerColor,
+} from "@/logic/renjuRules";
 
 import {
   type DirectionPattern,
@@ -109,17 +113,33 @@ export function analyzeDirection(
 /**
  * パターンからスコアを計算
  *
+ * 五の判定は `renjuRules.isFiveLength` に委ねる（SSoT・#125）。黒はちょうど 5 連、
+ * 白は 5 連以上が五。**黒の 6 連以上は長連＝禁手なので五でも四でもなく 0 点**（#132）。
+ *
+ * Zig 側の対は `zig/src/patterns.zig` の `getPatternScore`。
+ * パリティテスト: `patternScoreParity.wasm.test.ts`
+ *
  * @param pattern パターン分析結果
+ * @param color 石の色（黒の長連を五から除外するために必要）
  * @returns スコア
  */
-export function getPatternScore(pattern: DirectionPattern): number {
+export function getPatternScore(
+  pattern: DirectionPattern,
+  color: PlayerColor,
+): number {
   const { count, end1, end2 } = pattern;
+  if (isFiveLength(count, color)) {
+    return PATTERN_SCORES.FIVE;
+  }
+  // ここに来る count >= 5 は黒の長連のみ（count === 5 は黒白とも五）
+  if (count >= 5) {
+    return 0;
+  }
+
   const bothOpen = end1 === "empty" && end2 === "empty";
   const oneOpen = end1 === "empty" || end2 === "empty";
 
   switch (count) {
-    case 5:
-      return PATTERN_SCORES.FIVE;
     case 4:
       if (bothOpen) {
         return PATTERN_SCORES.OPEN_FOUR;
@@ -145,10 +165,6 @@ export function getPatternScore(pattern: DirectionPattern): number {
       }
       return 0;
     default:
-      // 6以上は長連（黒の禁手だが白には有利）
-      if (count >= 6) {
-        return PATTERN_SCORES.FIVE;
-      }
       return 0;
   }
 }
@@ -169,15 +185,26 @@ export function getCenterBonus(row: number, col: number): number {
 
 /**
  * パターンタイプを取得
+ *
+ * 五の判定は `getPatternScore` と同じく `renjuRules.isFiveLength`（#125）。
+ * 黒の 6 連以上（長連＝禁手）は `null`（#132）。
  */
-export function getPatternType(pattern: DirectionPattern): PatternType {
+export function getPatternType(
+  pattern: DirectionPattern,
+  color: PlayerColor,
+): PatternType {
   const { count, end1, end2 } = pattern;
+  if (isFiveLength(count, color)) {
+    return "five";
+  }
+  if (count >= 5) {
+    return null;
+  }
+
   const bothOpen = end1 === "empty" && end2 === "empty";
   const oneOpen = end1 === "empty" || end2 === "empty";
 
   switch (count) {
-    case 5:
-      return "five";
     case 4:
       if (bothOpen) {
         return "openFour";
@@ -203,9 +230,6 @@ export function getPatternType(pattern: DirectionPattern): PatternType {
       }
       return null;
     default:
-      if (count >= 6) {
-        return "five";
-      }
       return null;
   }
 }

--- a/src/logic/cpu/evaluation/patternScoreParity.wasm.test.ts
+++ b/src/logic/cpu/evaluation/patternScoreParity.wasm.test.ts
@@ -1,0 +1,105 @@
+/**
+ * パターンスコア／パターンタイプの TS⇄Zig パリティテスト（issue #132）
+ *
+ * `getPatternScore` / `getPatternType` は TS
+ * (`evaluation/directionAnalysis.ts`) と Zig (`zig/src/patterns.zig`) に
+ * 二重実装されている。#132 で「黒の長連（6 連以上＝禁手）は五でも四でもない」を
+ * 両方に入れたので、その一致を全入力の直積で機械的に確認する。
+ *
+ * 入力空間は小さい（count 0..15 × end1 3 値 × end2 3 値 × 色 2）ので全列挙する。
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { PlayerColor } from "@/logic/renjuRules";
+
+import { loadWasmModule } from "@/logic/cpu/wasm/loader";
+import { CELL, END_STATE } from "@/logic/cpu/wasm/types";
+
+import type { EndState, PatternType } from "./patternScores";
+
+import { getPatternScore, getPatternType } from "./directionAnalysis";
+
+const wasm = await loadWasmModule();
+
+const END_STATES: { name: EndState; code: number }[] = [
+  { name: "empty", code: END_STATE.EMPTY },
+  { name: "opponent", code: END_STATE.OPPONENT },
+  { name: "edge", code: END_STATE.EDGE },
+];
+
+const COLORS: { name: PlayerColor; code: number }[] = [
+  { name: "black", code: CELL.BLACK },
+  { name: "white", code: CELL.WHITE },
+];
+
+/** Zig `PatternType` の enum 値 → TS の PatternType 文字列 */
+const TYPE_CODE_TO_NAME: PatternType[] = [
+  null,
+  "five",
+  "openFour",
+  "four",
+  "openThree",
+  "three",
+  "openTwo",
+  "two",
+];
+
+/** count の上限。ライン長 15 が物理的な最大 */
+const MAX_COUNT = 15;
+
+describe("getPatternScore / getPatternType の TS⇄Zig パリティ", () => {
+  it("count 0..15 × 端状態 3×3 × 色 2 の全入力で一致する", () => {
+    for (const color of COLORS) {
+      for (let count = 0; count <= MAX_COUNT; count++) {
+        for (const end1 of END_STATES) {
+          for (const end2 of END_STATES) {
+            const label = `count=${count} e1=${end1.name} e2=${end2.name} color=${color.name}`;
+            const pattern = { count, end1: end1.name, end2: end2.name };
+
+            expect(
+              wasm.wasmGetPatternScore(count, end1.code, end2.code, color.code),
+              `score: ${label}`,
+            ).toBe(getPatternScore(pattern, color.name));
+
+            const zigType =
+              TYPE_CODE_TO_NAME[
+                wasm.wasmGetPatternType(count, end1.code, end2.code, color.code)
+              ] ?? null;
+            expect(zigType, `type: ${label}`).toBe(
+              getPatternType(pattern, color.name),
+            );
+          }
+        }
+      }
+    }
+  });
+
+  // #132 の本体: 色盲だったころは黒の長連も FIVE(100000) を返していた
+  it("黒の長連（6 連以上）は 0 点・null、白の長連は五（両実装）", () => {
+    for (let count = 6; count <= MAX_COUNT; count++) {
+      expect(
+        wasm.wasmGetPatternScore(
+          count,
+          END_STATE.EMPTY,
+          END_STATE.EMPTY,
+          CELL.BLACK,
+        ),
+        `zig black count=${count}`,
+      ).toBe(0);
+      expect(
+        getPatternScore({ count, end1: "empty", end2: "empty" }, "black"),
+        `ts black count=${count}`,
+      ).toBe(0);
+      expect(
+        wasm.wasmGetPatternType(
+          count,
+          END_STATE.EMPTY,
+          END_STATE.EMPTY,
+          CELL.WHITE,
+        ),
+        `zig white count=${count}`,
+      ).toBe(1); // five
+    }
+  });
+});

--- a/src/logic/cpu/evaluation/patternScoreParity.wasm.test.ts
+++ b/src/logic/cpu/evaluation/patternScoreParity.wasm.test.ts
@@ -33,6 +33,13 @@ const COLORS: { name: PlayerColor; code: number }[] = [
   { name: "white", code: CELL.WHITE },
 ];
 
+/**
+ * `.empty` は「石の色」ではないので本来渡されない（TS 側は `PlayerColor` 型で
+ * 弾いている）。Zig 側は黒扱いにフォールバックする＝空点が五になることはない、
+ * という安全側の挙動だけを確認しておく。
+ */
+const EMPTY_FALLBACK_IS_BLACK = true;
+
 /** Zig `PatternType` の enum 値 → TS の PatternType 文字列 */
 const TYPE_CODE_TO_NAME: PatternType[] = [
   null,
@@ -75,6 +82,27 @@ describe("getPatternScore / getPatternType の TS⇄Zig パリティ", () => {
     }
   });
 
+  it("color=.empty は黒扱いにフォールバックする（空点が五にならない）", () => {
+    expect(EMPTY_FALLBACK_IS_BLACK).toBe(true);
+    for (let count = 6; count <= MAX_COUNT; count++) {
+      expect(
+        wasm.wasmGetPatternScore(
+          count,
+          END_STATE.EMPTY,
+          END_STATE.EMPTY,
+          CELL.EMPTY,
+        ),
+        `count=${count}`,
+      ).toBe(0);
+    }
+    // ちょうど 5 は黒と同じく五
+    expect(
+      wasm.wasmGetPatternScore(5, END_STATE.EMPTY, END_STATE.EMPTY, CELL.EMPTY),
+    ).toBe(
+      wasm.wasmGetPatternScore(5, END_STATE.EMPTY, END_STATE.EMPTY, CELL.BLACK),
+    );
+  });
+
   // #132 の本体: 色盲だったころは黒の長連も FIVE(100000) を返していた
   it("黒の長連（6 連以上）は 0 点・null、白の長連は五（両実装）", () => {
     for (let count = 6; count <= MAX_COUNT; count++) {
@@ -92,14 +120,16 @@ describe("getPatternScore / getPatternType の TS⇄Zig パリティ", () => {
         `ts black count=${count}`,
       ).toBe(0);
       expect(
-        wasm.wasmGetPatternType(
-          count,
-          END_STATE.EMPTY,
-          END_STATE.EMPTY,
-          CELL.WHITE,
-        ),
+        TYPE_CODE_TO_NAME[
+          wasm.wasmGetPatternType(
+            count,
+            END_STATE.EMPTY,
+            END_STATE.EMPTY,
+            CELL.WHITE,
+          )
+        ] ?? null,
         `zig white count=${count}`,
-      ).toBe(1); // five
+      ).toBe("five");
     }
   });
 });

--- a/src/logic/cpu/lineTable/adapter.test.ts
+++ b/src/logic/cpu/lineTable/adapter.test.ts
@@ -53,12 +53,14 @@ function assertPattern(
   // lineTable なし（analyzeDirection パス）
   const withoutLt = getDirectionPattern(board, row, col, dirIndex, color);
   expect(withoutLt.count, "without LT: count").toBe(expectedCount);
-  expect(getPatternScore(withoutLt), "without LT: score").toBe(expectedScore);
+  expect(getPatternScore(withoutLt, color), "without LT: score").toBe(
+    expectedScore,
+  );
 
   // lineTable あり（analyzeLinePattern パス）
   const withLt = getDirectionPattern(board, row, col, dirIndex, color, lt);
   expect(withLt.count, "with LT: count").toBe(expectedCount);
-  expect(getPatternScore(withLt), "with LT: score").toBe(expectedScore);
+  expect(getPatternScore(withLt, color), "with LT: score").toBe(expectedScore);
 
   // 両パスで結果一致
   expect(withLt, "LT parity").toEqual(withoutLt);

--- a/src/logic/cpu/lineTable/lineScan.test.ts
+++ b/src/logic/cpu/lineTable/lineScan.test.ts
@@ -80,23 +80,34 @@ function randomBoard(rng: () => number, stoneCount: number): BoardState {
   return board;
 }
 
+const COLORS = ["black", "white"] as const;
+
 describe("PACKED_TO_SCORE", () => {
-  it("256全エントリが getPatternScore と一致", () => {
+  it.each(COLORS)("256全エントリが getPatternScore と一致 (%s)", (color) => {
     for (let packed = 0; packed < 256; packed++) {
       const { count, end1, end2 } = unpackPattern(packed);
       if (count === 0) {
-        expect(PACKED_TO_SCORE[packed]).toBe(0);
+        expect(PACKED_TO_SCORE[color][packed]).toBe(0);
         continue;
       }
-      const expected = getPatternScore({ count, end1, end2 });
+      const expected = getPatternScore({ count, end1, end2 }, color);
       // FIVE(100000) は Int16 clamp されるが、count>=5 は早期リターンで使われない
-      if (count >= 5) {
+      if (count >= 5 && expected !== 0) {
         continue;
       }
       expect(
-        PACKED_TO_SCORE[packed],
+        PACKED_TO_SCORE[color][packed],
         `packed=${packed} count=${count} e1=${end1} e2=${end2}`,
       ).toBe(expected);
+    }
+  });
+
+  // #132: 黒の長連は五ではないのでテーブルが色で分かれる
+  it("黒テーブルは count>=6 が 0・白テーブルは FIVE 相当", () => {
+    for (let count = 6; count <= 15; count++) {
+      const packed = (count << 4) | (2 << 2) | 2; // eslint-disable-line no-bitwise
+      expect(PACKED_TO_SCORE.black[packed], `black count=${count}`).toBe(0);
+      expect(PACKED_TO_SCORE.white[packed], `white count=${count}`).not.toBe(0);
     }
   });
 });
@@ -113,15 +124,16 @@ describe("PACKED_TO_TYPE", () => {
     7: "two",
   };
 
-  it("256全エントリが getPatternType と一致", () => {
+  it.each(COLORS)("256全エントリが getPatternType と一致 (%s)", (color) => {
     for (let packed = 0; packed < 256; packed++) {
       const { count, end1, end2 } = unpackPattern(packed);
       if (count === 0) {
-        expect(PACKED_TO_TYPE[packed]).toBe(0);
+        expect(PACKED_TO_TYPE[color][packed]).toBe(0);
         continue;
       }
-      const expected = getPatternType({ count, end1, end2 });
-      const actual = TYPE_CODE_TO_NAME[PACKED_TO_TYPE[packed] ?? 0] ?? null;
+      const expected = getPatternType({ count, end1, end2 }, color);
+      const actual =
+        TYPE_CODE_TO_NAME[PACKED_TO_TYPE[color][packed] ?? 0] ?? null;
       expect(
         actual,
         `packed=${packed} count=${count} e1=${end1} e2=${end2}`,
@@ -135,12 +147,8 @@ describe("rebuildPackedTables", () => {
     rebuildPackedTables();
     // count=4, end1=empty, end2=empty → OPEN_FOUR
     const packed = (4 << 4) | (2 << 2) | 2; // eslint-disable-line no-bitwise
-    expect(PACKED_TO_SCORE[packed]).toBe(
-      getPatternScore({
-        count: 4,
-        end1: "empty",
-        end2: "empty",
-      }),
+    expect(PACKED_TO_SCORE.black[packed]).toBe(
+      getPatternScore({ count: 4, end1: "empty", end2: "empty" }, "black"),
     );
   });
 });

--- a/src/logic/cpu/lineTable/lineScan.test.ts
+++ b/src/logic/cpu/lineTable/lineScan.test.ts
@@ -15,6 +15,7 @@ import {
   getPatternScore,
   getPatternType,
 } from "../evaluation/directionAnalysis";
+import { PATTERN_SCORES } from "../evaluation/patternScores";
 import { getDirectionPattern } from "./adapter";
 import { CELL_LINES_FLAT } from "./lineMapping";
 import {
@@ -91,8 +92,9 @@ describe("PACKED_TO_SCORE", () => {
         continue;
       }
       const expected = getPatternScore({ count, end1, end2 }, color);
-      // FIVE(100000) は Int16 clamp されるが、count>=5 は早期リターンで使われない
-      if (count >= 5 && expected !== 0) {
+      // FIVE(100000) は Int16 clamp される。五になる packed 値は minimax の
+      // 勝敗判定で処理されるため参照されない（黒の長連 = 0 は比較対象に残す）
+      if (expected === PATTERN_SCORES.FIVE) {
         continue;
       }
       expect(

--- a/src/logic/cpu/lineTable/lineScan.ts
+++ b/src/logic/cpu/lineTable/lineScan.ts
@@ -16,6 +16,8 @@
 
 /* eslint-disable no-bitwise -- ビットマスク操作に必要 */
 
+import type { PlayerColor } from "@/logic/renjuRules";
+
 import {
   getPatternScore,
   getPatternType,
@@ -73,7 +75,7 @@ function unpackPattern(packed: number): {
   };
 }
 
-function buildPackedToScore(): Int16Array {
+function buildPackedToScore(color: PlayerColor): Int16Array {
   const table = new Int16Array(256);
   for (let packed = 0; packed < 256; packed++) {
     const { count, end1, end2 } = unpackPattern(packed);
@@ -81,12 +83,12 @@ function buildPackedToScore(): Int16Array {
       table[packed] = 0;
       continue;
     }
-    table[packed] = getPatternScore({ count, end1, end2 });
+    table[packed] = getPatternScore({ count, end1, end2 }, color);
   }
   return table;
 }
 
-function buildPackedToType(): Uint8Array {
+function buildPackedToType(color: PlayerColor): Uint8Array {
   const table = new Uint8Array(256);
   for (let packed = 0; packed < 256; packed++) {
     const { count, end1, end2 } = unpackPattern(packed);
@@ -94,7 +96,7 @@ function buildPackedToType(): Uint8Array {
       table[packed] = 0;
       continue;
     }
-    const type = getPatternType({ count, end1, end2 });
+    const type = getPatternType({ count, end1, end2 }, color);
     table[packed] = type ? (TYPE_CODE_MAP[type] ?? 0) : 0;
   }
   return table;
@@ -103,20 +105,27 @@ function buildPackedToType(): Uint8Array {
 // ─── ルックアップテーブル ───
 
 /**
- * packed byte → score (getPatternScore と等価)。256 entries × 2 bytes = 512 bytes
+ * packed byte → score (getPatternScore と等価)。色ごとに 256 entries × 2 bytes
+ *
+ * 黒の長連（count >= 6）は五ではなく 0 点なので、テーブルは色で分かれる（#132）。
  *
  * FIVE(100000) は Int16Array の範囲外で clamp されるが、
  * 五連は minimax の勝敗判定で処理されるため、PACKED_TO_SCORE 経由での参照は
  * count <= 4 のパターンのみ（全て Int16 範囲内: max OPEN_FOUR=10000）。
  */
-export let PACKED_TO_SCORE: Int16Array = buildPackedToScore();
+export let PACKED_TO_SCORE: Record<PlayerColor, Int16Array> = {
+  black: buildPackedToScore("black"),
+  white: buildPackedToScore("white"),
+};
 
 /**
- * packed byte → type code (getPatternType と等価)
+ * packed byte → type code (getPatternType と等価)。色ごとに 256 entries × 1 byte
  * 0=null, 1=five, 2=openFour, 3=four, 4=openThree, 5=three, 6=openTwo, 7=two
- * 256 entries × 1 byte = 256 bytes
  */
-export let PACKED_TO_TYPE: Uint8Array = buildPackedToType();
+export let PACKED_TO_TYPE: Record<PlayerColor, Uint8Array> = {
+  black: buildPackedToType("black"),
+  white: buildPackedToType("white"),
+};
 
 /** type code 定数 */
 export const TYPE_FOUR = 3;
@@ -127,8 +136,14 @@ export const TYPE_OPEN_THREE = 4;
  * applyPatternScoreOverrides から呼び出される。
  */
 export function rebuildPackedTables(): void {
-  PACKED_TO_SCORE = buildPackedToScore();
-  PACKED_TO_TYPE = buildPackedToType();
+  PACKED_TO_SCORE = {
+    black: buildPackedToScore("black"),
+    white: buildPackedToScore("white"),
+  };
+  PACKED_TO_TYPE = {
+    black: buildPackedToType("black"),
+    white: buildPackedToType("white"),
+  };
 }
 
 // ─── 事前計算バッファ（非リエントラント） ───

--- a/src/logic/cpu/lineTable/lineScan.ts
+++ b/src/logic/cpu/lineTable/lineScan.ts
@@ -108,10 +108,14 @@ function buildPackedToType(color: PlayerColor): Uint8Array {
  * packed byte → score (getPatternScore と等価)。色ごとに 256 entries × 2 bytes
  *
  * 黒の長連（count >= 6）は五ではなく 0 点なので、テーブルは色で分かれる（#132）。
+ * 黒テーブルは count >= 6 が 0、白テーブルは count >= 5 が FIVE（clamp 後の値）。
  *
  * FIVE(100000) は Int16Array の範囲外で clamp されるが、
- * 五連は minimax の勝敗判定で処理されるため、PACKED_TO_SCORE 経由での参照は
- * count <= 4 のパターンのみ（全て Int16 範囲内: max OPEN_FOUR=10000）。
+ * 五連は minimax の勝敗判定で処理されるため、五になる packed 値は参照されない
+ * （参照されるのは count <= 4 と黒の長連 = 0 のみ。max OPEN_FOUR=10000）。
+ *
+ * ⚠️ 本番探索からの消費者はゼロ（探索は WASM 専用）。テスト＝パリティ検証専用の
+ * 参照実装として残っている（#43 の死蔵棚卸し候補）。
  */
 export let PACKED_TO_SCORE: Record<PlayerColor, Int16Array> = {
   black: buildPackedToScore("black"),

--- a/src/logic/cpu/wasm/types.ts
+++ b/src/logic/cpu/wasm/types.ts
@@ -34,8 +34,19 @@ export interface WasmModuleContext {
 
   // Pattern scoring
   evaluateDirectionScores: (row: number, col: number, color: number) => number;
-  wasmGetPatternScore: (count: number, end1: number, end2: number) => number;
-  wasmGetPatternType: (count: number, end1: number, end2: number) => number;
+  // #132: 黒の長連（6 連以上＝禁手）を五から外すため color を受け取る
+  wasmGetPatternScore: (
+    count: number,
+    end1: number,
+    end2: number,
+    color: number,
+  ) => number;
+  wasmGetPatternType: (
+    count: number,
+    end1: number,
+    end2: number,
+    color: number,
+  ) => number;
 
   // Board evaluation
   evaluateBoard: (perspective: number, optionsFlags: number) => number;

--- a/src/logic/renjuRules.test.ts
+++ b/src/logic/renjuRules.test.ts
@@ -4,6 +4,7 @@ import {
   checkDraw,
   checkFive,
   isFiveLength,
+  isOverlineLength,
   checkWin,
   copyBoard,
   createEmptyBoard,
@@ -73,6 +74,30 @@ describe("isFiveLength（五の定義）", () => {
     const asAny = isFiveLength as (l: number, c: unknown) => boolean;
     expect(asAny(6, null)).toBe(false);
     expect(asAny(7, null)).toBe(false);
+  });
+});
+
+describe("isOverlineLength（長連の定義）", () => {
+  it("黒は6以上が長連", () => {
+    expect(isOverlineLength(5, "black")).toBe(false);
+    expect(isOverlineLength(6, "black")).toBe(true);
+    expect(isOverlineLength(10, "black")).toBe(true);
+  });
+
+  it("白に長連は無い（6以上は五）", () => {
+    expect(isOverlineLength(6, "white")).toBe(false);
+    expect(isOverlineLength(10, "white")).toBe(false);
+  });
+
+  it("isFiveLength と排他（同じ長さで両方 true にならない）", () => {
+    for (const color of ["black", "white"] as const) {
+      for (let length = 0; length <= 15; length++) {
+        expect(
+          isFiveLength(length, color) && isOverlineLength(length, color),
+          `length=${length} color=${color}`,
+        ).toBe(false);
+      }
+    }
   });
 });
 

--- a/src/logic/renjuRules/core.ts
+++ b/src/logic/renjuRules/core.ts
@@ -10,7 +10,7 @@ import type { BoardState, Position, StoneColor } from "@/types/game";
 import { incrementBoardCopies } from "@/logic/cpu/profiling/counters";
 
 /** 実際に盤上に置かれる石の色（`StoneColor` から空点 `null` を除いたもの） */
-type PlayerColor = Exclude<StoneColor, null>;
+export type PlayerColor = Exclude<StoneColor, null>;
 
 // =============================================================================
 // 引き分けルール

--- a/src/logic/renjuRules/core.ts
+++ b/src/logic/renjuRules/core.ts
@@ -154,6 +154,20 @@ export function isFiveLength(length: number, color: PlayerColor): boolean {
 }
 
 /**
+ * 連の長さが「長連」かどうか（色別の連珠ルール）
+ *
+ * - 黒: 6 以上（＝禁手。五でも四でもない）
+ * - 白: 常に false（白に長連の制限は無い。6 連以上は `isFiveLength` で五になる）
+ *
+ * `isFiveLength` の対となる述語（issue #132）。評価・move ordering が
+ * 「黒の長連」を弾く箇所はこの述語を経由すること。
+ * Zig 側の SSoT は `zig/src/forbidden.zig` の `isOverlineLength`。
+ */
+export function isOverlineLength(length: number, color: PlayerColor): boolean {
+  return color !== "white" && length >= 6;
+}
+
+/**
  * 五連をチェック
  * @returns 五連が成立する場合true（白は長連＝6連以上も五）
  */

--- a/src/logic/renjuRules/index.ts
+++ b/src/logic/renjuRules/index.ts
@@ -23,3 +23,4 @@ export {
   isFiveLength,
   isValidPosition,
 } from "./core";
+export type { PlayerColor } from "./core";

--- a/src/logic/renjuRules/index.ts
+++ b/src/logic/renjuRules/index.ts
@@ -21,6 +21,7 @@ export {
   DRAW_MOVE_LIMIT,
   getLineLength,
   isFiveLength,
+  isOverlineLength,
   isValidPosition,
 } from "./core";
 export type { PlayerColor } from "./core";

--- a/zig/src/forbidden.zig
+++ b/zig/src/forbidden.zig
@@ -60,6 +60,21 @@ pub fn isFiveLength(length: u8, color: Cell) bool {
     return if (color == .white) length >= 5 else length == 5;
 }
 
+/// 連の長さが「長連」かどうか（色別の連珠ルール）
+///
+/// - 黒: 6 以上（＝禁手。五でも四でもない）
+/// - 白: 常に false（白に長連の制限は無い。6 連以上は `isFiveLength` で五になる）
+///
+/// `isFiveLength` の対となる述語（issue #132）。評価・move ordering・プロスペクトが
+/// 「黒の長連」を弾く箇所はこの述語を経由すること。TS 側の SSoT は
+/// `src/logic/renjuRules/core.ts` の `isOverlineLength`。
+///
+/// `.empty` は黒扱いになるが、呼び出し元は必ず実際の石の色を渡す
+/// （`isFiveLength` と同じく空点を数える経路では使わない）。
+pub fn isOverlineLength(length: u8, color: Cell) bool {
+    return color != .white and length >= 6;
+}
+
 /// 五連をチェック（白は長連＝6連以上も五）
 pub fn checkFive(cells: []const Cell, row: u8, col: u8, color: Cell) bool {
     // `.empty` は「石の色」ではない。getLineLength は空点も数えるので、

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -39,8 +39,8 @@ export fn analyzeDirection(row: u8, col: u8, dr: i8, dc: i8, color: u8) u32 {
 export fn evaluateDirectionScores(row: u8, col: u8, color: u8) i32 {
     return patterns.evaluateDirectionScores(row, col, color);
 }
-export fn wasmGetPatternScore(count: u8, end1: u8, end2: u8) i32 {
-    return patterns.wasmGetPatternScore(count, end1, end2);
+export fn wasmGetPatternScore(count: u8, end1: u8, end2: u8, color: u8) i32 {
+    return patterns.wasmGetPatternScore(count, end1, end2, color);
 }
 
 // --- eval 重み実行時注入（bench 専用。重みごとリビルド不要にする） ---
@@ -109,8 +109,8 @@ export fn extractProspectFeatures(perspective: u8, stm_is_perspective: u8) u32 {
     }
     return prospect.PROSPECT_PARAM_COUNT;
 }
-export fn wasmGetPatternType(count: u8, end1: u8, end2: u8) u8 {
-    return patterns.wasmGetPatternType(count, end1, end2);
+export fn wasmGetPatternType(count: u8, end1: u8, end2: u8, color: u8) u8 {
+    return patterns.wasmGetPatternType(count, end1, end2, color);
 }
 
 // === パリティテスト用 export（#21）===

--- a/zig/src/minimax.zig
+++ b/zig/src/minimax.zig
@@ -220,10 +220,11 @@ fn hasFourInDirection(cells: []const Cell, row: u8, col: u8, dr: i8, dc: i8, col
 
 /// analyzeFourAndThree: 四と活三の有無を分析（石配置済み前提）
 ///
-/// ⚠️ `has_five` の判定が色盲（`count >= 5`）で、黒の長連（6 連以上＝禁手で五ではない）も
-/// 五として返す。#125 では「勝敗に効く五判定」（`forbidden.checkFive`）のみを
-/// `forbidden.isFiveLength` に揃え、ここは**意図的に未変更**とした
-/// （評価・move ordering 系の色盲な五扱いはまとめて別 issue #132 で扱う）。
+/// 五の判定は `forbidden.isFiveLength`（SSoT・#125）。黒はちょうど 5 連、白は 5 連以上。
+///
+/// **黒の長連（6 連以上）は禁手なので、この着手自体が打てない**（#132）。
+/// 五でも四でもないため、`isFiveLength` に落とす前に「脅威なし」で早期 return する
+/// （単に置換すると黒の 6 連が下の `count == 4` 判定などに落ちて誤分類される）。
 pub fn analyzeFourAndThree(cells: []const Cell, row: u8, col: u8, color: Cell) struct { has_five: bool, has_four: bool, has_open_three: bool } {
     const jp = @import("jump_patterns.zig");
     var has_four = false;
@@ -232,7 +233,12 @@ pub fn analyzeFourAndThree(cells: []const Cell, row: u8, col: u8, color: Cell) s
     for (DIRECTIONS, 0..) |dir, i| {
         const result = board_mod.analyzeDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
 
-        if (result.count >= 5) {
+        // 黒の長連＝禁手。着手そのものが不可なので全方向まとめて脅威なしとする。
+        if (color == .black and result.count >= 6) {
+            return .{ .has_five = false, .has_four = false, .has_open_three = false };
+        }
+
+        if (forbidden.isFiveLength(result.count, color)) {
             return .{ .has_five = true, .has_four = false, .has_open_three = false };
         }
 
@@ -1152,6 +1158,39 @@ test "LMR table values" {
     try testing.expectEqual(getLMRReduction(0, 5), 0);
     // moveIndex=0 → 0
     try testing.expectEqual(getLMRReduction(5, 0), 0);
+}
+
+// #132: analyzeFourAndThree の五判定を forbidden.isFiveLength に揃えた回帰テスト
+test "analyzeFourAndThree: 黒の長連は五でも四でもない" {
+    const CELL_COUNT = board_mod.CELL_COUNT;
+    var cells: [CELL_COUNT]Cell = [_]Cell{.empty} ** CELL_COUNT;
+
+    // 横に黒 6 連（col 3..8、着手点は col 7）＝長連
+    for (3..9) |c| cells[7 * BOARD_SIZE + c] = .black;
+    // 同じ着手点に縦の活三（row 6,7,8 で両端空き）も作っておく
+    cells[6 * BOARD_SIZE + 7] = .black;
+    cells[8 * BOARD_SIZE + 7] = .black;
+
+    const r = analyzeFourAndThree(&cells, 7, 7, .black);
+    try testing.expect(!r.has_five);
+    try testing.expect(!r.has_four);
+    try testing.expect(!r.has_open_three);
+}
+
+test "analyzeFourAndThree: 白の長連は五・黒のちょうど五は五" {
+    const CELL_COUNT = board_mod.CELL_COUNT;
+    var cells: [CELL_COUNT]Cell = [_]Cell{.empty} ** CELL_COUNT;
+
+    // 白 6 連
+    for (3..9) |c| cells[7 * BOARD_SIZE + c] = .white;
+    const w = analyzeFourAndThree(&cells, 7, 7, .white);
+    try testing.expect(w.has_five);
+
+    // 黒ちょうど 5 連
+    @memset(&cells, .empty);
+    for (3..8) |c| cells[7 * BOARD_SIZE + c] = .black;
+    const b = analyzeFourAndThree(&cells, 7, 7, .black);
+    try testing.expect(b.has_five);
 }
 
 /// 序盤の均衡局面（minimax テスト用）。

--- a/zig/src/minimax.zig
+++ b/zig/src/minimax.zig
@@ -221,25 +221,36 @@ fn hasFourInDirection(cells: []const Cell, row: u8, col: u8, dr: i8, dc: i8, col
 /// analyzeFourAndThree: 四と活三の有無を分析（石配置済み前提）
 ///
 /// 五の判定は `forbidden.isFiveLength`（SSoT・#125）。黒はちょうど 5 連、白は 5 連以上。
+/// 黒の長連（`forbidden.isOverlineLength`）は禁手なので五でも四でもなく、
+/// **その着手自体が打てない**ため全フィールド false を返す（#132）。
 ///
-/// **黒の長連（6 連以上）は禁手なので、この着手自体が打てない**（#132）。
-/// 五でも四でもないため、`isFiveLength` に落とす前に「脅威なし」で早期 return する
-/// （単に置換すると黒の 6 連が下の `count == 4` 判定などに落ちて誤分類される）。
+/// 五と長連が同時に成立する黒の着手は**五が優先**（連珠ルール）。方向順に依存して
+/// 結果が変わらないよう、長連を見つけても即 return せず全方向をスキャンしてから
+/// 判定する。これは主探索の遅延禁手判定（`checkFive` を先に見て、五なら禁手判定を
+/// スキップする）と同じ優先順位。
+///
+/// ⚠️ 現状の消費者（`isThreatExtensionCandidate` / LMR 調整 / `demotePlainFourIfNeeded`）は
+/// いずれも `has_four` と `has_open_three` しか見ないため、黒長連での all-false 化は
+/// **挙動としては no-op**（禁手手は主探索では遅延禁手判定で先に捨てられ、ここには届かない）。
+/// あくまで構造体の契約（「has_five は五である」）を正しくするための変更。
 pub fn analyzeFourAndThree(cells: []const Cell, row: u8, col: u8, color: Cell) struct { has_five: bool, has_four: bool, has_open_three: bool } {
     const jp = @import("jump_patterns.zig");
     var has_four = false;
     var has_open_three = false;
+    var has_overline = false;
 
     for (DIRECTIONS, 0..) |dir, i| {
         const result = board_mod.analyzeDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
 
-        // 黒の長連＝禁手。着手そのものが不可なので全方向まとめて脅威なしとする。
-        if (color == .black and result.count >= 6) {
-            return .{ .has_five = false, .has_four = false, .has_open_three = false };
-        }
-
+        // 五は長連より優先。1 方向でも五があればその時点で確定。
         if (forbidden.isFiveLength(result.count, color)) {
             return .{ .has_five = true, .has_four = false, .has_open_three = false };
+        }
+
+        // 黒の長連＝禁手。他方向に五がないか見終わるまで判定は保留する。
+        if (forbidden.isOverlineLength(result.count, color)) {
+            has_overline = true;
+            continue;
         }
 
         // 四チェック
@@ -257,6 +268,11 @@ pub fn analyzeFourAndThree(cells: []const Cell, row: u8, col: u8, color: Cell) s
         if (result.count == 3 and result.end1 == .empty and result.end2 == .empty) {
             has_open_three = true;
         }
+    }
+
+    // 五が無く長連がある＝禁手。着手不可なので脅威として扱わない。
+    if (has_overline) {
+        return .{ .has_five = false, .has_four = false, .has_open_three = false };
     }
 
     return .{ .has_five = false, .has_four = has_four, .has_open_three = has_open_three };
@@ -1175,6 +1191,30 @@ test "analyzeFourAndThree: 黒の長連は五でも四でもない" {
     try testing.expect(!r.has_five);
     try testing.expect(!r.has_four);
     try testing.expect(!r.has_open_three);
+}
+
+// #132 レビュー指摘: 五と長連が同居する黒の着手は、方向順に関係なく五が優先される
+// （主探索の遅延禁手判定 checkFive → checkForbiddenMove と同じ順位）。
+test "analyzeFourAndThree: 五と長連が同居する黒は方向順に関係なく五" {
+    const CELL_COUNT = board_mod.CELL_COUNT;
+
+    // (a) 横（先に走査される方向）に長連・縦に五
+    {
+        var cells: [CELL_COUNT]Cell = [_]Cell{.empty} ** CELL_COUNT;
+        for (3..9) |c| cells[7 * BOARD_SIZE + c] = .black; // 横 6 連
+        for (3..7) |r| cells[r * BOARD_SIZE + 7] = .black; // 縦: row 3..6 + 着手点 7 = 5 連
+        const r = analyzeFourAndThree(&cells, 7, 7, .black);
+        try testing.expect(r.has_five);
+    }
+
+    // (b) 縦に長連・横に五（(a) と方向を入れ替えても同じ結論）
+    {
+        var cells: [CELL_COUNT]Cell = [_]Cell{.empty} ** CELL_COUNT;
+        for (3..9) |r| cells[r * BOARD_SIZE + 7] = .black; // 縦 6 連
+        for (3..7) |c| cells[7 * BOARD_SIZE + c] = .black; // 横: col 3..6 + 着手点 7 = 5 連
+        const r = analyzeFourAndThree(&cells, 7, 7, .black);
+        try testing.expect(r.has_five);
+    }
 }
 
 test "analyzeFourAndThree: 白の長連は五・黒のちょうど五は五" {

--- a/zig/src/move_order.zig
+++ b/zig/src/move_order.zig
@@ -331,6 +331,33 @@ test "HistoryTable basic" {
     try std.testing.expectEqual(history.getScore(.{ .row = 7, .col = 7 }), 0);
 }
 
+// #132 回帰: 黒番は skip_forbidden_check=true で候補を作るため、長連点も候補に入る。
+// 修正前は getPatternScore が黒の 6 連を FIVE(100000) として返し、静的評価で
+// 長連点が先頭に来ていた（探索直前に遅延禁手判定で捨てられるだけの無駄なソート）。
+test "sortMoves: 黒の長連点が静的評価で先頭に来ない" {
+    const ll = @import("line_lookup.zig");
+    const bitboard = @import("bitboard.zig");
+    ll.init();
+
+    const CELL_COUNT = board_mod.CELL_COUNT;
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    // row 7 に BBB_BB（col 3,4,5 / 7,8）。col 6 を埋めると col 3..8 の 6 連＝長連。
+    for ([_]usize{ 3, 4, 5, 7, 8 }) |c| cells[7 * BOARD_SIZE + c] = .black;
+    bitboard.initFromCells(&cells);
+
+    var moves_list = move_gen.MoveList.init();
+    moves_list.push(.{ .row = 7, .col = 6 }); // 長連点
+    moves_list.push(.{ .row = 6, .col = 6 });
+    moves_list.push(.{ .row = 8, .col = 8 });
+
+    const result = sortMoves(&moves_list, &cells, .black, .{
+        .use_static_eval = true,
+    });
+
+    const first = result.moves.items[0];
+    try std.testing.expect(!(first.row == 7 and first.col == 6));
+}
+
 test "sortMoves: TT move first" {
     const CELL_COUNT = board_mod.CELL_COUNT;
     var cells = [_]Cell{.empty} ** CELL_COUNT;

--- a/zig/src/patterns.zig
+++ b/zig/src/patterns.zig
@@ -11,16 +11,22 @@ const EndState = board_mod.EndState;
 const DIRECTIONS = board_mod.DIRECTIONS;
 
 /// パターンからスコアを計算（getPatternScore 相当）
-pub fn getPatternScore(count: u8, end1: EndState, end2: EndState) i32 {
+///
+/// 五の判定は `forbidden.isFiveLength` に委ねる（SSoT・#125）。黒はちょうど 5 連、
+/// 白は 5 連以上が五。**黒の 6 連以上は長連＝禁手なので五でも四でもなく 0 点**（#132）。
+pub fn getPatternScore(count: u8, end1: EndState, end2: EndState, color: Cell) i32 {
+    if (forbidden.isFiveLength(count, color)) return scores.FIVE;
+    // ここに来る count >= 5 は黒の長連のみ（count == 5 は黒白とも五）
+    if (count >= 5) return 0;
+
     const both_open = end1 == .empty and end2 == .empty;
     const one_open = end1 == .empty or end2 == .empty;
 
     return switch (count) {
-        5 => scores.FIVE,
         4 => if (both_open) scores.OPEN_FOUR else if (one_open) scores.FOUR else 0,
         3 => if (both_open) scores.OPEN_THREE else if (one_open) scores.THREE else 0,
         2 => if (both_open) scores.OPEN_TWO else if (one_open) scores.TWO else 0,
-        else => if (count >= 6) scores.FIVE else 0,
+        else => 0,
     };
 }
 
@@ -37,16 +43,20 @@ pub const PatternType = enum(u8) {
     two = 7,
 };
 
-pub fn getPatternType(count: u8, end1: EndState, end2: EndState) PatternType {
+/// 五の判定は `getPatternScore` と同じく `forbidden.isFiveLength`（#125）。
+/// 黒の 6 連以上（長連＝禁手）は `.none`（#132）。
+pub fn getPatternType(count: u8, end1: EndState, end2: EndState, color: Cell) PatternType {
+    if (forbidden.isFiveLength(count, color)) return .five;
+    if (count >= 5) return .none;
+
     const both_open = end1 == .empty and end2 == .empty;
     const one_open = end1 == .empty or end2 == .empty;
 
     return switch (count) {
-        5 => .five,
         4 => if (both_open) .open_four else if (one_open) .four else .none,
         3 => if (both_open) .open_three else if (one_open) .three else .none,
         2 => if (both_open) .open_two else if (one_open) .two else .none,
-        else => if (count >= 6) .five else .none,
+        else => .none,
     };
 }
 
@@ -57,7 +67,7 @@ pub fn evaluateDirectionScoresOnCells(cells: []const Cell, row: u8, col: u8, col
     for (DIRECTIONS, 0..) |dir, i| {
         const result = board_mod.analyzeDirectionOnCells(cells, row, col, dir.dr, dir.dc, color);
 
-        var dir_score = getPatternScore(result.count, result.end1, result.end2);
+        var dir_score = getPatternScore(result.count, result.end1, result.end2, color);
 
         // 斜め方向（index 2, 3）に 1.05 倍ボーナス
         if ((i == 2 or i == 3) and dir_score > 0) {
@@ -125,8 +135,8 @@ pub fn evaluateStonePatternsLightOnCells(cells: []Cell, row: u8, col: u8, color:
         dir_end1s[i] = adj_end1;
         dir_end2s[i] = adj_end2;
 
-        const base_score = getPatternScore(result.count, adj_end1, adj_end2);
-        const pattern_type = getPatternType(result.count, adj_end1, adj_end2);
+        const base_score = getPatternScore(result.count, adj_end1, adj_end2, color);
+        const pattern_type = getPatternType(result.count, adj_end1, adj_end2, color);
 
         if (base_score > 0) {
             active_direction_count += 1;
@@ -305,35 +315,55 @@ pub fn evaluateDirectionScores(row: u8, col: u8, color: u8) i32 {
     return evaluateDirectionScoresOnCells(&board_mod.board_cells, row, col, @enumFromInt(color));
 }
 
-pub fn wasmGetPatternScore(count: u8, end1: u8, end2: u8) i32 {
-    return getPatternScore(count, @enumFromInt(end1), @enumFromInt(end2));
+pub fn wasmGetPatternScore(count: u8, end1: u8, end2: u8, color: u8) i32 {
+    return getPatternScore(count, @enumFromInt(end1), @enumFromInt(end2), @enumFromInt(color));
 }
 
-pub fn wasmGetPatternType(count: u8, end1: u8, end2: u8) u8 {
-    return @intFromEnum(getPatternType(count, @enumFromInt(end1), @enumFromInt(end2)));
+pub fn wasmGetPatternType(count: u8, end1: u8, end2: u8, color: u8) u8 {
+    return @intFromEnum(getPatternType(count, @enumFromInt(end1), @enumFromInt(end2), @enumFromInt(color)));
 }
 
 // Zig unit tests
 test "getPatternScore basics" {
-    try std.testing.expectEqual(getPatternScore(5, .empty, .empty), scores.FIVE);
-    try std.testing.expectEqual(getPatternScore(4, .empty, .empty), scores.OPEN_FOUR);
-    try std.testing.expectEqual(getPatternScore(4, .empty, .opponent), scores.FOUR);
-    try std.testing.expectEqual(getPatternScore(4, .opponent, .opponent), 0);
-    try std.testing.expectEqual(getPatternScore(3, .empty, .empty), scores.OPEN_THREE);
-    try std.testing.expectEqual(getPatternScore(3, .empty, .edge), scores.THREE);
-    try std.testing.expectEqual(getPatternScore(2, .empty, .empty), scores.OPEN_TWO);
-    try std.testing.expectEqual(getPatternScore(2, .empty, .opponent), scores.TWO);
-    try std.testing.expectEqual(getPatternScore(6, .empty, .empty), scores.FIVE);
-    try std.testing.expectEqual(getPatternScore(1, .empty, .empty), 0);
+    try std.testing.expectEqual(getPatternScore(5, .empty, .empty, .black), scores.FIVE);
+    try std.testing.expectEqual(getPatternScore(5, .empty, .empty, .white), scores.FIVE);
+    try std.testing.expectEqual(getPatternScore(4, .empty, .empty, .black), scores.OPEN_FOUR);
+    try std.testing.expectEqual(getPatternScore(4, .empty, .opponent, .black), scores.FOUR);
+    try std.testing.expectEqual(getPatternScore(4, .opponent, .opponent, .black), 0);
+    try std.testing.expectEqual(getPatternScore(3, .empty, .empty, .black), scores.OPEN_THREE);
+    try std.testing.expectEqual(getPatternScore(3, .empty, .edge, .black), scores.THREE);
+    try std.testing.expectEqual(getPatternScore(2, .empty, .empty, .black), scores.OPEN_TWO);
+    try std.testing.expectEqual(getPatternScore(2, .empty, .opponent, .black), scores.TWO);
+    try std.testing.expectEqual(getPatternScore(1, .empty, .empty, .black), 0);
+}
+
+// #132: 黒の長連（6 連以上）は禁手なので五でも四でもない。白は五のまま。
+test "getPatternScore: 黒の長連は 0 点・白の長連は五" {
+    var count: u8 = 6;
+    while (count <= 10) : (count += 1) {
+        try std.testing.expectEqual(getPatternScore(count, .empty, .empty, .black), 0);
+        try std.testing.expectEqual(getPatternScore(count, .opponent, .opponent, .black), 0);
+        try std.testing.expectEqual(getPatternScore(count, .empty, .empty, .white), scores.FIVE);
+    }
 }
 
 test "getPatternType basics" {
-    try std.testing.expectEqual(getPatternType(5, .empty, .empty), .five);
-    try std.testing.expectEqual(getPatternType(4, .empty, .empty), .open_four);
-    try std.testing.expectEqual(getPatternType(4, .empty, .opponent), .four);
-    try std.testing.expectEqual(getPatternType(4, .opponent, .opponent), .none);
-    try std.testing.expectEqual(getPatternType(3, .empty, .empty), .open_three);
-    try std.testing.expectEqual(getPatternType(1, .empty, .empty), .none);
+    try std.testing.expectEqual(getPatternType(5, .empty, .empty, .black), .five);
+    try std.testing.expectEqual(getPatternType(5, .empty, .empty, .white), .five);
+    try std.testing.expectEqual(getPatternType(4, .empty, .empty, .black), .open_four);
+    try std.testing.expectEqual(getPatternType(4, .empty, .opponent, .black), .four);
+    try std.testing.expectEqual(getPatternType(4, .opponent, .opponent, .black), .none);
+    try std.testing.expectEqual(getPatternType(3, .empty, .empty, .black), .open_three);
+    try std.testing.expectEqual(getPatternType(1, .empty, .empty, .black), .none);
+}
+
+// #132: 黒の長連は .none（五でも四でもない）。白は .five。
+test "getPatternType: 黒の長連は none・白の長連は five" {
+    var count: u8 = 6;
+    while (count <= 10) : (count += 1) {
+        try std.testing.expectEqual(getPatternType(count, .empty, .empty, .black), .none);
+        try std.testing.expectEqual(getPatternType(count, .empty, .empty, .white), .five);
+    }
 }
 
 test "evaluateDirectionScores basic" {

--- a/zig/src/patterns.zig
+++ b/zig/src/patterns.zig
@@ -13,11 +13,18 @@ const DIRECTIONS = board_mod.DIRECTIONS;
 /// パターンからスコアを計算（getPatternScore 相当）
 ///
 /// 五の判定は `forbidden.isFiveLength` に委ねる（SSoT・#125）。黒はちょうど 5 連、
-/// 白は 5 連以上が五。**黒の 6 連以上は長連＝禁手なので五でも四でもなく 0 点**（#132）。
+/// 白は 5 連以上が五。**黒の 6 連以上は長連＝禁手なので五でも四でもなく 0 点**（#132、
+/// `forbidden.isOverlineLength` と同値）。
+///
+/// `color` に `.empty` を渡してはいけない（黒扱いになる）。呼び出し元はいずれも
+/// 実際に石を置く色を渡す。
+///
+/// ホットパス（`position_eval.computeAttackScore` から 1 手あたり 4 方向）なので、
+/// count 0..4 は先頭の `count >= 5` 1 比較だけで switch に落ちるようにしている。
 pub fn getPatternScore(count: u8, end1: EndState, end2: EndState, color: Cell) i32 {
-    if (forbidden.isFiveLength(count, color)) return scores.FIVE;
-    // ここに来る count >= 5 は黒の長連のみ（count == 5 は黒白とも五）
-    if (count >= 5) return 0;
+    // count >= 5 は「五」か「黒の長連」のいずれか。isFiveLength が false なら
+    // 残るのは黒の長連だけ（= isOverlineLength(count, color)）。
+    if (count >= 5) return if (forbidden.isFiveLength(count, color)) scores.FIVE else 0;
 
     const both_open = end1 == .empty and end2 == .empty;
     const one_open = end1 == .empty or end2 == .empty;
@@ -44,10 +51,9 @@ pub const PatternType = enum(u8) {
 };
 
 /// 五の判定は `getPatternScore` と同じく `forbidden.isFiveLength`（#125）。
-/// 黒の 6 連以上（長連＝禁手）は `.none`（#132）。
+/// 黒の 6 連以上（長連＝禁手）は `.none`（#132）。`color` の扱いも同じ。
 pub fn getPatternType(count: u8, end1: EndState, end2: EndState, color: Cell) PatternType {
-    if (forbidden.isFiveLength(count, color)) return .five;
-    if (count >= 5) return .none;
+    if (count >= 5) return if (forbidden.isFiveLength(count, color)) .five else .none;
 
     const both_open = end1 == .empty and end2 == .empty;
     const one_open = end1 == .empty or end2 == .empty;

--- a/zig/src/position_eval.zig
+++ b/zig/src/position_eval.zig
@@ -181,7 +181,7 @@ fn computeAttackScore(cells: []Cell, row: u8, col: u8, color: Cell) struct {
         dir_end1s[i] = ends.end1;
         dir_end2s[i] = ends.end2;
 
-        var dir_score = patterns.getPatternScore(lut.count, ends.end1, ends.end2);
+        var dir_score = patterns.getPatternScore(lut.count, ends.end1, ends.end2, color);
 
         // 斜め方向ボーナス
         if ((i == 2 or i == 3) and dir_score > 0) {

--- a/zig/src/prospect.zig
+++ b/zig/src/prospect.zig
@@ -143,7 +143,8 @@ pub fn classifyDirection(own_no_center: u9, block: u9, color: Cell) DirCode {
     const pt = ll.computePattern(own, block);
 
     // 黒の長連（窓内で観測できる範囲のみ。窓外は近似で見逃す＝§2.1-1）。
-    if (color == .black and pt.count >= 6) return .dead;
+    // 長連の定義は forbidden.isOverlineLength（SSoT・#132）。
+    if (forbidden.isOverlineLength(pt.count, color)) return .dead;
 
     // 五の定義は forbidden.isFiveLength（SSoT・#125）。黒はちょうど 5、白は 5 以上。
     if (forbidden.isFiveLength(pt.count, color)) return .f5;


### PR DESCRIPTION
## 原因

連珠では**黒はちょうど 5 連のみ五**（6 連以上＝長連は禁手）、**白は 5 連以上が五**。
#125 / #131 で「勝敗に効く五判定」は `isFiveLength(length, color)`（TS `renjuRules/core.ts` /
Zig `forbidden.zig`）に一本化したが、**評価・move ordering・分析系には色を受け取らない
`count >= 6` / `count >= 5` の五扱いが残っていた**。

黒番の候補生成は `minimax.zig:563` で `skip_forbidden_check = true` のため、
黒の長連点が候補に入り、ordering の静的評価に `FIVE`(100000) として載っていた。

## 棚卸し

「五」を色非依存で判定していた評価/分析系の全箇所と、その実害:

| 箇所 | 判定 | 実害 | 本 PR |
| --- | --- | --- | --- |
| `zig/src/patterns.zig getPatternScore` | `count >= 6` → `FIVE` | 攻め側の move ordering（黒長連点が 100000 で最上位）**＋ 下記 `computeAttackScore` 経由で合法手の評価値** | 修正 |
| `zig/src/patterns.zig getPatternType` | `count >= 6` → `.five` | ordering のみ（`.five` は `four_score`/`open_three_score` のどちらにも入らない） | 修正 |
| `zig/src/position_eval.zig computeAttackScore` | 上記 `getPatternScore` の呼び出し本体 | **白の合法手の評価値が変わる**（`position_eval.zig:414` は `opponent_color` で呼ぶため、白番の防御項で「黒が打てば 6 連になる空点」が `FIVE × DEFENSE 係数` ≒ 70000 として計上されていた） | 呼び出し側に color を渡す |
| `zig/src/quiescence.zig`（葉評価） | 同上（`incremental_eval.placeStone` → `evaluateStonePatternsLightOnCells` → `getPatternScore`） | **静止探索の葉評価が変わる**。quiescence は黒の禁手をフィルタしないので、黒が四受けを強制されその受け点が長連点になる局面で誤った大スコアが出ていた | 同上（着手可能な点は別 issue #142） |
| `zig/src/minimax.zig analyzeFourAndThree` | `count >= 5` → `has_five` | **挙動としては no-op**（下記参照）。構造体の契約の修正 | 修正 |
| `src/logic/cpu/evaluation/directionAnalysis.ts getPatternScore` / `getPatternType` | `count >= 6` → `FIVE` / `"five"` | Zig の対。**本番探索からの消費者はゼロ**（探索は WASM 専用、live な呼び出し元は `lineTable/lineScan.ts` のテーブル構築のみ）だが、TS⇄Zig 二重実装のドリフト防止のため同時修正 | 修正 |
| `zig/src/prospect.zig classifyDirection` | — | **#131 で対応済み** | `isOverlineLength` 経由に統一 |
| `zig/src/position_eval.zig` の残り 4 関数（`countMiseTargets` / `hasFollowUpThreat` / `canContinueFourAfterDefense` / `evaluateForbiddenTrap`） | 五の色盲判定なし | #133 の棚卸し (b) に挙がっているのは `has_jump_four` 系の別問題で、本 issue には該当しない | 変更なし |
| `src/logic/cpu/lineTable/lineChecks.ts checkOverlineBit` | `count >= 6` | 長連判定そのもの（黒専用）で誤りではない | 変更なし |

### 実害の訂正（重要）

issue 本文と本 PR の初版は「実害は ordering 効率のみ／探索結果は変わらない」としていたが、
**これは誤りだった**。レビューで以下が判明:

1. **白の合法手の評価値が変わる**（`position_eval.zig:414`）。
   `computeAttackScore` は防御スコアの算出で **opponent 色**でも呼ばれる。
   白番で「黒が打てば 6 連になる空点」の防御項が `FIVE × 0.7 = 70000` → 0 になる。
   黒はそこに打てない（禁手）ので、その点を守る価値は本来ゼロ。**修正が正しい方向**。
2. **静止探索の葉評価が変わる**（`quiescence.zig:150-155` / `:298`）。
   quiescence は黒の禁手をフィルタしない（`checkForbiddenMove` の呼び出しが存在しない）ため、
   黒が四受けを強制されその受け点が長連点になる局面で、葉評価に `FIVE` が載っていた。
   **変更前が誤り**。着手そのものがフィルタされない件は **follow-up issue #142** に切り出した。
3. **主探索の探索順序が変わる**（`minimax.zig:607-618`）。
   遅延禁手判定は `continue` で禁手手を捨てるが、`while (...) : (move_index += 1)` なので
   **`move_index` は進む**。黒長連点が最上位だった局面では真の最善手が `move_index == 1` になり、
   PVS のフルウィンドウ／LMR／Futility の境界が 1 手ぶんずれていた。**修正後は変わる（改善方向）**。

したがって本 PR は **ordering 効率だけの変更ではなく、評価値と探索結果が変わり得る**。
**Elo ベンチ（commit-bench）は必須**。

なお `reviewSnapshot.test.ts` を含む既存テストはスナップショット更新ゼロだったが、
これは上記 3 ケースを踏む局面がスナップショットに含まれていなかっただけで、
**「影響が小さい」ことの根拠にはならない**。

## 変更

### 1. 「五」と「長連」を対の述語に集約（SSoT）

`isFiveLength(length, color)`（#125）の対として **`isOverlineLength(length, color)`** を新設:

- Zig: `zig/src/forbidden.zig`（黒のみ `>= 6`、白は常に false）
- TS: `src/logic/renjuRules/core.ts`（同上。barrel からも re-export）

これで `patterns.zig` / `minimax.zig` / `prospect.zig` / `directionAnalysis.ts` に
散っていた 4 通りの長連表現（`count >= 6` / `color == .black and count >= 6` /
`isFiveLength` 後の残余）が 1 つの述語に揃う。
`isFiveLength` と `isOverlineLength` が同じ長さで同時に true にならないことをテストで固定。

### 2. `getPatternScore` / `getPatternType` に `color` を追加（TS/Zig）

```
if (count >= 5) return isFiveLength(count, color) ? FIVE : 0;  // 残るのは黒の長連だけ
```

の形にした。`count == 5` は黒白とも五なので、else 側に落ちるのは黒の 6 連以上のみ。
**ホットパス**（`computeAttackScore` から 1 手あたり 4 方向）なので、
`count 0..4` が先頭 1 比較だけで switch に落ちるようこの並びにしている。

### 3. `analyzeFourAndThree` は五優先の二段判定

黒の長連は禁手で着手そのものが不可なので all-false を返す。ただし
**五と長連が同時に成立する黒の着手は五が優先**（主探索の遅延禁手判定が
`checkFive` を先に見るのと同じ順位）。方向順で結果が変わらないよう、
長連を見つけても即 return せず**全方向をスキャンしてから**判定する二段構成にした。

⚠️ **この変更は現状の全消費者で挙動 no-op**。
`isThreatExtensionCandidate` / LMR 調整（`minimax.zig`）/ `demotePlainFourIfNeeded`（`search.zig`）は
いずれも `has_four` と `has_open_three` しか見ず、`has_five` が true でも false でも
`has_four = has_open_three = false` なら同値。さらに主探索では禁手手は遅延禁手判定で
先に捨てられるためここに届かない。**構造体の契約（「`has_five` は五である」）を正すための変更**。

### 4. TS の packed テーブルを色別化

`PACKED_TO_SCORE` / `PACKED_TO_TYPE` は黒と白で `count >= 6` の値が分かれるため
`Record<PlayerColor, Int16Array>` / `Record<PlayerColor, Uint8Array>` にした。
これらと TS の `getPatternScore` / `getPatternType` は**本番消費者ゼロ**
（パリティ検証専用の参照実装）である旨を doc コメントに明記した（#43 の棚卸し候補）。

### 5. WASM export に color を追加

`wasmGetPatternScore` / `wasmGetPatternType`（パリティ oracle。本番探索からは未使用）
にも `color` を追加。`src/logic/cpu/wasm/types.ts` の型も更新。

### スコア表は不変

`PATTERN_SCORES` / `scores.zig` の値は**一切変更していない**。
評価重みは Texel 調整済みなので、変更は「黒の長連を五から外す」だけに絞った。

## テスト

**先行して書いた**（TDD）。新規テストが修正前に落ちることも確認済み
（`patterns.zig` を色盲版に戻すと `patterns.test.getPatternScore: 黒の長連は 0 点・白の長連は五` と
`move_order.test.sortMoves: 黒の長連点が静的評価で先頭に来ない` の 2 件が fail）。

- `zig/src/patterns.zig`: 黒 `count 6..10` が 0 / `.none`、白が `FIVE` / `.five`、黒白ともちょうど 5 は五
- `zig/src/minimax.zig`:
  - `analyzeFourAndThree` が黒の横 6 連（同じ着手点に縦の活三あり）で全フィールド false
  - **五と長連が同居する黒の着手は方向順に関係なく五**（横長連×縦五／縦長連×横五の両方）
  - 白 6 連・黒ちょうど 5 連は `has_five`
- `zig/src/move_order.zig`（**回帰**）: 黒番 `BBB_BB` の局面で `sortMoves` の先頭が長連点でない
- `src/logic/renjuRules.test.ts`: `isOverlineLength` の色別挙動と `isFiveLength` との排他
- `src/logic/cpu/evaluation/directionAnalysis.test.ts`: TS 側の同等ケース
- **`src/logic/cpu/evaluation/patternScoreParity.wasm.test.ts`（新設）**:
  `count 0..15 × end1 3 値 × end2 3 値 × 色 2` の全入力で TS⇄Zig（wasm）一致。
  `color = .empty` が黒扱いにフォールバックする（空点が五にならない）ことも固定
- `src/logic/cpu/lineTable/lineScan.test.ts`: 色別テーブルの全 256 エントリ一致
  （スキップ条件は「clamp される FIVE のみ」に厳密化し、黒の長連 = 0 を比較対象に残した）

結果:

- `pnpm check-fix` ✅
- `pnpm test` ✅ 123 files / 1892 tests
- `cd zig && zig build test` ✅

## 対局 CPU への影響

- **白の合法手の評価値が変わる**（黒が打てない長連点の防御価値 70000 → 0。正しい方向）
- **静止探索の葉評価が変わる**（黒の強制四受けが長連点になる局面。変更前が誤り）
- **主探索の move ordering と PVS/LMR/Futility の境界が変わる**（黒長連点が最上位を
  占めなくなるぶん、真の最善手が `move_index == 0` に戻る。改善方向）

いずれも「誤った大スコアが消える」方向だが、**探索結果が変わる以上 Elo は測らないと分からない**。
commit-bench はオーケストレータ側で実施。

## 関連

Closes #132
follow-up: #142（静止探索が黒の禁手をフィルタしていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
