### PR TITLE
feat(bench): ハング診断の情報強化（生存信号・メインスレッド計測）と replay-hang 履歴再生 (#128)

### DIFF
--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -42,7 +42,9 @@ import type {
 } from "./types/commit-bench.ts";
 
 import { estimateEloDiff, formatEloDiff } from "./lib/eloDiff.ts";
+import { startEventLoopSampler } from "./lib/eventLoopSampler.ts";
 import { type HangDumpSideConfig, writeHangDump } from "./lib/hangDump.ts";
+import { deriveGameSeed } from "./lib/hangReplay.ts";
 import {
   buildJushuTasks,
   createBridgeWorker,
@@ -50,7 +52,6 @@ import {
   type HangMatchInfo,
   runMatch,
 } from "./lib/match.ts";
-import { mixSeed } from "./lib/mulberry32.ts";
 import { parseHangInjectEnv } from "./lib/parseHangInjectEnv.ts";
 import { DEFAULT_SPRT_CONFIG, formatSPRT, updateSPRT } from "./lib/sprt.ts";
 
@@ -688,6 +689,10 @@ function removeWorktree(worktreePath: string): void {
 async function main(): Promise<void> {
   const options = parseArgs();
   const startTime = performance.now();
+  // #128: メインスレッドのイベントループ遅延・時計ずれを常時サンプリングする。
+  // 「worker がハングした」のか「メインスレッド/マシンが止まっていた」のかを
+  // ハングダンプで切り分けるため（実ダンプ g172 の 38.7 分の空白）。
+  startEventLoopSampler();
 
   // コミット情報を取得
   const commitA = getCommitInfo(options.refA);
@@ -915,10 +920,7 @@ async function main(): Promise<void> {
           jushuName: info.jushuName,
           isABlack: info.isABlack,
           pairIdx: info.pairIdx,
-          gameSeed:
-            seedInEffect === undefined
-              ? undefined
-              : mixSeed(seedInEffect, info.gameIdx),
+          gameSeed: deriveGameSeed(seedInEffect, info.gameIdx),
         },
         bench: {
           tool: "commit-bench",
@@ -929,11 +931,13 @@ async function main(): Promise<void> {
           baseSeed: seedInEffect,
         },
         workerConfigs,
-        recentGames: info.recentGames,
       });
+      const { telemetry, liveness, mainThread } = context;
       console.warn(
-        `⚠ hang detected g${info.gameIdx}, dumped to ${dumpPath} ` +
-          `(requests=${context.telemetry.requestCount}, recentMoves=${context.telemetry.recentMoves.length}, recentGames=${info.recentGames.length})`,
+        `⚠ hang detected g${info.gameIdx}, dumped to ${dumpPath}\n` +
+          `  worker: requests=${telemetry.requestCount} recentMoves=${telemetry.recentMoves.length} recentGames=${telemetry.recentGames.length}\n` +
+          `  liveness: ${liveness.verdict} (timeChecks=${liveness.timeCheckCount}, +${liveness.timeCheckDeltaDuringSample} in ${liveness.sampleWindowMs}ms)\n` +
+          `  mainThread: maxTimerLag=${mainThread.maxTimerLagMs}ms maxClockSkewJump=${mainThread.maxClockSkewJumpMs}ms`,
       );
     };
 
@@ -973,7 +977,8 @@ async function main(): Promise<void> {
         getGameSeed:
           seedInEffect === undefined
             ? undefined
-            : (gameIdx: number): number => mixSeed(seedInEffect, gameIdx),
+            : (gameIdx: number): number =>
+                deriveGameSeed(seedInEffect, gameIdx)!,
       },
     );
 

--- a/scripts/commit-bench.ts
+++ b/scripts/commit-bench.ts
@@ -929,8 +929,12 @@ async function main(): Promise<void> {
           baseSeed: seedInEffect,
         },
         workerConfigs,
+        recentGames: info.recentGames,
       });
-      console.warn(`⚠ hang detected g${info.gameIdx}, dumped to ${dumpPath}`);
+      console.warn(
+        `⚠ hang detected g${info.gameIdx}, dumped to ${dumpPath} ` +
+          `(requests=${context.telemetry.requestCount}, recentMoves=${context.telemetry.recentMoves.length}, recentGames=${info.recentGames.length})`,
+      );
     };
 
     const hangInjectParsed = parseHangInjectEnv(process.env.HANG_INJECT);

--- a/scripts/commit-game-runner.ts
+++ b/scripts/commit-game-runner.ts
@@ -10,7 +10,12 @@ import type { Worker } from "node:worker_threads";
 
 import type { BoardState, Position } from "../src/types/game.ts";
 
-import { mixSeed } from "./lib/mulberry32.ts";
+import {
+  type EventLoopSnapshot,
+  snapshotEventLoop,
+} from "./lib/eventLoopSampler.ts";
+import { deriveMoveSeed } from "./lib/hangReplay.ts";
+import { type HangLiveness, diagnoseLiveness } from "./lib/workerLiveness.ts";
 import { WorkerMoveTimeoutError } from "./lib/workerMoveTimeoutError.ts";
 import {
   type WorkerTelemetrySnapshot,
@@ -113,9 +118,20 @@ export interface HangContext {
    *
    * **wasm 側の「現在の探索統計」は取得できない**: worker スレッドは wasm 探索で
    * 同期的にブロックされており、postMessage を送っても event loop が回らないため
-   * 応答できない。直近手の統計（recentMoves）で代替する。
+   * 応答できない。直近手の統計（recentMoves）と liveness で代替する。
    */
   telemetry: WorkerTelemetrySnapshot;
+  /**
+   * #128: 共有メモリ経由の worker 生存信号。wasm が時間チェックを回し続けている
+   * （＝探索が終わらない）のか、探索ループの外で固まっているのかを区別する。
+   */
+  liveness: HangLiveness;
+  /**
+   * #128: メインスレッド自身のイベントループ遅延・時計ずれ。
+   * 実ダンプ g172 のように「経過時間だけが異常に長い」ケースが worker のハングでは
+   * なくメインスレッド停止／マシンのサスペンドである可能性を切り分ける。
+   */
+  mainThread: EventLoopSnapshot;
 }
 
 export class GameHangError extends Error {
@@ -177,7 +193,15 @@ function askWorker(params: AskWorkerParams): Promise<MoveResponse> {
 
     const timer = setTimeout(() => {
       worker.off("message", handler);
-      reject(new WorkerMoveTimeoutError({ requestId, timeoutMs, color, side }));
+      reject(
+        new WorkerMoveTimeoutError({
+          requestId,
+          timeoutMs,
+          color,
+          side,
+          telemetry: telemetry.snapshot(),
+        }),
+      );
     }, timeoutMs);
 
     const handler = (msg: WorkerMessage): void => {
@@ -188,6 +212,9 @@ function askWorker(params: AskWorkerParams): Promise<MoveResponse> {
       clearTimeout(timer);
 
       if ("error" in msg) {
+        // 着手ではないが応答は返っている。pending を残すとダンプの
+        // pendingRequest が「ハングした要求」でなくなるので必ず消す。
+        telemetry.clearPending(requestId);
         reject(new Error(msg.error));
       } else {
         telemetry.recordResponse({
@@ -197,6 +224,7 @@ function askWorker(params: AskWorkerParams): Promise<MoveResponse> {
           color,
           depth: msg.depth,
           score: msg.score,
+          interrupted: msg.interrupted,
           thinkingTimeMs: msg.thinkingTimeMs,
           roundTripMs: performance.now() - sentAtMs,
           stats: msg.stats,
@@ -262,6 +290,10 @@ async function askOrHang(params: AskOrHangParams): Promise<MoveResponse> {
     return await askWorker({ ...askParams, board });
   } catch (err: unknown) {
     if (err instanceof WorkerMoveTimeoutError) {
+      // 生存信号は 2 点サンプリングが要るので await する（ハング経路のみ）。
+      const liveness = await diagnoseLiveness(
+        getWorkerTelemetry(params.worker).getLivenessChannel(),
+      );
       throw new GameHangError({
         requestId: err.requestId,
         timeoutMs: err.timeoutMs,
@@ -271,7 +303,9 @@ async function askOrHang(params: AskOrHangParams): Promise<MoveResponse> {
         moveHistory,
         elapsedMs: performance.now() - gameStartTime,
         moveNumber: params.moveNumber,
-        telemetry: getWorkerTelemetry(params.worker).snapshot(),
+        telemetry: err.telemetry,
+        liveness,
+        mainThread: snapshotEventLoop(),
       });
     }
     throw err;
@@ -378,10 +412,8 @@ export async function runCommitGame(
 
     const moveStartTime = performance.now();
 
-    const moveSeed =
-      options.gameSeed === undefined
-        ? undefined
-        : mixSeed(options.gameSeed, nonOpeningRequestOrdinal);
+    // 導出規則は hangReplay.ts に一本化（replay-hang と必ず一致させるため）
+    const moveSeed = deriveMoveSeed(options.gameSeed, nonOpeningRequestOrdinal);
     const response = await askOrHang({
       worker,
       board,

--- a/scripts/commit-game-runner.ts
+++ b/scripts/commit-game-runner.ts
@@ -12,6 +12,10 @@ import type { BoardState, Position } from "../src/types/game.ts";
 
 import { mixSeed } from "./lib/mulberry32.ts";
 import { WorkerMoveTimeoutError } from "./lib/workerMoveTimeoutError.ts";
+import {
+  type WorkerTelemetrySnapshot,
+  getWorkerTelemetry,
+} from "./lib/workerTelemetry.ts";
 
 /** 着手記録 */
 export interface MoveRecord {
@@ -102,6 +106,16 @@ export interface HangContext {
    * moveHistory の直後に打とうとしていた手の番号（= moveHistory.length + 1）。
    */
   moveNumber: number;
+  /**
+   * #128: ハングした worker についてメインスレッドが保持していた計測。
+   * 起動時の解決済みパラメータ・起動からの要求数・ハングした要求のパラメータ・
+   * 直近 N 手の思考統計を含む。
+   *
+   * **wasm 側の「現在の探索統計」は取得できない**: worker スレッドは wasm 探索で
+   * 同期的にブロックされており、postMessage を送っても event loop が回らないため
+   * 応答できない。直近手の統計（recentMoves）で代替する。
+   */
+  telemetry: WorkerTelemetrySnapshot;
 }
 
 export class GameHangError extends Error {
@@ -130,17 +144,36 @@ interface AskWorkerParams {
    * 未指定なら worker 側は非決定的（Math.random）にフォールバック。
    */
   moveSeed?: number;
+  /** #128: 計測用メタ（ダンプ以外の挙動には影響しない） */
+  moveNumber: number;
+  nonOpeningOrdinal: number;
+  gameIdx?: number;
 }
 
 /**
  * workerに着手を要求し、レスポンスを待つ。
  * timeout 時は WorkerMoveTimeoutError を throw（runCommitGame が context を付与する）。
+ *
+ * #128: 送信/受信を worker 単位の telemetry に記録する。ハング時にはこの記録が
+ * 「メインスレッドから見た worker の最後の状態」としてダンプに載る。
  */
 function askWorker(params: AskWorkerParams): Promise<MoveResponse> {
-  const { worker, board, color, timeoutMs, side, hangInject, moveSeed } =
-    params;
+  const {
+    worker,
+    board,
+    color,
+    timeoutMs,
+    side,
+    hangInject,
+    moveSeed,
+    moveNumber,
+    nonOpeningOrdinal,
+    gameIdx,
+  } = params;
+  const telemetry = getWorkerTelemetry(worker);
   return new Promise<MoveResponse>((resolve, reject) => {
     const requestId = nextRequestId++;
+    const sentAtMs = performance.now();
 
     const timer = setTimeout(() => {
       worker.off("message", handler);
@@ -157,10 +190,30 @@ function askWorker(params: AskWorkerParams): Promise<MoveResponse> {
       if ("error" in msg) {
         reject(new Error(msg.error));
       } else {
+        telemetry.recordResponse({
+          requestId,
+          gameIdx,
+          moveNumber,
+          color,
+          depth: msg.depth,
+          score: msg.score,
+          thinkingTimeMs: msg.thinkingTimeMs,
+          roundTripMs: performance.now() - sentAtMs,
+          stats: msg.stats,
+        });
         resolve(msg);
       }
     };
 
+    telemetry.recordRequest({
+      requestId,
+      gameIdx,
+      moveNumber,
+      color,
+      nonOpeningOrdinal,
+      moveSeed,
+      sentAt: new Date().toISOString(),
+    });
     worker.on("message", handler);
     worker.postMessage({ requestId, board, color, hangInject, moveSeed });
   });
@@ -197,7 +250,6 @@ export interface HangInjectSpec {
 interface AskOrHangParams extends AskWorkerParams {
   moveHistory: MoveRecord[];
   gameStartTime: number;
-  moveCount: number;
 }
 
 /**
@@ -205,7 +257,7 @@ interface AskOrHangParams extends AskWorkerParams {
  * ループ内クロージャで no-loop-func 警告を出さないため、ループ外の関数として切り出す。
  */
 async function askOrHang(params: AskOrHangParams): Promise<MoveResponse> {
-  const { board, moveHistory, gameStartTime, moveCount, ...askParams } = params;
+  const { board, moveHistory, gameStartTime, ...askParams } = params;
   try {
     return await askWorker({ ...askParams, board });
   } catch (err: unknown) {
@@ -218,7 +270,8 @@ async function askOrHang(params: AskOrHangParams): Promise<MoveResponse> {
         board,
         moveHistory,
         elapsedMs: performance.now() - gameStartTime,
-        moveNumber: moveCount + 1,
+        moveNumber: params.moveNumber,
+        telemetry: getWorkerTelemetry(params.worker).snapshot(),
       });
     }
     throw err;
@@ -250,6 +303,11 @@ export async function runCommitGame(
      * 選択を決定的にする。未指定なら bridge worker は Math.random にフォールバック。
      */
     gameSeed?: number;
+    /**
+     * #128: ベンチのタスク index（0-based）。worker 計測に記録するだけで
+     * 対局挙動には影響しない。ハングダンプで「どの局の要求か」を辿るのに使う。
+     */
+    gameIdx?: number;
   } = {},
 ): Promise<GameResult> {
   // #43 PR-6: 禁手判定(forbidden) と脅威検出(detectOpponentThreats→threat) はどちらも
@@ -334,7 +392,9 @@ export async function runCommitGame(
       moveSeed,
       moveHistory,
       gameStartTime: startTime,
-      moveCount,
+      moveNumber: moveCount + 1,
+      nonOpeningOrdinal: nonOpeningRequestOrdinal,
+      gameIdx: options.gameIdx,
     });
     const moveTime = performance.now() - moveStartTime;
 

--- a/scripts/cpu-bridge-worker.ts
+++ b/scripts/cpu-bridge-worker.ts
@@ -26,6 +26,7 @@ import type { DifficultyParams } from "../src/types/cpu.ts";
 import type { BoardState, Position } from "../src/types/game.ts";
 import type { EngineParamsSnapshot } from "./lib/workerTelemetry.ts";
 
+import { fingerprintEvalWeights } from "./lib/bridgeWorkerProtocol.ts";
 import { mergeDifficultyParams } from "./lib/difficultyParamsMerge.ts";
 import { EVAL_PARAM_IDS } from "./lib/evalParams.ts";
 import { mulberry32 } from "./lib/mulberry32.ts";
@@ -34,6 +35,11 @@ import {
   loadOpeningBookFromWorktree,
 } from "./lib/openingBookBridge.ts";
 import { encodeEvalOptionsForWasm } from "./lib/wasmEvalOptionsEncoder.ts";
+import {
+  type LivenessChannel,
+  createTimestampProbe,
+  markLivenessRequest,
+} from "./lib/workerLiveness.ts";
 
 // ============================================================================
 // 型定義
@@ -64,6 +70,13 @@ interface BridgeWorkerData {
    * commit-bench で再検証するための実行時レバー。
    */
   threatProbeEnabled?: boolean;
+  /**
+   * #128: ハング診断用の生存信号チャネル（SharedArrayBuffer）。
+   * 指定されると wasm の `getTimestampMsExternal` 呼び出しを計上し、
+   * メインスレッドが「探索ループがまだ回っているか」を観測できるようになる。
+   * 未指定なら完全に従来挙動（後方互換）。
+   */
+  livenessChannel?: LivenessChannel;
 }
 
 interface MoveRequest {
@@ -233,9 +246,12 @@ async function loadWasmFromWorktree(
 
   try {
     const buffer = fs.readFileSync(wasmPath);
+    // #128: 時間チェックのたびに生存信号を更新する。wasm はハング中も
+    // この関数を呼び返すので、メインスレッドは共有メモリ越しに
+    // 「探索が走り続けているか」を観測できる（Zig 側は無改造）。
     const imports = {
       env: {
-        getTimestampMsExternal: () => Math.round(performance.now()),
+        getTimestampMsExternal: createTimestampProbe(data.livenessChannel),
       },
     };
     const { instance } = await WebAssembly.instantiate(buffer, imports);
@@ -672,12 +688,15 @@ async function main(): Promise<void> {
     bookEnabled: bookBridge !== null,
     hasStatsBuffer: typeof wasm?.getStatsBuffer === "function",
     threatProbe: threatProbeState,
+    evalWeightsFingerprint: fingerprintEvalWeights(data.evalWeights),
   };
   parentPort?.postMessage({ ready: true, params: engineParams });
 
   // 着手要求を処理（同期的にCPUを呼び出す）
   parentPort?.on("message", (msg: MoveRequest) => {
     const { requestId, board, color, hangInject, moveSeed } = msg;
+    // #128: 生存信号に「今どの要求を処理中か」を刻む
+    markLivenessRequest(data.livenessChannel, requestId);
     // テスト用: hangInject が立っていれば応答せず沈黙 → 呼び出し側が timeout する
     if (hangInject) {
       console.warn(

--- a/scripts/cpu-bridge-worker.ts
+++ b/scripts/cpu-bridge-worker.ts
@@ -24,6 +24,7 @@ import { parentPort, workerData } from "node:worker_threads";
 
 import type { DifficultyParams } from "../src/types/cpu.ts";
 import type { BoardState, Position } from "../src/types/game.ts";
+import type { EngineParamsSnapshot } from "./lib/workerTelemetry.ts";
 
 import { mergeDifficultyParams } from "./lib/difficultyParamsMerge.ts";
 import { EVAL_PARAM_IDS } from "./lib/evalParams.ts";
@@ -616,6 +617,8 @@ async function main(): Promise<void> {
   const wasm = await loadWasmFromWorktree(worktreePath);
   let wasmHandler: WasmSearchHandler | null = null;
   let tsFindBestMove: FindBestMoveFn | null = null;
+  // #128: ready 通知（EngineParamsSnapshot）にも載せるためブロック外で保持する
+  let threatProbeState = "ON(default)";
 
   if (wasm) {
     wasmHandler = createWasmSearchHandler(wasm);
@@ -623,7 +626,6 @@ async function main(): Promise<void> {
     applyEvalWeights(wasm, data.evalWeights);
     // 脅威プローブトグル（Gate 0 計測用）。既定 true=従来挙動、false のときのみ
     // 明示 off。setThreatProbeEnabled が無い古い wasm は warn してスキップ。
-    let threatProbeState = "ON(default)";
     if (data.threatProbeEnabled === false) {
       if (typeof wasm.setThreatProbeEnabled === "function") {
         wasm.setThreatProbeEnabled(0);
@@ -654,8 +656,24 @@ async function main(): Promise<void> {
     );
   }
 
-  // 初期化完了を通知
-  parentPort?.postMessage({ ready: true });
+  // 初期化完了を通知。#128: 解決済みのエンジンパラメータを同梱し、メインスレッド
+  // 側（workerTelemetry）がハングダンプに載せられるようにする。ハング中の worker
+  // は問い合わせに応答できないため、この「起動時の自己申告」が唯一の入手経路。
+  const engineParams: EngineParamsSnapshot = {
+    worktreePath,
+    difficulty: data.difficulty,
+    depth: params.depth,
+    timeLimit: params.timeLimit,
+    maxNodes: params.maxNodes,
+    randomFactor: params.randomFactor,
+    randomCriticalScoreThreshold: params.randomCriticalScoreThreshold,
+    evaluationOptions: params.evaluationOptions,
+    engine: wasmHandler ? "wasm" : "ts",
+    bookEnabled: bookBridge !== null,
+    hasStatsBuffer: typeof wasm?.getStatsBuffer === "function",
+    threatProbe: threatProbeState,
+  };
+  parentPort?.postMessage({ ready: true, params: engineParams });
 
   // 着手要求を処理（同期的にCPUを呼び出す）
   parentPort?.on("message", (msg: MoveRequest) => {

--- a/scripts/lib/bridgeWorkerProtocol.test.ts
+++ b/scripts/lib/bridgeWorkerProtocol.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import type { EngineParamsSnapshot } from "./workerTelemetry.ts";
+
+import {
+  diffEngineParams,
+  fingerprintEvalWeights,
+  isReadyMessage,
+  parseEngineParams,
+} from "./bridgeWorkerProtocol.ts";
+
+const params: EngineParamsSnapshot = {
+  worktreePath: "/tmp/A-abc1234",
+  difficulty: "hard",
+  depth: 12,
+  timeLimit: 10000,
+  maxNodes: 1000000,
+  randomFactor: 0.02,
+  evaluationOptions: { evalBasis: "prospect" },
+  engine: "wasm",
+  bookEnabled: false,
+  hasStatsBuffer: true,
+  threatProbe: "ON(default)",
+};
+
+describe("isReadyMessage", () => {
+  it("ready:true なら true", () => {
+    expect(isReadyMessage({ ready: true })).toBe(true);
+  });
+  it("着手応答は false", () => {
+    expect(isReadyMessage({ requestId: 1 })).toBe(false);
+  });
+  it("非オブジェクトは false", () => {
+    expect(isReadyMessage(null)).toBe(false);
+    expect(isReadyMessage("ready")).toBe(false);
+  });
+});
+
+describe("parseEngineParams", () => {
+  it("ready ペイロードから params を取り出す", () => {
+    expect(parseEngineParams({ ready: true, params })).toEqual(params);
+  });
+
+  it("params が無い古い bridge worker では undefined", () => {
+    expect(parseEngineParams({ ready: true })).toBeUndefined();
+  });
+
+  it("必須フィールドが欠けていれば undefined（部分的に壊れた params を通さない）", () => {
+    const { depth: _depth, ...withoutDepth } = params;
+    expect(
+      parseEngineParams({ ready: true, params: withoutDepth }),
+    ).toBeUndefined();
+  });
+
+  it("型が違うフィールドがあれば undefined", () => {
+    expect(
+      parseEngineParams({ ready: true, params: { ...params, maxNodes: "1M" } }),
+    ).toBeUndefined();
+  });
+
+  it("engine が想定外の値なら undefined", () => {
+    expect(
+      parseEngineParams({ ready: true, params: { ...params, engine: "gpu" } }),
+    ).toBeUndefined();
+  });
+
+  it("NaN は有効な数値として扱わない", () => {
+    expect(
+      parseEngineParams({ ready: true, params: { ...params, timeLimit: NaN } }),
+    ).toBeUndefined();
+  });
+
+  it("オブジェクト以外は undefined", () => {
+    expect(parseEngineParams(null)).toBeUndefined();
+    expect(parseEngineParams("ready")).toBeUndefined();
+  });
+});
+
+describe("diffEngineParams", () => {
+  it("同一なら差分なし", () => {
+    expect(diffEngineParams(params, { ...params })).toEqual([]);
+  });
+
+  it("探索に効く値の差を検出する", () => {
+    const diffs = diffEngineParams(params, { ...params, maxNodes: 3000000 });
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]?.key).toBe("maxNodes");
+  });
+
+  it("evaluationOptions の差も検出する", () => {
+    const diffs = diffEngineParams(params, {
+      ...params,
+      evaluationOptions: { evalBasis: "legacy" },
+    });
+    expect(diffs.map((d) => d.key)).toContain("evaluationOptions");
+  });
+
+  it("eval 重みの指紋差も検出する", () => {
+    const diffs = diffEngineParams(params, {
+      ...params,
+      evalWeightsFingerprint: { count: 2, hash: "abc" },
+    });
+    expect(diffs.map((d) => d.key)).toContain("evalWeightsFingerprint");
+  });
+
+  it("どちらかが未取得なら比較しない（誤検知を避ける）", () => {
+    expect(diffEngineParams(undefined, params)).toEqual([]);
+    expect(diffEngineParams(params, undefined)).toEqual([]);
+  });
+});
+
+describe("fingerprintEvalWeights", () => {
+  it("未指定なら undefined", () => {
+    expect(fingerprintEvalWeights(undefined)).toBeUndefined();
+  });
+
+  it("空なら count 0", () => {
+    expect(fingerprintEvalWeights({})).toEqual({ count: 0, hash: "0" });
+  });
+
+  it("キー順が違っても同じ指紋", () => {
+    const a = fingerprintEvalWeights({ x: 1, y: 2 });
+    const b = fingerprintEvalWeights({ y: 2, x: 1 });
+    expect(a).toEqual(b);
+  });
+
+  it("値が違えば指紋も違う", () => {
+    const a = fingerprintEvalWeights({ x: 1 });
+    const b = fingerprintEvalWeights({ x: 2 });
+    expect(a?.hash).not.toBe(b?.hash);
+  });
+});

--- a/scripts/lib/bridgeWorkerProtocol.ts
+++ b/scripts/lib/bridgeWorkerProtocol.ts
@@ -1,0 +1,140 @@
+/**
+ * bridge worker ⇄ メインスレッドのメッセージ封筒（envelope）の知識。
+ *
+ * 「ready 通知がどんな形か」は worker 計測（workerTelemetry.ts）の関心事ではないので
+ * 分離する。計測は `EngineParamsSnapshot` という値だけを知っていればよい。
+ *
+ * 古い commit の worktree から起動された bridge worker は `params` を同梱しない
+ * （`{ ready: true }` だけ）ため、パーサは必ず undefined を返せる形にしてある。
+ */
+import type { EngineParamsSnapshot } from "./workerTelemetry.ts";
+
+/** ready 通知かどうか。 */
+export function isReadyMessage(msg: unknown): boolean {
+  return (
+    typeof msg === "object" &&
+    msg !== null &&
+    "ready" in msg &&
+    (msg as { ready: unknown }).ready === true
+  );
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * ready 通知から解決済みエンジンパラメータを取り出す。
+ * 形が違えば undefined（部分的に壊れた params を通すと replay の突き合わせが
+ * 誤検知するため、必須フィールドが揃っていることまで確認する）。
+ */
+export function parseEngineParams(
+  msg: unknown,
+): EngineParamsSnapshot | undefined {
+  if (typeof msg !== "object" || msg === null) {
+    return undefined;
+  }
+  const { params } = msg as { params?: unknown };
+  if (typeof params !== "object" || params === null) {
+    return undefined;
+  }
+  const p = params as Partial<EngineParamsSnapshot>;
+  const ok =
+    typeof p.worktreePath === "string" &&
+    typeof p.difficulty === "string" &&
+    isFiniteNumber(p.depth) &&
+    isFiniteNumber(p.timeLimit) &&
+    isFiniteNumber(p.maxNodes) &&
+    isFiniteNumber(p.randomFactor) &&
+    (p.engine === "wasm" || p.engine === "ts") &&
+    typeof p.bookEnabled === "boolean" &&
+    typeof p.hasStatsBuffer === "boolean" &&
+    typeof p.threatProbe === "string";
+  return ok ? (params as EngineParamsSnapshot) : undefined;
+}
+
+/** replay の突き合わせで比較する項目（探索結果に効くものだけ） */
+const COMPARED_KEYS = [
+  "difficulty",
+  "depth",
+  "timeLimit",
+  "maxNodes",
+  "randomFactor",
+  "engine",
+  "bookEnabled",
+  "threatProbe",
+] as const;
+
+export interface EngineParamsDiff {
+  key: string;
+  expected: unknown;
+  actual: unknown;
+}
+
+/**
+ * ダンプに記録された engineParams と、replay で起動した worker の実パラメータを
+ * 突き合わせる。差分があると「別条件で再現を試みて再現せずと結論する」事故になる。
+ */
+export function diffEngineParams(
+  expected: EngineParamsSnapshot | undefined,
+  actual: EngineParamsSnapshot | undefined,
+): EngineParamsDiff[] {
+  if (!expected || !actual) {
+    return [];
+  }
+  const diffs: EngineParamsDiff[] = [];
+  for (const key of COMPARED_KEYS) {
+    if (expected[key] !== actual[key]) {
+      diffs.push({ key, expected: expected[key], actual: actual[key] });
+    }
+  }
+  const expectedEval = JSON.stringify(expected.evaluationOptions ?? null);
+  const actualEval = JSON.stringify(actual.evaluationOptions ?? null);
+  if (expectedEval !== actualEval) {
+    diffs.push({
+      key: "evaluationOptions",
+      expected: expected.evaluationOptions,
+      actual: actual.evaluationOptions,
+    });
+  }
+  const expectedWeights = JSON.stringify(
+    expected.evalWeightsFingerprint ?? null,
+  );
+  const actualWeights = JSON.stringify(actual.evalWeightsFingerprint ?? null);
+  if (expectedWeights !== actualWeights) {
+    diffs.push({
+      key: "evalWeightsFingerprint",
+      expected: expected.evalWeightsFingerprint,
+      actual: actual.evalWeightsFingerprint,
+    });
+  }
+  return diffs;
+}
+
+/**
+ * eval 重みの指紋を計算する（順序非依存の安定ハッシュ）。
+ * 重み本体をダンプに載せずに「同じ重みか」を判定するためのもの。
+ */
+export function fingerprintEvalWeights(
+  weights: Record<string, number> | undefined,
+): { count: number; hash: string } | undefined {
+  if (!weights) {
+    return undefined;
+  }
+  const entries = Object.entries(weights).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  if (entries.length === 0) {
+    return { count: 0, hash: "0" };
+  }
+  // FNV-1a 32bit（暗号用途ではない。差分検出だけが目的）
+  let hash = 0x811c9dc5;
+  for (const [key, value] of entries) {
+    const text = `${key}=${value};`;
+    for (let i = 0; i < text.length; i++) {
+      hash ^= text.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+  }
+  return { count: entries.length, hash: hash.toString(16) };
+}

--- a/scripts/lib/eventLoopSampler.ts
+++ b/scripts/lib/eventLoopSampler.ts
@@ -1,0 +1,136 @@
+/**
+ * メインスレッドのイベントループ遅延・時計ずれサンプラ（#128）。
+ *
+ * 実ダンプ g172 は「局開始からの経過時間が、各手の思考時間合計 + タイムアウト値より
+ * **38.7 分**も長い」という形をしていた。これは worker の探索が長引いたのではなく、
+ * **メインスレッド側が止まっていた**（イベントループ飽和 / プロセス・マシンの
+ * サスペンド）ことを示唆する。worker 側の計測だけでは区別できないため、メイン
+ * スレッド自身の健康状態を常時サンプリングしてハングダンプに載せる。
+ *
+ * 2 つの指標を取る:
+ * - **timer lag**: `setInterval(…, 1000)` の予定発火と実発火の差。イベントループが
+ *   詰まっている（同期処理で専有されている）と伸びる。
+ * - **clock skew**: `Date.now()`（壁時計）と `performance.now()`（単調時計）の差の
+ *   推移。マシンのサスペンド／レジュームで**跳ぶ**。timer lag と組み合わせると
+ *   「忙しかった」のか「眠っていた」のかを切り分けられる。
+ */
+
+/** 1 サンプル */
+export interface EventLoopSample {
+  /** サンプル時刻（ISO8601） */
+  at: string;
+  /** タイマの予定発火からの遅れ ms（0 に近いほど健康） */
+  timerLagMs: number;
+  /** `Date.now() - (基準 + performance.now())` の値 ms。跳びがサスペンドの兆候 */
+  clockSkewMs: number;
+}
+
+/** ダンプに載せるスナップショット */
+export interface EventLoopSnapshot {
+  /** サンプラが動いていたか（未起動なら false で samples は空） */
+  running: boolean;
+  intervalMs: number;
+  /** 直近 N サンプル（古→新） */
+  samples: EventLoopSample[];
+  /** 観測した最大 timer lag */
+  maxTimerLagMs: number;
+  /**
+   * 隣接サンプル間の clockSkew の最大跳び幅。
+   * 数百 ms を超えるならサスペンド／時計調整を疑う。
+   */
+  maxClockSkewJumpMs: number;
+}
+
+const DEFAULT_INTERVAL_MS = 1000;
+const DEFAULT_SAMPLE_LIMIT = 60;
+
+interface SamplerState {
+  timer: ReturnType<typeof setInterval>;
+  intervalMs: number;
+  limit: number;
+  samples: EventLoopSample[];
+  skewBase: number;
+  expectedAt: number;
+}
+
+let state: SamplerState | null = null;
+
+/**
+ * サンプリングを開始する。多重起動は無視（最初の設定が生きる）。
+ * タイマは `unref()` するのでプロセス終了を妨げない。
+ */
+export function startEventLoopSampler(
+  intervalMs: number = DEFAULT_INTERVAL_MS,
+  limit: number = DEFAULT_SAMPLE_LIMIT,
+): void {
+  if (state) {
+    return;
+  }
+  const skewBase = Date.now() - performance.now();
+  const local: SamplerState = {
+    timer: setInterval(() => {
+      const now = performance.now();
+      const sample: EventLoopSample = {
+        at: new Date().toISOString(),
+        timerLagMs: Math.round(now - local.expectedAt),
+        clockSkewMs: Math.round(
+          Date.now() - performance.now() - local.skewBase,
+        ),
+      };
+      local.expectedAt = now + intervalMs;
+      local.samples.push(sample);
+      if (local.samples.length > local.limit) {
+        local.samples.shift();
+      }
+    }, intervalMs),
+    intervalMs,
+    limit: Math.max(1, limit),
+    samples: [],
+    skewBase,
+    expectedAt: performance.now() + intervalMs,
+  };
+  local.timer.unref();
+  state = local;
+}
+
+export function stopEventLoopSampler(): void {
+  if (!state) {
+    return;
+  }
+  clearInterval(state.timer);
+  state = null;
+}
+
+/** 現在のスナップショットを返す（未起動なら running=false の空スナップショット）。 */
+export function snapshotEventLoop(): EventLoopSnapshot {
+  if (!state) {
+    return {
+      running: false,
+      intervalMs: 0,
+      samples: [],
+      maxTimerLagMs: 0,
+      maxClockSkewJumpMs: 0,
+    };
+  }
+  const samples = [...state.samples];
+  let maxTimerLagMs = 0;
+  let maxClockSkewJumpMs = 0;
+  let previousSkew: number | undefined = undefined;
+  for (const sample of samples) {
+    maxTimerLagMs = Math.max(maxTimerLagMs, sample.timerLagMs);
+    if (previousSkew !== undefined) {
+      maxClockSkewJumpMs = Math.max(
+        maxClockSkewJumpMs,
+        Math.abs(sample.clockSkewMs - previousSkew),
+      );
+    }
+    previousSkew = sample.clockSkewMs;
+  }
+  return {
+    running: true,
+    intervalMs: state.intervalMs,
+    samples,
+    maxTimerLagMs,
+    maxClockSkewJumpMs,
+  };
+}

--- a/scripts/lib/hangDump.test.ts
+++ b/scripts/lib/hangDump.test.ts
@@ -1,0 +1,222 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { BoardState } from "../../src/types/game.ts";
+import type { HangContext } from "../commit-game-runner.ts";
+
+import {
+  HANG_DUMP_SCHEMA_VERSION,
+  type HangDumpBench,
+  type HangDumpJson,
+  type HangDumpMatch,
+  type HangDumpSideConfig,
+  hangSideColor,
+  writeHangDump,
+} from "./hangDump.ts";
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hang-dump-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop()!;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const emptyBoard = (): BoardState =>
+  Array.from({ length: 15 }, () => Array.from({ length: 15 }, () => null));
+
+const context = (): HangContext => ({
+  requestId: 265,
+  timeoutMs: 30000,
+  side: "A",
+  color: "white",
+  board: emptyBoard(),
+  moveHistory: [
+    { row: 7, col: 7, time: 0, isOpening: true },
+    { row: 6, col: 8, time: 0, isOpening: true },
+    { row: 9, col: 7, time: 0, isOpening: true },
+  ],
+  elapsedMs: 293418,
+  moveNumber: 4,
+  telemetry: {
+    requestCount: 42,
+    engineParams: {
+      worktreePath: "/tmp/A-480f4f4",
+      difficulty: "hard",
+      depth: 12,
+      timeLimit: 5000,
+      maxNodes: 3000000,
+      randomFactor: 0.02,
+      evaluationOptions: { evalBasis: "prospect" },
+      engine: "wasm",
+      bookEnabled: false,
+      hasStatsBuffer: true,
+      threatProbe: "ON(default)",
+    },
+    pendingRequest: {
+      requestId: 265,
+      gameIdx: 3,
+      moveNumber: 4,
+      color: "white",
+      nonOpeningOrdinal: 1,
+      moveSeed: 12345,
+      sentAt: "2026-08-23T00:00:00.000Z",
+    },
+    recentMoves: [
+      {
+        requestId: 264,
+        gameIdx: 3,
+        moveNumber: 2,
+        color: "white",
+        depth: 6,
+        score: 40,
+        thinkingTimeMs: 4900,
+        roundTripMs: 4950,
+        stats: { nodes: 987654 },
+      },
+    ],
+  },
+});
+
+const match: HangDumpMatch = {
+  gameIdx: 3,
+  jushuName: "峡月",
+  isABlack: false,
+  pairIdx: 3,
+  gameSeed: 319205941,
+};
+
+const bench: HangDumpBench = {
+  tool: "commit-bench",
+  difficulty: "hard",
+  randomFactor: 0.02,
+  moveTimeoutMs: 30000,
+  jobs: 5,
+  baseSeed: 20260825,
+};
+
+const sideConfig = (label: string): HangDumpSideConfig => ({
+  worktreePath: `/tmp/${label}`,
+  evaluationOptions: undefined,
+  bookEnabled: false,
+  commit: {
+    sha: `${label}0000000000000000000000000000000000`,
+    shortSha: label,
+    message: `commit ${label}`,
+    date: "2026-08-23 01:13:47 +0900",
+  },
+});
+
+const workerConfigs = { A: sideConfig("aaaaaaa"), B: sideConfig("bbbbbbb") };
+
+function writeAndRead(
+  overrides: Partial<Parameters<typeof writeHangDump>[0]> = {},
+): { outPath: string; dump: HangDumpJson } {
+  const outputDir = path.join(makeTmpDir(), "hang-dumps");
+  const outPath = writeHangDump({
+    outputDir,
+    context: context(),
+    match,
+    bench,
+    workerConfigs,
+    ...overrides,
+  });
+  return {
+    outPath,
+    dump: JSON.parse(fs.readFileSync(outPath, "utf-8")) as HangDumpJson,
+  };
+}
+
+describe("hangSideColor", () => {
+  it("A側は isABlack のとき黒", () => {
+    expect(hangSideColor("A", true)).toBe("black");
+  });
+  it("A側は isABlack が false なら白", () => {
+    expect(hangSideColor("A", false)).toBe("white");
+  });
+  it("B側は isABlack のとき白", () => {
+    expect(hangSideColor("B", true)).toBe("white");
+  });
+  it("B側は isABlack が false なら黒", () => {
+    expect(hangSideColor("B", false)).toBe("black");
+  });
+});
+
+describe("writeHangDump", () => {
+  it("出力ディレクトリが無ければ作り、hang-<iso>-g<idx>.json に書く", () => {
+    const { outPath } = writeAndRead();
+    expect(fs.existsSync(outPath)).toBe(true);
+    expect(path.basename(outPath)).toMatch(/^hang-.+-g3\.json$/);
+  });
+
+  it("schemaVersion は 2（#128 で telemetry/recentGames を追加）", () => {
+    const { dump } = writeAndRead();
+    expect(dump.schemaVersion).toBe(HANG_DUMP_SCHEMA_VERSION);
+    expect(dump.schemaVersion).toBe(2);
+  });
+
+  it("ハングした側の worker 設定と telemetry を載せる", () => {
+    const { dump } = writeAndRead();
+    expect(dump.worker.side).toBe("A");
+    expect(dump.worker.commit.shortSha).toBe("aaaaaaa");
+    expect(dump.worker.telemetry?.requestCount).toBe(42);
+    expect(dump.worker.telemetry?.engineParams?.maxNodes).toBe(3000000);
+    expect(dump.worker.telemetry?.pendingRequest?.moveSeed).toBe(12345);
+    expect(dump.worker.telemetry?.recentMoves[0]?.stats?.nodes).toBe(987654);
+  });
+
+  it("相手側は opponent に入る", () => {
+    const { dump } = writeAndRead();
+    expect(dump.opponent.side).toBe("B");
+    expect(dump.opponent.commit.shortSha).toBe("bbbbbbb");
+  });
+
+  it("recentGames 未指定なら空配列", () => {
+    const { dump } = writeAndRead();
+    expect(dump.recentGames).toEqual([]);
+  });
+
+  it("recentGames はそのまま保存される（replay-history の入力）", () => {
+    const recentGames = [
+      {
+        gameIdx: 1,
+        jushuName: "寒星",
+        isABlack: true,
+        gameSeed: 111,
+        moves: [
+          { row: 7, col: 7, isOpening: true },
+          { row: 6, col: 8, isOpening: true },
+          { row: 9, col: 7, isOpening: true },
+          { row: 6, col: 6, isOpening: false },
+        ],
+      },
+    ];
+    const { dump } = writeAndRead({ recentGames });
+    expect(dump.recentGames).toEqual(recentGames);
+  });
+
+  it("wasm live stats が取れない理由を notes に残す", () => {
+    const { dump } = writeAndRead();
+    expect(dump.notes?.length).toBeGreaterThan(0);
+    expect(dump.notes?.[0]).toContain("wasm");
+  });
+
+  it("盤面・着手履歴・ハング情報を保持する", () => {
+    const { dump } = writeAndRead();
+    expect(dump.type).toBe("hang-dump");
+    expect(dump.board).toHaveLength(15);
+    expect(dump.moveHistory).toHaveLength(3);
+    expect(dump.hang.moveNumber).toBe(4);
+    expect(dump.match.gameSeed).toBe(319205941);
+    expect(dump.bench.baseSeed).toBe(20260825);
+  });
+});

--- a/scripts/lib/hangDump.test.ts
+++ b/scripts/lib/hangDump.test.ts
@@ -10,9 +10,11 @@ import {
   HANG_DUMP_SCHEMA_VERSION,
   type HangDumpBench,
   type HangDumpJson,
+  type HangDumpJsonV1,
+  type HangDumpJsonV2,
   type HangDumpMatch,
   type HangDumpSideConfig,
-  hangSideColor,
+  isHangDumpV2,
   writeHangDump,
 } from "./hangDump.ts";
 
@@ -53,8 +55,8 @@ const context = (): HangContext => ({
       worktreePath: "/tmp/A-480f4f4",
       difficulty: "hard",
       depth: 12,
-      timeLimit: 5000,
-      maxNodes: 3000000,
+      timeLimit: 10000,
+      maxNodes: 1000000,
       randomFactor: 0.02,
       evaluationOptions: { evalBasis: "prospect" },
       engine: "wasm",
@@ -79,11 +81,44 @@ const context = (): HangContext => ({
         color: "white",
         depth: 6,
         score: 40,
-        thinkingTimeMs: 4900,
-        roundTripMs: 4950,
+        interrupted: true,
+        thinkingTimeMs: 29600,
+        roundTripMs: 29650,
         stats: { nodes: 987654 },
       },
     ],
+    recentGames: [
+      {
+        gameIdx: 1,
+        jushuName: "寒星",
+        isABlack: true,
+        gameSeed: 111,
+        moves: [
+          { row: 7, col: 7, isOpening: true },
+          { row: 6, col: 8, isOpening: true },
+          { row: 9, col: 7, isOpening: true },
+          { row: 6, col: 6, isOpening: false },
+        ],
+      },
+    ],
+  },
+  liveness: {
+    timeCheckCount: 918273,
+    lastTimeCheckAt: "2026-08-23T00:00:29.000Z",
+    msSinceLastTimeCheck: 12,
+    requestId: 265,
+    timeCheckDeltaDuringSample: 4211,
+    sampleWindowMs: 250,
+    verdict: "searching",
+  },
+  mainThread: {
+    running: true,
+    intervalMs: 1000,
+    samples: [
+      { at: "2026-08-23T00:00:00.000Z", timerLagMs: 3, clockSkewMs: 0 },
+    ],
+    maxTimerLagMs: 3,
+    maxClockSkewJumpMs: 0,
   },
 });
 
@@ -118,36 +153,33 @@ const sideConfig = (label: string): HangDumpSideConfig => ({
 
 const workerConfigs = { A: sideConfig("aaaaaaa"), B: sideConfig("bbbbbbb") };
 
-function writeAndRead(
-  overrides: Partial<Parameters<typeof writeHangDump>[0]> = {},
-): { outPath: string; dump: HangDumpJson } {
+function writeAndRead(ctx: HangContext = context()): {
+  outPath: string;
+  dump: HangDumpJsonV2;
+} {
   const outputDir = path.join(makeTmpDir(), "hang-dumps");
   const outPath = writeHangDump({
     outputDir,
-    context: context(),
+    context: ctx,
     match,
     bench,
     workerConfigs,
-    ...overrides,
   });
   return {
     outPath,
-    dump: JSON.parse(fs.readFileSync(outPath, "utf-8")) as HangDumpJson,
+    dump: JSON.parse(fs.readFileSync(outPath, "utf-8")) as HangDumpJsonV2,
   };
 }
 
-describe("hangSideColor", () => {
-  it("A側は isABlack のとき黒", () => {
-    expect(hangSideColor("A", true)).toBe("black");
+describe("isHangDumpV2", () => {
+  it("v2 なら true", () => {
+    const { dump } = writeAndRead();
+    expect(isHangDumpV2(dump)).toBe(true);
   });
-  it("A側は isABlack が false なら白", () => {
-    expect(hangSideColor("A", false)).toBe("white");
-  });
-  it("B側は isABlack のとき白", () => {
-    expect(hangSideColor("B", true)).toBe("white");
-  });
-  it("B側は isABlack が false なら黒", () => {
-    expect(hangSideColor("B", false)).toBe("black");
+
+  it("v1 ダンプ（ディスクに残る実データ）は false", () => {
+    const v1 = { schemaVersion: 1 } as HangDumpJsonV1 as HangDumpJson;
+    expect(isHangDumpV2(v1)).toBe(false);
   });
 });
 
@@ -158,7 +190,7 @@ describe("writeHangDump", () => {
     expect(path.basename(outPath)).toMatch(/^hang-.+-g3\.json$/);
   });
 
-  it("schemaVersion は 2（#128 で telemetry/recentGames を追加）", () => {
+  it("schemaVersion は 2（#128 で telemetry/liveness/recentGames を追加）", () => {
     const { dump } = writeAndRead();
     expect(dump.schemaVersion).toBe(HANG_DUMP_SCHEMA_VERSION);
     expect(dump.schemaVersion).toBe(2);
@@ -168,10 +200,39 @@ describe("writeHangDump", () => {
     const { dump } = writeAndRead();
     expect(dump.worker.side).toBe("A");
     expect(dump.worker.commit.shortSha).toBe("aaaaaaa");
-    expect(dump.worker.telemetry?.requestCount).toBe(42);
-    expect(dump.worker.telemetry?.engineParams?.maxNodes).toBe(3000000);
-    expect(dump.worker.telemetry?.pendingRequest?.moveSeed).toBe(12345);
-    expect(dump.worker.telemetry?.recentMoves[0]?.stats?.nodes).toBe(987654);
+    expect(dump.worker.telemetry.requestCount).toBe(42);
+    expect(dump.worker.telemetry.engineParams?.maxNodes).toBe(1000000);
+    expect(dump.worker.telemetry.pendingRequest?.moveSeed).toBe(12345);
+    expect(dump.worker.telemetry.recentMoves[0]?.stats?.nodes).toBe(987654);
+  });
+
+  it("interrupted を保持する（長考が打ち切られたかの判別）", () => {
+    const { dump } = writeAndRead();
+    expect(dump.worker.telemetry.recentMoves[0]?.interrupted).toBe(true);
+  });
+
+  it("生存信号（liveness）を載せる", () => {
+    const { dump } = writeAndRead();
+    expect(dump.hang.liveness.verdict).toBe("searching");
+    expect(dump.hang.liveness.timeCheckDeltaDuringSample).toBe(4211);
+  });
+
+  it("メインスレッドのイベントループ状態を載せる", () => {
+    const { dump } = writeAndRead();
+    expect(dump.hang.mainThread.running).toBe(true);
+    expect(dump.hang.mainThread.maxTimerLagMs).toBe(3);
+  });
+
+  it("recentGames は telemetry から取る（SSoT）", () => {
+    const { dump } = writeAndRead();
+    expect(dump.recentGames).toEqual(context().telemetry.recentGames);
+  });
+
+  it("telemetry に直近局が無ければ空配列", () => {
+    const ctx = context();
+    ctx.telemetry.recentGames = [];
+    const { dump } = writeAndRead(ctx);
+    expect(dump.recentGames).toEqual([]);
   });
 
   it("相手側は opponent に入る", () => {
@@ -180,34 +241,10 @@ describe("writeHangDump", () => {
     expect(dump.opponent.commit.shortSha).toBe("bbbbbbb");
   });
 
-  it("recentGames 未指定なら空配列", () => {
+  it("何が取れて何が取れないかを notes に残す", () => {
     const { dump } = writeAndRead();
-    expect(dump.recentGames).toEqual([]);
-  });
-
-  it("recentGames はそのまま保存される（replay-history の入力）", () => {
-    const recentGames = [
-      {
-        gameIdx: 1,
-        jushuName: "寒星",
-        isABlack: true,
-        gameSeed: 111,
-        moves: [
-          { row: 7, col: 7, isOpening: true },
-          { row: 6, col: 8, isOpening: true },
-          { row: 9, col: 7, isOpening: true },
-          { row: 6, col: 6, isOpening: false },
-        ],
-      },
-    ];
-    const { dump } = writeAndRead({ recentGames });
-    expect(dump.recentGames).toEqual(recentGames);
-  });
-
-  it("wasm live stats が取れない理由を notes に残す", () => {
-    const { dump } = writeAndRead();
-    expect(dump.notes?.length).toBeGreaterThan(0);
-    expect(dump.notes?.[0]).toContain("wasm");
+    expect(dump.notes.length).toBeGreaterThan(0);
+    expect(dump.notes.join("\n")).toContain("liveness");
   });
 
   it("盤面・着手履歴・ハング情報を保持する", () => {

--- a/scripts/lib/hangDump.ts
+++ b/scripts/lib/hangDump.ts
@@ -6,8 +6,9 @@
  * BoardState 等）。両者ともこのファイルから型と writeHangDump をインポートする。
  *
  * ダンプは commit-bench の bench-results/hang-dumps/hang-*.json に保存され、
- * 後日 replay-hang スクリプトで局面再現に使う。schemaVersion 変更時は
- * replay-hang.ts の後方互換ロジックを同時に更新すること。
+ * 後日 replay-hang スクリプトで局面再現に使う。ディスク上には旧版（v1）の
+ * ダンプも残るため、型は schemaVersion による discriminated union にしてある。
+ * schemaVersion を上げるときは replay-hang.ts の後方互換ロジックも同時に更新すること。
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -16,7 +17,35 @@ import type { EvaluationOptions } from "../../src/logic/cpu/evaluation/patternSc
 import type { BoardState } from "../../src/types/game.ts";
 import type { HangContext, MoveRecord } from "../commit-game-runner.ts";
 import type { CommitInfo } from "../types/commit-bench.ts";
-import type { WorkerTelemetrySnapshot } from "./workerTelemetry.ts";
+import type { EventLoopSnapshot } from "./eventLoopSampler.ts";
+import type { HangLiveness } from "./workerLiveness.ts";
+import type {
+  RecentGameRecord,
+  WorkerTelemetrySnapshot,
+} from "./workerTelemetry.ts";
+
+/**
+ * ダンプの現行スキーマ版。
+ * - v1: PR #109 初版
+ * - v2: #128 で worker.telemetry / recentGames / hang.liveness / hang.mainThread / notes を追加
+ */
+export const HANG_DUMP_SCHEMA_VERSION = 2;
+
+/**
+ * 「ハング中の worker から何が取れて何が取れないか」をダンプ自身に残す。
+ * 調査者が毎回同じ問いを立て直さなくて済むようにする。
+ */
+export const HANG_DUMP_NOTES = [
+  "worker はハング中もメッセージに応答できない（wasm 探索でスレッドが同期ブロックされ event loop が回らない）ため、" +
+    "getStatsBuffer 等の『現在の探索統計』を問い合わせることはできない。" +
+    "worker.telemetry.recentMoves（直前 N 手の nodes/depth/interrupted/time）で代替している。",
+  "hang.liveness は SharedArrayBuffer 経由の生存信号。wasm は時間制限判定のたびに JS の " +
+    "getTimestampMsExternal を呼び返すので、その呼び出し回数が進んでいれば『探索が走り続けている』、" +
+    "止まっていれば『探索ループの外で固まっている』と切り分けられる（Zig 側は無改造）。",
+  "hang.mainThread はメインスレッド自身のイベントループ遅延・時計ずれ。" +
+    "timer lag が小さいのに elapsedMs だけが巨大なら、worker の探索ではなく " +
+    "プロセス/マシンのサスペンドを疑う。",
+];
 
 /** ダンプに含める側（A/B）ごとの worker 設定 */
 export interface HangDumpSideConfig {
@@ -56,8 +85,8 @@ export interface HangDumpMatch {
   gameSeed?: number;
 }
 
-/** ハング時の状態スナップショット */
-export interface HangDumpHang {
+/** ハング時の状態スナップショット（v1 共通部） */
+export interface HangDumpHangBase {
   /** ハングした側（A/B）— この情報だけで worker 側の worktree/config を引ける */
   side: "A" | "B";
   color: "black" | "white";
@@ -68,8 +97,19 @@ export interface HangDumpHang {
   moveNumber: number;
 }
 
+/** v2 のハング情報（生存信号とメインスレッド健康状態を追加） */
+export interface HangDumpHangV2 extends HangDumpHangBase {
+  /** 共有メモリ経由の worker 生存信号（#128） */
+  liveness: HangLiveness;
+  /**
+   * メインスレッドのイベントループ遅延・時計ずれ。
+   * 「worker がハングした」のか「メインスレッドが止まっていた」のかを切り分ける。
+   */
+  mainThread: EventLoopSnapshot;
+}
+
 /** ハングした側の worker 設定（replay 用の完全情報） */
-export interface HangDumpWorker {
+export interface HangDumpWorkerBase {
   side: "A" | "B";
   worktreePath: string;
   commit: CommitInfo;
@@ -78,32 +118,16 @@ export interface HangDumpWorker {
   evaluationOptions: Partial<EvaluationOptions> | undefined;
   bookEnabled: boolean;
   color: "black" | "white";
-  /**
-   * #128: メインスレッドが保持していた worker 計測のスナップショット。
-   * 起動時の解決済みパラメータ（difficulty/depth/timeLimit/maxNodes/evalOptions/
-   * engine/threatProbe）、起動からの要求数、ハングした要求（seed 含む）、
-   * 直近 N 手の思考統計（nodes/depth/time）を含む。
-   *
-   * schemaVersion>=2 で必ず書かれる。v1 ダンプを読むと undefined（後方互換）。
-   */
-  telemetry?: WorkerTelemetrySnapshot;
 }
 
-/**
- * #128: ハングした worker が **同一インスタンスで直前に打った局**の記録。
- * TT/wasm メモリ等の蓄積状態を再現するため、replay-hang が
- * `--replay-history` でこれらを同じ順に再生してから該当手を要求する。
- *
- * 着手は座標のみに切り詰める（時間/統計はダンプ肥大化を招くうえ再生に不要）。
- */
-export interface HangDumpRecentGame {
-  gameIdx: number;
-  jushuName: string;
-  isABlack: boolean;
-  /** この局の PRNG seed（未指定 bench なら undefined） */
-  gameSeed?: number;
-  /** opening 3手を含む全着手（打たれた順） */
-  moves: { row: number; col: number; isOpening: boolean }[];
+/** v2 の worker 情報（メインスレッドが保持していた計測を追加） */
+export interface HangDumpWorkerV2 extends HangDumpWorkerBase {
+  /**
+   * メインスレッドが保持していた worker 計測のスナップショット。
+   * 起動時の解決済みパラメータ・起動からの要求数・ハングした要求（moveSeed 含む）・
+   * 直近 N 手の思考統計・同一 worker が打ち終えた直近 M 局を含む。
+   */
+  telemetry: WorkerTelemetrySnapshot;
 }
 
 /** 相手側の worker 設定（対戦再構築が必要な将来のため） */
@@ -115,47 +139,47 @@ export interface HangDumpOpponent {
   bookEnabled: boolean;
 }
 
-/**
- * ダンプの現行スキーマ版。
- * - v1: PR #109 初版
- * - v2: #128 で worker.telemetry / recentGames / notes を追加
- */
-export const HANG_DUMP_SCHEMA_VERSION = 2;
-
-/**
- * wasm 側の「探索中の統計」を同期取得できない理由をダンプ自身に残す。
- * 調査者が「なぜ nodes の実測が無いのか」を毎回問い直さなくて済むようにする。
- */
-export const WASM_LIVE_STATS_NOTE =
-  "ハング中の worker は wasm 探索でスレッドが同期ブロックされており、" +
-  "postMessage を送っても event loop が回らないため『現在の探索統計』は取得できない。" +
-  "worker.telemetry.recentMoves（直前 N 手の nodes/depth/time）で代替している。";
-
-/**
- * ダンプ JSON の全体スキーマ。
- * ディスク上には v1 ダンプも残るため、v2 で足したフィールドは optional。
- */
-export interface HangDumpJson {
+/** v1/v2 で共通のフィールド */
+interface HangDumpCommon {
   type: "hang-dump";
-  schemaVersion: number;
   timestamp: string;
   bench: HangDumpBench;
   match: HangDumpMatch;
-  hang: HangDumpHang;
-  worker: HangDumpWorker;
   opponent: HangDumpOpponent;
   /** ハング直前の盤面（そのままリクエストとして送れる形） */
   board: BoardState;
   /** ハング直前までの着手履歴（opening 3手を含む。row/col/isOpening/time…） */
   moveHistory: MoveRecord[];
+}
+
+/** PR #109 初版のダンプ（ディスク上に残っている実データ 2 件がこれ） */
+export interface HangDumpJsonV1 extends HangDumpCommon {
+  schemaVersion: 1;
+  hang: HangDumpHangBase;
+  worker: HangDumpWorkerBase;
+}
+
+/** #128 で拡張したダンプ */
+export interface HangDumpJsonV2 extends HangDumpCommon {
+  schemaVersion: 2;
+  hang: HangDumpHangV2;
+  worker: HangDumpWorkerV2;
   /**
-   * #128 (v2): ハングした worker が同一インスタンスで直前に打ち終えた局
-   * （古→新）。`replay-hang --replay-history` の入力。
-   * v1 ダンプを読むと undefined（後方互換）。
+   * ハングした worker が同一インスタンスで直前に打ち終えた局（古→新）。
+   * `worker.telemetry.recentGames` と同じ内容を、読み手が辿りやすいよう
+   * トップレベルにも置く。`replay-hang --replay-history=N` の入力。
    */
-  recentGames?: HangDumpRecentGame[];
-  /** 人間向けの注記（wasm live stats が取れない理由など）。v2 以降。 */
-  notes?: string[];
+  recentGames: RecentGameRecord[];
+  /** 人間向けの注記（何が取れて何が取れないか） */
+  notes: string[];
+}
+
+/** ダンプ JSON の全体スキーマ（版で分岐する discriminated union） */
+export type HangDumpJson = HangDumpJsonV1 | HangDumpJsonV2;
+
+/** v2 ダンプかを判定する型ガード。 */
+export function isHangDumpV2(dump: HangDumpJson): dump is HangDumpJsonV2 {
+  return dump.schemaVersion === 2;
 }
 
 export interface WriteHangDumpParams {
@@ -164,41 +188,17 @@ export interface WriteHangDumpParams {
   match: HangDumpMatch;
   bench: HangDumpBench;
   workerConfigs: { A: HangDumpSideConfig; B: HangDumpSideConfig };
-  /** #128: ハングした worker が直前に打ち終えた局（古→新）。無ければ空配列。 */
-  recentGames?: HangDumpRecentGame[];
-}
-
-/**
- * 側（A/B）と先後割当から、その側が担当した石色を求める。
- * recentGames の再生で「ハングした worker がどの手番を打っていたか」を
- * 局ごとに復元するのに使う純粋関数。
- */
-export function hangSideColor(
-  side: "A" | "B",
-  isABlack: boolean,
-): "black" | "white" {
-  if (side === "A") {
-    return isABlack ? "black" : "white";
-  }
-  return isABlack ? "white" : "black";
 }
 
 /** 呼び出し側は match/bench の中身を組み立てて渡す。書き込んだ絶対パスを返す。 */
 export function writeHangDump(params: WriteHangDumpParams): string {
-  const {
-    outputDir,
-    context,
-    match,
-    bench,
-    workerConfigs,
-    recentGames = [],
-  } = params;
+  const { outputDir, context, match, bench, workerConfigs } = params;
   const hangSide = context.side;
   const oppSide: "A" | "B" = hangSide === "A" ? "B" : "A";
   const hangCfg = workerConfigs[hangSide];
   const oppCfg = workerConfigs[oppSide];
 
-  const dump: HangDumpJson = {
+  const dump: HangDumpJsonV2 = {
     type: "hang-dump",
     schemaVersion: HANG_DUMP_SCHEMA_VERSION,
     timestamp: new Date().toISOString(),
@@ -211,6 +211,8 @@ export function writeHangDump(params: WriteHangDumpParams): string {
       timeoutMs: context.timeoutMs,
       elapsedMs: context.elapsedMs,
       moveNumber: context.moveNumber,
+      liveness: context.liveness,
+      mainThread: context.mainThread,
     },
     worker: {
       side: hangSide,
@@ -232,8 +234,8 @@ export function writeHangDump(params: WriteHangDumpParams): string {
     },
     board: context.board,
     moveHistory: context.moveHistory,
-    recentGames,
-    notes: [WASM_LIVE_STATS_NOTE],
+    recentGames: context.telemetry.recentGames,
+    notes: HANG_DUMP_NOTES,
   };
 
   if (!fs.existsSync(outputDir)) {

--- a/scripts/lib/hangDump.ts
+++ b/scripts/lib/hangDump.ts
@@ -16,6 +16,7 @@ import type { EvaluationOptions } from "../../src/logic/cpu/evaluation/patternSc
 import type { BoardState } from "../../src/types/game.ts";
 import type { HangContext, MoveRecord } from "../commit-game-runner.ts";
 import type { CommitInfo } from "../types/commit-bench.ts";
+import type { WorkerTelemetrySnapshot } from "./workerTelemetry.ts";
 
 /** ダンプに含める側（A/B）ごとの worker 設定 */
 export interface HangDumpSideConfig {
@@ -77,6 +78,32 @@ export interface HangDumpWorker {
   evaluationOptions: Partial<EvaluationOptions> | undefined;
   bookEnabled: boolean;
   color: "black" | "white";
+  /**
+   * #128: メインスレッドが保持していた worker 計測のスナップショット。
+   * 起動時の解決済みパラメータ（difficulty/depth/timeLimit/maxNodes/evalOptions/
+   * engine/threatProbe）、起動からの要求数、ハングした要求（seed 含む）、
+   * 直近 N 手の思考統計（nodes/depth/time）を含む。
+   *
+   * schemaVersion>=2 で必ず書かれる。v1 ダンプを読むと undefined（後方互換）。
+   */
+  telemetry?: WorkerTelemetrySnapshot;
+}
+
+/**
+ * #128: ハングした worker が **同一インスタンスで直前に打った局**の記録。
+ * TT/wasm メモリ等の蓄積状態を再現するため、replay-hang が
+ * `--replay-history` でこれらを同じ順に再生してから該当手を要求する。
+ *
+ * 着手は座標のみに切り詰める（時間/統計はダンプ肥大化を招くうえ再生に不要）。
+ */
+export interface HangDumpRecentGame {
+  gameIdx: number;
+  jushuName: string;
+  isABlack: boolean;
+  /** この局の PRNG seed（未指定 bench なら undefined） */
+  gameSeed?: number;
+  /** opening 3手を含む全着手（打たれた順） */
+  moves: { row: number; col: number; isOpening: boolean }[];
 }
 
 /** 相手側の worker 設定（対戦再構築が必要な将来のため） */
@@ -88,10 +115,29 @@ export interface HangDumpOpponent {
   bookEnabled: boolean;
 }
 
-/** ダンプ JSON の全体スキーマ */
+/**
+ * ダンプの現行スキーマ版。
+ * - v1: PR #109 初版
+ * - v2: #128 で worker.telemetry / recentGames / notes を追加
+ */
+export const HANG_DUMP_SCHEMA_VERSION = 2;
+
+/**
+ * wasm 側の「探索中の統計」を同期取得できない理由をダンプ自身に残す。
+ * 調査者が「なぜ nodes の実測が無いのか」を毎回問い直さなくて済むようにする。
+ */
+export const WASM_LIVE_STATS_NOTE =
+  "ハング中の worker は wasm 探索でスレッドが同期ブロックされており、" +
+  "postMessage を送っても event loop が回らないため『現在の探索統計』は取得できない。" +
+  "worker.telemetry.recentMoves（直前 N 手の nodes/depth/time）で代替している。";
+
+/**
+ * ダンプ JSON の全体スキーマ。
+ * ディスク上には v1 ダンプも残るため、v2 で足したフィールドは optional。
+ */
 export interface HangDumpJson {
   type: "hang-dump";
-  schemaVersion: 1;
+  schemaVersion: number;
   timestamp: string;
   bench: HangDumpBench;
   match: HangDumpMatch;
@@ -102,6 +148,14 @@ export interface HangDumpJson {
   board: BoardState;
   /** ハング直前までの着手履歴（opening 3手を含む。row/col/isOpening/time…） */
   moveHistory: MoveRecord[];
+  /**
+   * #128 (v2): ハングした worker が同一インスタンスで直前に打ち終えた局
+   * （古→新）。`replay-hang --replay-history` の入力。
+   * v1 ダンプを読むと undefined（後方互換）。
+   */
+  recentGames?: HangDumpRecentGame[];
+  /** 人間向けの注記（wasm live stats が取れない理由など）。v2 以降。 */
+  notes?: string[];
 }
 
 export interface WriteHangDumpParams {
@@ -110,11 +164,35 @@ export interface WriteHangDumpParams {
   match: HangDumpMatch;
   bench: HangDumpBench;
   workerConfigs: { A: HangDumpSideConfig; B: HangDumpSideConfig };
+  /** #128: ハングした worker が直前に打ち終えた局（古→新）。無ければ空配列。 */
+  recentGames?: HangDumpRecentGame[];
+}
+
+/**
+ * 側（A/B）と先後割当から、その側が担当した石色を求める。
+ * recentGames の再生で「ハングした worker がどの手番を打っていたか」を
+ * 局ごとに復元するのに使う純粋関数。
+ */
+export function hangSideColor(
+  side: "A" | "B",
+  isABlack: boolean,
+): "black" | "white" {
+  if (side === "A") {
+    return isABlack ? "black" : "white";
+  }
+  return isABlack ? "white" : "black";
 }
 
 /** 呼び出し側は match/bench の中身を組み立てて渡す。書き込んだ絶対パスを返す。 */
 export function writeHangDump(params: WriteHangDumpParams): string {
-  const { outputDir, context, match, bench, workerConfigs } = params;
+  const {
+    outputDir,
+    context,
+    match,
+    bench,
+    workerConfigs,
+    recentGames = [],
+  } = params;
   const hangSide = context.side;
   const oppSide: "A" | "B" = hangSide === "A" ? "B" : "A";
   const hangCfg = workerConfigs[hangSide];
@@ -122,7 +200,7 @@ export function writeHangDump(params: WriteHangDumpParams): string {
 
   const dump: HangDumpJson = {
     type: "hang-dump",
-    schemaVersion: 1,
+    schemaVersion: HANG_DUMP_SCHEMA_VERSION,
     timestamp: new Date().toISOString(),
     bench,
     match,
@@ -143,6 +221,7 @@ export function writeHangDump(params: WriteHangDumpParams): string {
       evaluationOptions: hangCfg.evaluationOptions,
       bookEnabled: hangCfg.bookEnabled,
       color: context.color,
+      telemetry: context.telemetry,
     },
     opponent: {
       side: oppSide,
@@ -153,6 +232,8 @@ export function writeHangDump(params: WriteHangDumpParams): string {
     },
     board: context.board,
     moveHistory: context.moveHistory,
+    recentGames,
+    notes: [WASM_LIVE_STATS_NOTE],
   };
 
   if (!fs.existsSync(outputDir)) {

--- a/scripts/lib/hangReplay.test.ts
+++ b/scripts/lib/hangReplay.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ReplayMove,
+  colorOfMoveIndex,
+  deriveGameSeed,
+  deriveMoveSeed,
+  nonOpeningOrdinalOf,
+  planGameReplay,
+  sideColor,
+} from "./hangReplay.ts";
+import { mixSeed } from "./mulberry32.ts";
+
+/** 開局3手 + 非オープニング手 n 手の棋譜を作る */
+function makeMoves(nonOpeningCount: number): ReplayMove[] {
+  const moves: ReplayMove[] = [
+    { row: 7, col: 7, isOpening: true },
+    { row: 6, col: 8, isOpening: true },
+    { row: 9, col: 7, isOpening: true },
+  ];
+  for (let i = 0; i < nonOpeningCount; i++) {
+    moves.push({ row: i, col: i, isOpening: false });
+  }
+  return moves;
+}
+
+describe("colorOfMoveIndex", () => {
+  it("開局手を含め黒→白→黒…と交互", () => {
+    expect(colorOfMoveIndex(0)).toBe("black");
+    expect(colorOfMoveIndex(1)).toBe("white");
+    expect(colorOfMoveIndex(2)).toBe("black");
+    expect(colorOfMoveIndex(3)).toBe("white");
+  });
+});
+
+describe("sideColor", () => {
+  it("A側は isABlack のとき黒", () => {
+    expect(sideColor("A", true)).toBe("black");
+  });
+  it("A側は isABlack が false なら白", () => {
+    expect(sideColor("A", false)).toBe("white");
+  });
+  it("B側は isABlack のとき白", () => {
+    expect(sideColor("B", true)).toBe("white");
+  });
+  it("B側は isABlack が false なら黒", () => {
+    expect(sideColor("B", false)).toBe("black");
+  });
+});
+
+describe("seed 導出", () => {
+  it("baseSeed 未指定なら gameSeed も未指定", () => {
+    expect(deriveGameSeed(undefined, 3)).toBeUndefined();
+  });
+
+  it("gameSeed は mixSeed(baseSeed, gameIdx)", () => {
+    expect(deriveGameSeed(12345, 3)).toBe(mixSeed(12345, 3));
+  });
+
+  it("gameSeed 未指定なら moveSeed も未指定", () => {
+    expect(deriveMoveSeed(undefined, 1)).toBeUndefined();
+  });
+
+  it("moveSeed は mixSeed(gameSeed, nonOpeningOrdinal)", () => {
+    expect(deriveMoveSeed(999, 4)).toBe(mixSeed(999, 4));
+  });
+
+  it("局が違えば seed も違う（局間で棋譜が同一にならない）", () => {
+    expect(deriveGameSeed(1, 0)).not.toBe(deriveGameSeed(1, 1));
+  });
+});
+
+describe("planGameReplay", () => {
+  it("ハング側の非オープニング手だけを要求する（A黒なら偶数 index）", () => {
+    const plan = planGameReplay({
+      moves: makeMoves(4),
+      side: "A",
+      isABlack: true,
+    });
+    expect(plan.color).toBe("black");
+    // index 0,2 は開局手（黒）なので除外。黒の非オープニングは index 4, 6
+    expect(plan.requests.map((r) => r.moveIndex)).toEqual([4, 6]);
+  });
+
+  it("A白なら白番だけを要求する", () => {
+    const plan = planGameReplay({
+      moves: makeMoves(4),
+      side: "A",
+      isABlack: false,
+    });
+    expect(plan.color).toBe("white");
+    expect(plan.requests.map((r) => r.moveIndex)).toEqual([3, 5]);
+  });
+
+  it("nonOpeningOrdinal は相手の手も含めて通し番号（bench と同じ規則）", () => {
+    const plan = planGameReplay({
+      moves: makeMoves(4),
+      side: "A",
+      isABlack: false,
+    });
+    // index 3 が 1 手目、index 5 が 3 手目の非オープニング要求
+    expect(plan.requests.map((r) => r.nonOpeningOrdinal)).toEqual([1, 3]);
+  });
+
+  it("moveSeed は gameSeed と nonOpeningOrdinal から導出される", () => {
+    const plan = planGameReplay({
+      moves: makeMoves(4),
+      side: "A",
+      isABlack: false,
+      gameSeed: 777,
+    });
+    expect(plan.requests[0]?.moveSeed).toBe(mixSeed(777, 1));
+    expect(plan.requests[1]?.moveSeed).toBe(mixSeed(777, 3));
+  });
+
+  it("gameSeed 未指定なら moveSeed も未指定", () => {
+    const plan = planGameReplay({
+      moves: makeMoves(2),
+      side: "B",
+      isABlack: true,
+    });
+    expect(plan.requests.every((r) => r.moveSeed === undefined)).toBe(true);
+  });
+
+  it("開局手しかなければ要求は 0 件", () => {
+    const plan = planGameReplay({
+      moves: makeMoves(0),
+      side: "A",
+      isABlack: true,
+    });
+    expect(plan.requests).toEqual([]);
+  });
+
+  it("moveNumber は 1-based", () => {
+    const plan = planGameReplay({
+      moves: makeMoves(2),
+      side: "A",
+      isABlack: false,
+    });
+    expect(plan.requests[0]?.moveNumber).toBe(4);
+  });
+});
+
+describe("nonOpeningOrdinalOf", () => {
+  it("開局3手のあと 4 手目は 1 番目の非オープニング要求", () => {
+    expect(nonOpeningOrdinalOf(makeMoves(4), 4)).toBe(1);
+  });
+
+  it("6 手目は 3 番目", () => {
+    expect(nonOpeningOrdinalOf(makeMoves(4), 6)).toBe(3);
+  });
+
+  it("記録された手数 + 1（次に打つ手）でも数えられる", () => {
+    const moves = makeMoves(2); // 5手ぶん
+    expect(nonOpeningOrdinalOf(moves, moves.length + 1)).toBe(3);
+  });
+});

--- a/scripts/lib/hangReplay.ts
+++ b/scripts/lib/hangReplay.ts
@@ -1,0 +1,138 @@
+/**
+ * ハング再現の共通ロジック（#128）。
+ *
+ * 「何手目を誰が打つか」「その手の PRNG seed は何か」は commit-bench の対局ループと
+ * replay-hang の再生で**必ず一致していなければならない**。ずれると replay は黙って
+ * 別の seed・別の手番で探索し、「再現せず」という誤った結論になる。
+ * そのため導出規則はこのモジュールに一本化し、両者がここを呼ぶ。
+ */
+import { mixSeed } from "./mulberry32.ts";
+
+/** 再生に必要な最小限の着手情報（座標＋開局手フラグ） */
+export interface ReplayMove {
+  row: number;
+  col: number;
+  isOpening: boolean;
+}
+
+/**
+ * 手番の色。連珠は黒先で、開局手 3 手（黒白黒）を含めて必ず交互に進むため、
+ * 着手インデックス（0-based）の偶奇だけで決まる。
+ */
+export function colorOfMoveIndex(index: number): "black" | "white" {
+  return index % 2 === 0 ? "black" : "white";
+}
+
+/**
+ * 側（A/B）と先後割当から、その側が担当した石色を求める。
+ */
+export function sideColor(
+  side: "A" | "B",
+  isABlack: boolean,
+): "black" | "white" {
+  if (side === "A") {
+    return isABlack ? "black" : "white";
+  }
+  return isABlack ? "white" : "black";
+}
+
+/**
+ * baseSeed（--seed）と局 index から、その局の gameSeed を導出する。
+ * commit-bench の getGameSeed と同一である必要がある。
+ */
+export function deriveGameSeed(
+  baseSeed: number | undefined,
+  gameIdx: number,
+): number | undefined {
+  return baseSeed === undefined ? undefined : mixSeed(baseSeed, gameIdx);
+}
+
+/**
+ * gameSeed と非オープニング要求の通し番号（1-based）から moveSeed を導出する。
+ * commit-game-runner の 1 手ごとの導出と同一である必要がある。
+ */
+export function deriveMoveSeed(
+  gameSeed: number | undefined,
+  nonOpeningOrdinal: number,
+): number | undefined {
+  return gameSeed === undefined
+    ? undefined
+    : mixSeed(gameSeed, nonOpeningOrdinal);
+}
+
+/** 再生時に worker へ投げる 1 要求 */
+export interface PlannedRequest {
+  /** moves 配列上のインデックス（この手を打つ「前」の盤面で要求する） */
+  moveIndex: number;
+  /** 1-based の手数（開局手込み） */
+  moveNumber: number;
+  /** 非オープニング要求の通し番号（1-based） */
+  nonOpeningOrdinal: number;
+  color: "black" | "white";
+  moveSeed?: number;
+}
+
+export interface PlanGameReplayParams {
+  moves: ReplayMove[];
+  /** ハングした側（この側の手番だけを worker に要求する） */
+  side: "A" | "B";
+  isABlack: boolean;
+  gameSeed?: number;
+}
+
+export interface GameReplayPlan {
+  /** ハングした側がこの局で持っていた石色 */
+  color: "black" | "white";
+  /** worker に投げるべき要求（moves の順） */
+  requests: PlannedRequest[];
+}
+
+/**
+ * 1 局分の再生計画を立てる純粋関数。
+ *
+ * ハングした側の**非オープニング手だけ**を要求対象にする。相手側の手は棋譜どおりに
+ * 盤へ適用するだけでよく、相手 worker を起動する必要はない。
+ */
+export function planGameReplay(params: PlanGameReplayParams): GameReplayPlan {
+  const { moves, side, isABlack, gameSeed } = params;
+  const color = sideColor(side, isABlack);
+  const requests: PlannedRequest[] = [];
+  let nonOpeningOrdinal = 0;
+  for (const [moveIndex, move] of moves.entries()) {
+    if (move.isOpening) {
+      continue;
+    }
+    nonOpeningOrdinal++;
+    if (colorOfMoveIndex(moveIndex) !== color) {
+      continue;
+    }
+    requests.push({
+      moveIndex,
+      moveNumber: moveIndex + 1,
+      nonOpeningOrdinal,
+      color,
+      moveSeed: deriveMoveSeed(gameSeed, nonOpeningOrdinal),
+    });
+  }
+  return { color, requests };
+}
+
+/**
+ * moves 列のうち非オープニング手の通し番号を、ある手数（1-based）について求める。
+ * ダンプのハング手について moveSeed を再導出するときのフォールバックに使う
+ * （権威は telemetry.pendingRequest.moveSeed）。
+ */
+export function nonOpeningOrdinalOf(
+  moves: ReplayMove[],
+  moveNumber: number,
+): number {
+  let ordinal = 0;
+  for (let i = 0; i < moveNumber && i < moves.length + 1; i++) {
+    const move = moves[i];
+    // moveNumber がちょうど moves.length + 1（次に打つ手）なら最後は未記録手
+    if (move === undefined || !move.isOpening) {
+      ordinal++;
+    }
+  }
+  return ordinal;
+}

--- a/scripts/lib/hangReplayRunner.test.ts
+++ b/scripts/lib/hangReplayRunner.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReplayMove } from "./hangReplay.ts";
+
+import {
+  type ReplayRequestOutcome,
+  type ReplayStage,
+  countPlannedRequests,
+  runReplayStages,
+} from "./hangReplayRunner.ts";
+
+function makeMoves(nonOpeningCount: number): ReplayMove[] {
+  const moves: ReplayMove[] = [
+    { row: 7, col: 7, isOpening: true },
+    { row: 6, col: 8, isOpening: true },
+    { row: 9, col: 7, isOpening: true },
+  ];
+  for (let i = 0; i < nonOpeningCount; i++) {
+    moves.push({ row: i, col: 14 - i, isOpening: false });
+  }
+  return moves;
+}
+
+const stage = (
+  label: string,
+  isABlack: boolean,
+  count: number,
+): ReplayStage => ({
+  label,
+  moves: makeMoves(count),
+  isABlack,
+  gameSeed: 555,
+});
+
+const responded: ReplayRequestOutcome = { status: "responded", elapsedMs: 10 };
+
+describe("countPlannedRequests", () => {
+  it("ステージ横断で要求数を数える", () => {
+    const stages = [stage("g1", true, 4), stage("g2", false, 4)];
+    expect(countPlannedRequests(stages, "A")).toBe(4);
+  });
+
+  it("side が変われば数も変わりうる", () => {
+    // 非オープニング手は index 3(白) 4(黒) 5(白)。A黒なら 1 手、B（白）なら 2 手。
+    const stages = [stage("g1", true, 3)];
+    expect(countPlannedRequests(stages, "A")).toBe(1);
+    expect(countPlannedRequests(stages, "B")).toBe(2);
+  });
+});
+
+describe("runReplayStages", () => {
+  it("ハング側の手番だけを、盤面を進めながら順に要求する", async () => {
+    const seen: { color: string; stones: number }[] = [];
+    const result = await runReplayStages({
+      stages: [stage("g1", true, 4)],
+      side: "A",
+      request: ({ board, color }) => {
+        const stones = board.flat().filter((cell) => cell !== null).length;
+        seen.push({ color, stones });
+        return Promise.resolve(responded);
+      },
+    });
+    expect(result.requestedMoves).toBe(2);
+    expect(result.failure).toBeUndefined();
+    // 黒番の要求は「3(開局)+1」個と「3+3」個の石が置かれた局面
+    expect(seen).toEqual([
+      { color: "black", stones: 4 },
+      { color: "black", stones: 6 },
+    ]);
+  });
+
+  it("moveSeed は計画どおり渡される", async () => {
+    const seeds: (number | undefined)[] = [];
+    await runReplayStages({
+      stages: [stage("g1", false, 4)],
+      side: "A",
+      request: ({ moveSeed }) => {
+        seeds.push(moveSeed);
+        return Promise.resolve(responded);
+      },
+    });
+    expect(seeds).toHaveLength(2);
+    expect(seeds[0]).toBeTypeOf("number");
+    expect(seeds[0]).not.toBe(seeds[1]);
+  });
+
+  it("timed-out が返ったらその場で止めて failure を返す", async () => {
+    let calls = 0;
+    const result = await runReplayStages({
+      stages: [stage("g1", true, 6)],
+      side: "A",
+      request: () => {
+        calls++;
+        return Promise.resolve(
+          calls === 2
+            ? { status: "timed-out" as const, elapsedMs: 30000 }
+            : responded,
+        );
+      },
+    });
+    expect(result.requestedMoves).toBe(2);
+    expect(result.failure?.status).toBe("timed-out");
+    expect(result.failure?.stageLabel).toBe("g1");
+  });
+
+  it("error は timed-out と区別して返す", async () => {
+    const result = await runReplayStages({
+      stages: [stage("g1", true, 2)],
+      side: "A",
+      request: () =>
+        Promise.resolve({
+          status: "error" as const,
+          elapsedMs: 5,
+          errorMessage: "boom",
+        }),
+    });
+    expect(result.failure?.status).toBe("error");
+    expect(result.failure?.errorMessage).toBe("boom");
+  });
+
+  it("複数ステージを順に再生し、局ごとに盤面をリセットする", async () => {
+    const stoneCounts: number[] = [];
+    const result = await runReplayStages({
+      stages: [stage("g1", true, 2), stage("g2", true, 2)],
+      side: "A",
+      request: ({ board }) => {
+        stoneCounts.push(board.flat().filter((c) => c !== null).length);
+        return Promise.resolve(responded);
+      },
+    });
+    expect(result.requestedMoves).toBe(2);
+    // 2局目も 4 石から始まる（前局の石を持ち越さない）
+    expect(stoneCounts).toEqual([4, 4]);
+  });
+
+  it("進捗フックが呼ばれる", async () => {
+    const stageStarts: number[] = [];
+    let doneCalls = 0;
+    await runReplayStages({
+      stages: [stage("g1", true, 4)],
+      side: "A",
+      request: () => Promise.resolve(responded),
+      onStageStart: (_s, planned) => stageStarts.push(planned),
+      onRequestDone: () => {
+        doneCalls++;
+      },
+    });
+    expect(stageStarts).toEqual([2]);
+    expect(doneCalls).toBe(2);
+  });
+});

--- a/scripts/lib/hangReplayRunner.ts
+++ b/scripts/lib/hangReplayRunner.ts
@@ -1,0 +1,156 @@
+/**
+ * ハング再現の実行エンジン（#128）。
+ *
+ * 「計画」は `hangReplay.ts`（純粋関数）、「実行」はここ、「CLI と worker 起動」は
+ * `scripts/replay-hang.ts` という分担。着手要求の送信を関数として受け取るので、
+ * worker を起動せずに単体テストできる。
+ *
+ * 再生の考え方: ハングした側の手番だけを同一 worker に打たせ直し、相手の手は
+ * 棋譜どおり盤に置く。相手側 worker は不要。
+ */
+import type { BoardState } from "../../src/types/game.ts";
+
+import { applyMove } from "../../src/logic/cpu/core/boardUtils.ts";
+import { createEmptyBoard } from "../../src/logic/renjuRules/index.ts";
+import {
+  type PlannedRequest,
+  type ReplayMove,
+  colorOfMoveIndex,
+  planGameReplay,
+} from "./hangReplay.ts";
+
+/** 1 要求の結果（worker の応答種別） */
+export interface ReplayRequestOutcome {
+  status: "responded" | "timed-out" | "error";
+  elapsedMs: number;
+  errorMessage?: string;
+}
+
+/** 着手要求の送信関数（worker 依存部分を注入する） */
+export type ReplayRequestFn = (params: {
+  board: BoardState;
+  color: "black" | "white";
+  moveSeed: number | undefined;
+}) => Promise<ReplayRequestOutcome>;
+
+/** 再生する 1 ステージ（＝1 局分の棋譜） */
+export interface ReplayStage {
+  /** 表示用ラベル（例: "g12 寒星 (A黒)"） */
+  label: string;
+  moves: ReplayMove[];
+  isABlack: boolean;
+  gameSeed?: number;
+}
+
+/** 再生の失敗（ハング再現 or worker エラー） */
+export interface ReplayFailure {
+  stageLabel: string;
+  moveNumber: number;
+  status: "timed-out" | "error";
+  elapsedMs: number;
+  errorMessage?: string;
+}
+
+export interface ReplayStagesResult {
+  /** worker に投げた要求の総数 */
+  requestedMoves: number;
+  /** 途中で止まった場合の情報。最後まで走れば undefined */
+  failure?: ReplayFailure;
+}
+
+export interface RunReplayStagesParams {
+  stages: ReplayStage[];
+  /** ハングした側（この側の手番だけを要求する） */
+  side: "A" | "B";
+  request: ReplayRequestFn;
+  /** 進捗表示のフック（省略可） */
+  onStageStart?: (stage: ReplayStage, plannedRequests: number) => void;
+  onRequestDone?: (
+    stage: ReplayStage,
+    planned: PlannedRequest,
+    outcome: ReplayRequestOutcome,
+    doneCount: number,
+  ) => void;
+}
+
+/**
+ * ステージ列を順に再生する。1 要求でも timed-out / error になったらそこで止める
+ * （その時点が新しい調査対象なので、先へ進めても意味がないため）。
+ */
+export async function runReplayStages(
+  params: RunReplayStagesParams,
+): Promise<ReplayStagesResult> {
+  const { stages, side, request, onStageStart, onRequestDone } = params;
+  let requestedMoves = 0;
+
+  for (const stage of stages) {
+    const plan = planGameReplay({
+      moves: stage.moves,
+      side,
+      isABlack: stage.isABlack,
+      gameSeed: stage.gameSeed,
+    });
+    onStageStart?.(stage, plan.requests.length);
+
+    const requestByMoveIndex = new Map<number, PlannedRequest>();
+    for (const planned of plan.requests) {
+      requestByMoveIndex.set(planned.moveIndex, planned);
+    }
+
+    let board: BoardState = createEmptyBoard();
+    for (const [moveIndex, move] of stage.moves.entries()) {
+      const planned = requestByMoveIndex.get(moveIndex);
+      if (planned) {
+        // 逐次実行が必須: 同一 worker に順番に要求するので並列化できない
+        const outcome = await request({
+          board,
+          color: planned.color,
+          moveSeed: planned.moveSeed,
+        });
+        requestedMoves++;
+        onRequestDone?.(stage, planned, outcome, requestedMoves);
+        if (outcome.status !== "responded") {
+          return {
+            requestedMoves,
+            failure: {
+              stageLabel: stage.label,
+              moveNumber: planned.moveNumber,
+              status: outcome.status,
+              elapsedMs: outcome.elapsedMs,
+              errorMessage: outcome.errorMessage,
+            },
+          };
+        }
+      }
+      // 棋譜どおりに進める（worker が返した手ではない）。
+      // 禁手負けの局では最終手が盤に置かれないまま記録されているが、
+      // その手より後の要求は無いので再生に影響しない。
+      board = applyMove(
+        board,
+        { row: move.row, col: move.col },
+        colorOfMoveIndex(moveIndex),
+      );
+    }
+  }
+  return { requestedMoves };
+}
+
+/**
+ * 再生に必要な要求数を数える（所要時間見積もり用）。
+ */
+export function countPlannedRequests(
+  stages: ReplayStage[],
+  side: "A" | "B",
+): number {
+  return stages.reduce(
+    (sum, stage) =>
+      sum +
+      planGameReplay({
+        moves: stage.moves,
+        side,
+        isABlack: stage.isABlack,
+        gameSeed: stage.gameSeed,
+      }).requests.length,
+    0,
+  );
+}

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -17,7 +17,6 @@ import type { DifficultyParams } from "../../src/types/cpu.ts";
 import type { Position } from "../../src/types/game.ts";
 import type { SPRTConfig, WDLCount } from "../types/ab.ts";
 import type { CommitGameResult } from "../types/commit-bench.ts";
-import type { HangDumpRecentGame } from "./hangDump.ts";
 
 import {
   getAllJushuNames,
@@ -29,15 +28,11 @@ import {
   type HangInjectSpec,
   runCommitGame,
 } from "../commit-game-runner.ts";
+import { isReadyMessage, parseEngineParams } from "./bridgeWorkerProtocol.ts";
 import { estimateEloDiff } from "./eloDiff.ts";
 import { updateSPRT } from "./sprt.ts";
-import { extractEngineParams, getWorkerTelemetry } from "./workerTelemetry.ts";
-
-/**
- * #128: ハングダンプに載せる「同一 worker が直前に打った局」の保持数。
- * TT/wasm メモリ蓄積の再現が目的なので直近数局あれば足り、ダンプ肥大も避ける。
- */
-export const RECENT_GAMES_HISTORY_LIMIT = 3;
+import { createLivenessChannel } from "./workerLiveness.ts";
+import { getWorkerTelemetry } from "./workerTelemetry.ts";
 
 /** 1局分の珠型タスク（開始局面＋先後割当）。 */
 export interface MatchTask {
@@ -52,12 +47,6 @@ export interface HangMatchInfo {
   jushuName: string;
   isABlack: boolean;
   pairIdx: number;
-  /**
-   * #128: この worker ペアが**同一インスタンスのまま**直前に打ち終えた局
-   * （古→新、最大 RECENT_GAMES_HISTORY_LIMIT 件）。worker 再生成でクリアされる。
-   * replay-hang の `--replay-history` がこれを再生して蓄積状態を再現する。
-   */
-  recentGames: HangDumpRecentGame[];
 }
 
 /** runMatch の結果（caller が後処理＝性能統計や保存を行う）。 */
@@ -255,6 +244,8 @@ export function createBridgeWorker(
       maxNodes,
       maxDepth,
     );
+    // #128: ハング中でも読める生存信号を共有メモリで用意する
+    const livenessChannel = createLivenessChannel();
 
     const worker = new Worker(workerPath, {
       workerData: {
@@ -264,6 +255,7 @@ export function createBridgeWorker(
         evalWeights,
         bookEnabled,
         threatProbeEnabled,
+        livenessChannel,
       },
       execArgv: [
         "--experimental-strip-types",
@@ -281,20 +273,17 @@ export function createBridgeWorker(
     }, 60000);
 
     const readyHandler = (msg: unknown): void => {
-      if (
-        typeof msg === "object" &&
-        msg !== null &&
-        "ready" in msg &&
-        (msg as { ready: unknown }).ready === true
-      ) {
+      if (isReadyMessage(msg)) {
         clearTimeout(initTimeout);
         worker.off("message", readyHandler);
         // #128: ready 通知に同梱された解決済みエンジンパラメータを worker 計測へ
         // 記録する。ハング中の worker には問い合わせられないため、ここが唯一の
         // 取得機会。古い bridge worker（params 無し）では undefined のまま進む。
-        const engineParams = extractEngineParams(msg);
+        const telemetry = getWorkerTelemetry(worker);
+        telemetry.setLivenessChannel(livenessChannel);
+        const engineParams = parseEngineParams(msg);
         if (engineParams) {
-          getWorkerTelemetry(worker).setEngineParams(engineParams);
+          telemetry.setEngineParams(engineParams);
         }
         resolve(worker);
       }
@@ -375,10 +364,6 @@ export async function runMatch(
     pairRef: { a: Worker; b: Worker },
   ): Promise<void> => {
     let pair = pairRef;
-    // #128: この worker ペアが同一インスタンスのまま打ち終えた直近局（古→新）。
-    // ハング時のダンプに載せ、replay-hang が蓄積状態を再現できるようにする。
-    // worker を再生成したらリセットする（状態が引き継がれないため）。
-    let recentGames: HangDumpRecentGame[] = [];
     while (!stop) {
       const taskIdx = nextTask;
       nextTask += 1;
@@ -422,7 +407,6 @@ export async function runMatch(
               jushuName,
               isABlack,
               pairIdx,
-              recentGames: [...recentGames],
             });
           } catch (dumpErr: unknown) {
             const dm =
@@ -441,8 +425,6 @@ export async function runMatch(
           pair.b.terminate();
           pair = await recreatePair(pairIdx);
           pairs[pairIdx] = pair;
-          // 新しい worker は TT も wasm メモリも空。直近局の履歴は無効になる。
-          recentGames = [];
           console.warn(
             `↳ worker pair (idx=${pairIdx}) 再生成完了。残り局を継続します。`,
           );
@@ -469,8 +451,9 @@ export async function runMatch(
       games.push(result);
       completedGames++;
 
-      // #128: この worker ペアの直近局リング（座標のみ）を更新する。
-      recentGames.push({
+      // #128: 打ち終えた局を両 worker の計測に記録する（履歴再生の入力）。
+      // worker を再生成すると計測ごと作り直されるので、明示的なリセットは不要。
+      const recentGame = {
         gameIdx: taskIdx,
         jushuName,
         isABlack,
@@ -480,10 +463,9 @@ export async function runMatch(
           col: m.col,
           isOpening: m.isOpening,
         })),
-      });
-      while (recentGames.length > RECENT_GAMES_HISTORY_LIMIT) {
-        recentGames.shift();
-      }
+      };
+      getWorkerTelemetry(pair.a).recordGame(recentGame);
+      getWorkerTelemetry(pair.b).recordGame(recentGame);
 
       // 初回ゲーム後のサニティチェック
       if (completedGames === 1) {

--- a/scripts/lib/match.ts
+++ b/scripts/lib/match.ts
@@ -17,6 +17,7 @@ import type { DifficultyParams } from "../../src/types/cpu.ts";
 import type { Position } from "../../src/types/game.ts";
 import type { SPRTConfig, WDLCount } from "../types/ab.ts";
 import type { CommitGameResult } from "../types/commit-bench.ts";
+import type { HangDumpRecentGame } from "./hangDump.ts";
 
 import {
   getAllJushuNames,
@@ -30,6 +31,13 @@ import {
 } from "../commit-game-runner.ts";
 import { estimateEloDiff } from "./eloDiff.ts";
 import { updateSPRT } from "./sprt.ts";
+import { extractEngineParams, getWorkerTelemetry } from "./workerTelemetry.ts";
+
+/**
+ * #128: ハングダンプに載せる「同一 worker が直前に打った局」の保持数。
+ * TT/wasm メモリ蓄積の再現が目的なので直近数局あれば足り、ダンプ肥大も避ける。
+ */
+export const RECENT_GAMES_HISTORY_LIMIT = 3;
 
 /** 1局分の珠型タスク（開始局面＋先後割当）。 */
 export interface MatchTask {
@@ -44,6 +52,12 @@ export interface HangMatchInfo {
   jushuName: string;
   isABlack: boolean;
   pairIdx: number;
+  /**
+   * #128: この worker ペアが**同一インスタンスのまま**直前に打ち終えた局
+   * （古→新、最大 RECENT_GAMES_HISTORY_LIMIT 件）。worker 再生成でクリアされる。
+   * replay-hang の `--replay-history` がこれを再生して蓄積状態を再現する。
+   */
+  recentGames: HangDumpRecentGame[];
 }
 
 /** runMatch の結果（caller が後処理＝性能統計や保存を行う）。 */
@@ -275,6 +289,13 @@ export function createBridgeWorker(
       ) {
         clearTimeout(initTimeout);
         worker.off("message", readyHandler);
+        // #128: ready 通知に同梱された解決済みエンジンパラメータを worker 計測へ
+        // 記録する。ハング中の worker には問い合わせられないため、ここが唯一の
+        // 取得機会。古い bridge worker（params 無し）では undefined のまま進む。
+        const engineParams = extractEngineParams(msg);
+        if (engineParams) {
+          getWorkerTelemetry(worker).setEngineParams(engineParams);
+        }
         resolve(worker);
       }
     };
@@ -354,6 +375,10 @@ export async function runMatch(
     pairRef: { a: Worker; b: Worker },
   ): Promise<void> => {
     let pair = pairRef;
+    // #128: この worker ペアが同一インスタンスのまま打ち終えた直近局（古→新）。
+    // ハング時のダンプに載せ、replay-hang が蓄積状態を再現できるようにする。
+    // worker を再生成したらリセットする（状態が引き継がれないため）。
+    let recentGames: HangDumpRecentGame[] = [];
     while (!stop) {
       const taskIdx = nextTask;
       nextTask += 1;
@@ -375,6 +400,7 @@ export async function runMatch(
           openingMoves: positions,
           hangInject: injectHere,
           gameSeed,
+          gameIdx: taskIdx,
         });
         result = { ...r, jushuName };
       } catch (err: unknown) {
@@ -396,6 +422,7 @@ export async function runMatch(
               jushuName,
               isABlack,
               pairIdx,
+              recentGames: [...recentGames],
             });
           } catch (dumpErr: unknown) {
             const dm =
@@ -414,6 +441,8 @@ export async function runMatch(
           pair.b.terminate();
           pair = await recreatePair(pairIdx);
           pairs[pairIdx] = pair;
+          // 新しい worker は TT も wasm メモリも空。直近局の履歴は無効になる。
+          recentGames = [];
           console.warn(
             `↳ worker pair (idx=${pairIdx}) 再生成完了。残り局を継続します。`,
           );
@@ -439,6 +468,22 @@ export async function runMatch(
 
       games.push(result);
       completedGames++;
+
+      // #128: この worker ペアの直近局リング（座標のみ）を更新する。
+      recentGames.push({
+        gameIdx: taskIdx,
+        jushuName,
+        isABlack,
+        gameSeed,
+        moves: result.moveHistory.map((m) => ({
+          row: m.row,
+          col: m.col,
+          isOpening: m.isOpening,
+        })),
+      });
+      while (recentGames.length > RECENT_GAMES_HISTORY_LIMIT) {
+        recentGames.shift();
+      }
 
       // 初回ゲーム後のサニティチェック
       if (completedGames === 1) {

--- a/scripts/lib/workerLiveness.test.ts
+++ b/scripts/lib/workerLiveness.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createLivenessChannel,
+  createTimestampProbe,
+  diagnoseLiveness,
+  markLivenessRequest,
+  readLiveness,
+} from "./workerLiveness.ts";
+
+describe("createTimestampProbe", () => {
+  it("チャネル無しでも動き、performance.now() の ms を返す", () => {
+    const probe = createTimestampProbe(undefined, () => 1234.6);
+    expect(probe()).toBe(1235);
+  });
+
+  it("呼ばれるたびに時間チェック回数が増える", () => {
+    const channel = createLivenessChannel();
+    const probe = createTimestampProbe(channel, () => 10);
+    probe();
+    probe();
+    probe();
+    expect(readLiveness(channel).timeCheckCount).toBe(3);
+  });
+
+  it("戻り値は元の実装と同じ（探索挙動を変えない）", () => {
+    const channel = createLivenessChannel();
+    const probe = createTimestampProbe(channel, () => 42.4);
+    expect(probe()).toBe(42);
+  });
+
+  it("直近の時間チェック時刻が記録される", () => {
+    const channel = createLivenessChannel();
+    createTimestampProbe(channel, () => 0)();
+    const { lastCheckMs } = readLiveness(channel);
+    expect(lastCheckMs).toBeGreaterThanOrEqual(0);
+    expect(lastCheckMs).toBeLessThan(60000);
+  });
+});
+
+describe("markLivenessRequest", () => {
+  it("処理中の requestId を刻む", () => {
+    const channel = createLivenessChannel();
+    markLivenessRequest(channel, 265);
+    expect(readLiveness(channel).requestId).toBe(265);
+  });
+
+  it("チャネル無しでも例外にならない", () => {
+    expect(() => markLivenessRequest(undefined, 1)).not.toThrow();
+  });
+});
+
+describe("diagnoseLiveness", () => {
+  it("チャネルが無ければ unavailable", async () => {
+    const result = await diagnoseLiveness(undefined);
+    expect(result.verdict).toBe("unavailable");
+  });
+
+  it("一度も時間チェックが無ければ never-started", async () => {
+    const channel = createLivenessChannel();
+    const result = await diagnoseLiveness(channel, 5);
+    expect(result.verdict).toBe("never-started");
+    expect(result.timeCheckCount).toBe(0);
+  });
+
+  it("サンプル中に進んでいなければ stalled", async () => {
+    const channel = createLivenessChannel();
+    createTimestampProbe(channel, () => 0)();
+    const result = await diagnoseLiveness(channel, 5);
+    expect(result.verdict).toBe("stalled");
+    expect(result.timeCheckDeltaDuringSample).toBe(0);
+    expect(result.lastTimeCheckAt).toBeTypeOf("string");
+  });
+
+  it("サンプル中も進んでいれば searching（探索が走り続けている）", async () => {
+    const channel = createLivenessChannel();
+    const probe = createTimestampProbe(channel, () => 0);
+    probe();
+    const timer = setInterval(probe, 1);
+    const result = await diagnoseLiveness(channel, 30);
+    clearInterval(timer);
+    expect(result.verdict).toBe("searching");
+    expect(result.timeCheckDeltaDuringSample).toBeGreaterThan(0);
+  });
+
+  it("処理中の requestId も返す", async () => {
+    const channel = createLivenessChannel();
+    createTimestampProbe(channel, () => 0)();
+    markLivenessRequest(channel, 77);
+    const result = await diagnoseLiveness(channel, 5);
+    expect(result.requestId).toBe(77);
+  });
+});

--- a/scripts/lib/workerLiveness.ts
+++ b/scripts/lib/workerLiveness.ts
@@ -1,0 +1,172 @@
+/**
+ * ハング中の bridge worker の「生存信号」（#128）。
+ *
+ * ハングした worker はメッセージに応答できないが、**完全に止まっているとは限らない**。
+ * wasm 探索は時間制限を判定するたびに JS の `getTimestampMsExternal` を呼び返す
+ * （zig 側の vcf/vct/quiescence/minimax/search の各所）。したがって、その呼び出しを
+ * `SharedArrayBuffer` + `Atomics` で記録しておけば、メインスレッドは worker に
+ * 問い合わせることなく
+ *
+ *   - 時間チェックが今も進んでいる → **探索が走り続けている**（時間制限が効いていない）
+ *   - 時間チェックが止まっている   → 探索ループの外で固まっている / スレッドが止まった
+ *
+ * を区別できる。Zig 側は無改造（import する関数を JS 側で包むだけ）。
+ *
+ * バッファ表現（Int32Array 4 スロット）:
+ *   [0] 時間チェック呼び出し回数（Atomics.add）
+ *   [1] 直近の時間チェック時刻（epochBase からの経過 ms, Atomics.store）
+ *   [2] 現在処理中の requestId（Atomics.store）
+ *   [3] 予約
+ *
+ * 時刻を epoch そのものではなく `Date.now() - epochBase` で持つのは、Int32 に収める
+ * ため（int32 上限 ≈ 24 日ぶんの ms なのでベンチの実行時間には十分）。epochBase は
+ * バッファ生成時の `Date.now()` で、workerData 経由で worker と共有する。
+ */
+
+export const LIVENESS_SLOT_COUNT = 4;
+
+export const LIVENESS_IDX = {
+  timeCheckCount: 0,
+  lastCheckMs: 1,
+  requestId: 2,
+} as const;
+
+/** worker 起動時に渡す生存信号の共有バッファ一式 */
+export interface LivenessChannel {
+  buffer: SharedArrayBuffer;
+  /** `Date.now() - epochBase` で ms を持つための基準 epoch */
+  epochBase: number;
+}
+
+export function createLivenessChannel(): LivenessChannel {
+  return {
+    buffer: new SharedArrayBuffer(LIVENESS_SLOT_COUNT * 4),
+    epochBase: Date.now(),
+  };
+}
+
+/** ダンプに載せる生存信号の診断結果 */
+export interface HangLiveness {
+  /** worker 起動からの時間チェック回数 */
+  timeCheckCount: number;
+  /** 直近の時間チェック時刻（ISO8601）。一度も呼ばれていなければ undefined */
+  lastTimeCheckAt?: string;
+  /** ハング検出時点から見た経過 ms */
+  msSinceLastTimeCheck?: number;
+  /** worker が最後に受け取った requestId */
+  requestId: number;
+  /** サンプリング間に時間チェックが進んだ回数（0 なら探索ループが回っていない） */
+  timeCheckDeltaDuringSample: number;
+  sampleWindowMs: number;
+  /**
+   * 判定:
+   * - `searching`: 時間チェックが進行中＝wasm 探索が走り続けている（時間制限が効いていない疑い）
+   * - `stalled`: 時間チェックが進んでいない＝探索ループの外で停止している疑い
+   * - `never-started`: 一度も時間チェックが呼ばれていない
+   * - `unavailable`: 生存信号バッファが無い（古い worker / 未配線）
+   */
+  verdict: "searching" | "stalled" | "never-started" | "unavailable";
+}
+
+// ============================================================================
+// worker 側
+// ============================================================================
+
+/**
+ * wasm の `env.getTimestampMsExternal` を包み、呼び出しのたびに生存信号を更新する。
+ * 戻り値は元の実装と同じ「performance.now() の ms」。
+ */
+export function createTimestampProbe(
+  channel: LivenessChannel | undefined,
+  now: () => number = () => performance.now(),
+): () => number {
+  if (!channel) {
+    return () => Math.round(now());
+  }
+  const view = new Int32Array(channel.buffer);
+  const { epochBase } = channel;
+  return () => {
+    const value = Math.round(now());
+    Atomics.add(view, LIVENESS_IDX.timeCheckCount, 1);
+    Atomics.store(view, LIVENESS_IDX.lastCheckMs, Date.now() - epochBase);
+    return value;
+  };
+}
+
+/** worker が着手要求を受け取ったときに、処理中の requestId を記録する。 */
+export function markLivenessRequest(
+  channel: LivenessChannel | undefined,
+  requestId: number,
+): void {
+  if (!channel) {
+    return;
+  }
+  const view = new Int32Array(channel.buffer);
+  Atomics.store(view, LIVENESS_IDX.requestId, requestId);
+}
+
+// ============================================================================
+// メインスレッド側
+// ============================================================================
+
+interface LivenessReading {
+  timeCheckCount: number;
+  lastCheckMs: number;
+  requestId: number;
+}
+
+export function readLiveness(channel: LivenessChannel): LivenessReading {
+  const view = new Int32Array(channel.buffer);
+  return {
+    timeCheckCount: Atomics.load(view, LIVENESS_IDX.timeCheckCount),
+    lastCheckMs: Atomics.load(view, LIVENESS_IDX.lastCheckMs),
+    requestId: Atomics.load(view, LIVENESS_IDX.requestId),
+  };
+}
+
+const DEFAULT_SAMPLE_WINDOW_MS = 250;
+
+/**
+ * 生存信号を 2 回サンプリングして、探索ループが回っているかを判定する。
+ * ハング検出時（GameHangError を作る直前）に呼ぶ。
+ */
+export async function diagnoseLiveness(
+  channel: LivenessChannel | undefined,
+  sampleWindowMs: number = DEFAULT_SAMPLE_WINDOW_MS,
+): Promise<HangLiveness> {
+  if (!channel) {
+    return {
+      timeCheckCount: 0,
+      requestId: 0,
+      timeCheckDeltaDuringSample: 0,
+      sampleWindowMs: 0,
+      verdict: "unavailable",
+    };
+  }
+  const first = readLiveness(channel);
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, sampleWindowMs);
+  });
+  const second = readLiveness(channel);
+  const delta = second.timeCheckCount - first.timeCheckCount;
+
+  if (second.timeCheckCount === 0) {
+    return {
+      timeCheckCount: 0,
+      requestId: second.requestId,
+      timeCheckDeltaDuringSample: 0,
+      sampleWindowMs,
+      verdict: "never-started",
+    };
+  }
+  const lastTimeCheckEpoch = channel.epochBase + second.lastCheckMs;
+  return {
+    timeCheckCount: second.timeCheckCount,
+    lastTimeCheckAt: new Date(lastTimeCheckEpoch).toISOString(),
+    msSinceLastTimeCheck: Date.now() - lastTimeCheckEpoch,
+    requestId: second.requestId,
+    timeCheckDeltaDuringSample: delta,
+    sampleWindowMs,
+    verdict: delta > 0 ? "searching" : "stalled",
+  };
+}

--- a/scripts/lib/workerMoveTimeoutError.ts
+++ b/scripts/lib/workerMoveTimeoutError.ts
@@ -7,17 +7,26 @@
  * 満たすためと、bench 以外の caller（将来の replay 用ハーネス等）から
  * 「単純な timeout として拾って再 raise しない」ケースにも使いたいため。
  */
+import type { WorkerTelemetrySnapshot } from "./workerTelemetry.ts";
+
 export class WorkerMoveTimeoutError extends Error {
   readonly requestId: number;
   readonly timeoutMs: number;
   readonly color: "black" | "white";
   readonly side: "A" | "B";
+  /**
+   * timeout を検知した**その瞬間**の worker 計測。
+   * 上位で worker からレジストリを引き直すと、その間に届いた遅延応答で
+   * pendingRequest が消えている可能性があるため、検知側でスナップショットを取る。
+   */
+  readonly telemetry: WorkerTelemetrySnapshot;
 
   constructor(params: {
     requestId: number;
     timeoutMs: number;
     color: "black" | "white";
     side: "A" | "B";
+    telemetry: WorkerTelemetrySnapshot;
   }) {
     super(
       `Worker move request timed out (requestId=${params.requestId}, side=${params.side}, color=${params.color}, timeoutMs=${params.timeoutMs})`,
@@ -27,5 +36,6 @@ export class WorkerMoveTimeoutError extends Error {
     this.timeoutMs = params.timeoutMs;
     this.color = params.color;
     this.side = params.side;
+    this.telemetry = params.telemetry;
   }
 }

--- a/scripts/lib/workerTelemetry.test.ts
+++ b/scripts/lib/workerTelemetry.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type EngineParamsSnapshot,
+  type MoveStatRecord,
+  RECENT_MOVE_HISTORY_LIMIT,
+  WorkerTelemetry,
+  extractEngineParams,
+  getWorkerTelemetry,
+} from "./workerTelemetry.ts";
+
+const engineParams: EngineParamsSnapshot = {
+  worktreePath: "/tmp/A-abc1234",
+  difficulty: "hard",
+  depth: 12,
+  timeLimit: 5000,
+  maxNodes: 3000000,
+  randomFactor: 0.02,
+  evaluationOptions: { evalBasis: "prospect" },
+  engine: "wasm",
+  bookEnabled: false,
+  hasStatsBuffer: true,
+  threatProbe: "ON(default)",
+};
+
+const makeMove = (requestId: number): MoveStatRecord => ({
+  requestId,
+  gameIdx: 3,
+  moveNumber: requestId,
+  color: "white" as const,
+  depth: 6,
+  score: 120,
+  thinkingTimeMs: 4900,
+  roundTripMs: 4950,
+  stats: { nodes: 123456 },
+});
+
+describe("WorkerTelemetry", () => {
+  it("初期状態は要求 0・直近手なし・pending なし", () => {
+    const t = new WorkerTelemetry();
+    expect(t.snapshot()).toEqual({
+      requestCount: 0,
+      engineParams: undefined,
+      pendingRequest: undefined,
+      recentMoves: [],
+    });
+  });
+
+  it("recordRequest で要求数が増え pending が入る", () => {
+    const t = new WorkerTelemetry();
+    t.recordRequest({
+      requestId: 7,
+      moveNumber: 4,
+      color: "black",
+      nonOpeningOrdinal: 1,
+      moveSeed: 999,
+      sentAt: "2026-08-23T00:00:00.000Z",
+    });
+    const snap = t.snapshot();
+    expect(snap.requestCount).toBe(1);
+    expect(snap.pendingRequest?.requestId).toBe(7);
+    expect(snap.pendingRequest?.moveSeed).toBe(999);
+  });
+
+  it("応答が返ると pending がクリアされ直近手に積まれる", () => {
+    const t = new WorkerTelemetry();
+    t.recordRequest({
+      requestId: 7,
+      moveNumber: 4,
+      color: "white",
+      sentAt: "2026-08-23T00:00:00.000Z",
+    });
+    t.recordResponse(makeMove(7));
+    const snap = t.snapshot();
+    expect(snap.pendingRequest).toBeUndefined();
+    expect(snap.recentMoves).toHaveLength(1);
+    expect(snap.recentMoves[0]?.stats?.nodes).toBe(123456);
+  });
+
+  it("ハング時（応答なし）は pending が残る＝ハングした要求そのもの", () => {
+    const t = new WorkerTelemetry();
+    t.recordRequest({
+      requestId: 1,
+      moveNumber: 1,
+      color: "black",
+      sentAt: "2026-08-23T00:00:00.000Z",
+    });
+    t.recordResponse(makeMove(1));
+    t.recordRequest({
+      requestId: 2,
+      moveNumber: 3,
+      color: "black",
+      sentAt: "2026-08-23T00:00:10.000Z",
+    });
+    const snap = t.snapshot();
+    expect(snap.requestCount).toBe(2);
+    expect(snap.pendingRequest?.requestId).toBe(2);
+    expect(snap.recentMoves).toHaveLength(1);
+  });
+
+  it("直近手は historyLimit 件で古いものから捨てられる", () => {
+    const t = new WorkerTelemetry(3);
+    for (let i = 1; i <= 5; i++) {
+      t.recordResponse(makeMove(i));
+    }
+    const ids = t.snapshot().recentMoves.map((m) => m.requestId);
+    expect(ids).toEqual([3, 4, 5]);
+  });
+
+  it("既定の historyLimit は RECENT_MOVE_HISTORY_LIMIT", () => {
+    const t = new WorkerTelemetry();
+    for (let i = 1; i <= RECENT_MOVE_HISTORY_LIMIT + 4; i++) {
+      t.recordResponse(makeMove(i));
+    }
+    expect(t.snapshot().recentMoves).toHaveLength(RECENT_MOVE_HISTORY_LIMIT);
+  });
+
+  it("snapshot は内部配列のコピーを返す（後続更新の影響を受けない）", () => {
+    const t = new WorkerTelemetry();
+    t.recordResponse(makeMove(1));
+    const snap = t.snapshot();
+    t.recordResponse(makeMove(2));
+    expect(snap.recentMoves).toHaveLength(1);
+  });
+
+  it("setEngineParams はそのまま snapshot に載る", () => {
+    const t = new WorkerTelemetry();
+    t.setEngineParams(engineParams);
+    expect(t.snapshot().engineParams).toEqual(engineParams);
+  });
+});
+
+describe("getWorkerTelemetry", () => {
+  it("同じ worker オブジェクトには同じ計測を返す", () => {
+    const worker = {};
+    expect(getWorkerTelemetry(worker)).toBe(getWorkerTelemetry(worker));
+  });
+
+  it("別の worker（再生成後）には空の計測を返す", () => {
+    const oldWorker = {};
+    getWorkerTelemetry(oldWorker).recordResponse(makeMove(1));
+    const newWorker = {};
+    expect(getWorkerTelemetry(newWorker).snapshot().recentMoves).toEqual([]);
+  });
+});
+
+describe("extractEngineParams", () => {
+  it("ready ペイロードから params を取り出す", () => {
+    expect(extractEngineParams({ ready: true, params: engineParams })).toEqual(
+      engineParams,
+    );
+  });
+
+  it("params が無い古い bridge worker では undefined", () => {
+    expect(extractEngineParams({ ready: true })).toBeUndefined();
+  });
+
+  it("params の必須フィールドが欠けていれば undefined", () => {
+    expect(
+      extractEngineParams({ ready: true, params: { difficulty: "hard" } }),
+    ).toBeUndefined();
+  });
+
+  it("オブジェクト以外は undefined", () => {
+    expect(extractEngineParams(null)).toBeUndefined();
+    expect(extractEngineParams("ready")).toBeUndefined();
+  });
+});

--- a/scripts/lib/workerTelemetry.test.ts
+++ b/scripts/lib/workerTelemetry.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   type EngineParamsSnapshot,
   type MoveStatRecord,
+  type RecentGameRecord,
+  RECENT_GAMES_HISTORY_LIMIT,
   RECENT_MOVE_HISTORY_LIMIT,
   WorkerTelemetry,
-  extractEngineParams,
   getWorkerTelemetry,
 } from "./workerTelemetry.ts";
 
@@ -13,8 +14,8 @@ const engineParams: EngineParamsSnapshot = {
   worktreePath: "/tmp/A-abc1234",
   difficulty: "hard",
   depth: 12,
-  timeLimit: 5000,
-  maxNodes: 3000000,
+  timeLimit: 10000,
+  maxNodes: 1000000,
   randomFactor: 0.02,
   evaluationOptions: { evalBasis: "prospect" },
   engine: "wasm",
@@ -27,22 +28,32 @@ const makeMove = (requestId: number): MoveStatRecord => ({
   requestId,
   gameIdx: 3,
   moveNumber: requestId,
-  color: "white" as const,
+  color: "white",
   depth: 6,
   score: 120,
-  thinkingTimeMs: 4900,
-  roundTripMs: 4950,
+  interrupted: true,
+  thinkingTimeMs: 29600,
+  roundTripMs: 29650,
   stats: { nodes: 123456 },
 });
 
+const makeGame = (gameIdx: number): RecentGameRecord => ({
+  gameIdx,
+  jushuName: "寒星",
+  isABlack: true,
+  gameSeed: 111,
+  moves: [{ row: 7, col: 7, isOpening: true }],
+});
+
 describe("WorkerTelemetry", () => {
-  it("初期状態は要求 0・直近手なし・pending なし", () => {
+  it("初期状態は要求 0・直近手/直近局なし・pending なし", () => {
     const t = new WorkerTelemetry();
     expect(t.snapshot()).toEqual({
       requestCount: 0,
       engineParams: undefined,
       pendingRequest: undefined,
       recentMoves: [],
+      recentGames: [],
     });
   });
 
@@ -77,6 +88,40 @@ describe("WorkerTelemetry", () => {
     expect(snap.recentMoves[0]?.stats?.nodes).toBe(123456);
   });
 
+  it("interrupted を保持する（長考が打ち切られたか走り切ったかの判別）", () => {
+    const t = new WorkerTelemetry();
+    t.recordResponse({ ...makeMove(1), interrupted: false });
+    t.recordResponse({ ...makeMove(2), interrupted: true });
+    expect(t.snapshot().recentMoves.map((m) => m.interrupted)).toEqual([
+      false,
+      true,
+    ]);
+  });
+
+  it("エラー応答で clearPending すると pending が消える", () => {
+    const t = new WorkerTelemetry();
+    t.recordRequest({
+      requestId: 9,
+      moveNumber: 2,
+      color: "black",
+      sentAt: "2026-08-23T00:00:00.000Z",
+    });
+    t.clearPending(9);
+    expect(t.snapshot().pendingRequest).toBeUndefined();
+  });
+
+  it("別 requestId の clearPending では消えない", () => {
+    const t = new WorkerTelemetry();
+    t.recordRequest({
+      requestId: 9,
+      moveNumber: 2,
+      color: "black",
+      sentAt: "2026-08-23T00:00:00.000Z",
+    });
+    t.clearPending(8);
+    expect(t.snapshot().pendingRequest?.requestId).toBe(9);
+  });
+
   it("ハング時（応答なし）は pending が残る＝ハングした要求そのもの", () => {
     const t = new WorkerTelemetry();
     t.recordRequest({
@@ -103,16 +148,40 @@ describe("WorkerTelemetry", () => {
     for (let i = 1; i <= 5; i++) {
       t.recordResponse(makeMove(i));
     }
-    const ids = t.snapshot().recentMoves.map((m) => m.requestId);
-    expect(ids).toEqual([3, 4, 5]);
+    expect(t.snapshot().recentMoves.map((m) => m.requestId)).toEqual([3, 4, 5]);
   });
 
-  it("既定の historyLimit は RECENT_MOVE_HISTORY_LIMIT", () => {
+  it("既定の historyLimit は RECENT_MOVE_HISTORY_LIMIT（32）", () => {
+    expect(RECENT_MOVE_HISTORY_LIMIT).toBe(32);
     const t = new WorkerTelemetry();
     for (let i = 1; i <= RECENT_MOVE_HISTORY_LIMIT + 4; i++) {
       t.recordResponse(makeMove(i));
     }
     expect(t.snapshot().recentMoves).toHaveLength(RECENT_MOVE_HISTORY_LIMIT);
+  });
+
+  it("直近局も上限で切られる", () => {
+    const t = new WorkerTelemetry(8, 2);
+    t.recordGame(makeGame(1));
+    t.recordGame(makeGame(2));
+    t.recordGame(makeGame(3));
+    expect(t.snapshot().recentGames.map((g) => g.gameIdx)).toEqual([2, 3]);
+  });
+
+  it("既定の直近局上限は RECENT_GAMES_HISTORY_LIMIT（10）", () => {
+    expect(RECENT_GAMES_HISTORY_LIMIT).toBe(10);
+    const t = new WorkerTelemetry();
+    for (let i = 0; i < RECENT_GAMES_HISTORY_LIMIT + 3; i++) {
+      t.recordGame(makeGame(i));
+    }
+    expect(t.snapshot().recentGames).toHaveLength(RECENT_GAMES_HISTORY_LIMIT);
+  });
+
+  it("clearGames で直近局を捨てられる", () => {
+    const t = new WorkerTelemetry();
+    t.recordGame(makeGame(1));
+    t.clearGames();
+    expect(t.snapshot().recentGames).toEqual([]);
   });
 
   it("snapshot は内部配列のコピーを返す（後続更新の影響を受けない）", () => {
@@ -128,6 +197,14 @@ describe("WorkerTelemetry", () => {
     t.setEngineParams(engineParams);
     expect(t.snapshot().engineParams).toEqual(engineParams);
   });
+
+  it("生存信号チャネルを保持する", () => {
+    const t = new WorkerTelemetry();
+    expect(t.getLivenessChannel()).toBeUndefined();
+    const channel = { buffer: new SharedArrayBuffer(16), epochBase: 1 };
+    t.setLivenessChannel(channel);
+    expect(t.getLivenessChannel()).toBe(channel);
+  });
 });
 
 describe("getWorkerTelemetry", () => {
@@ -138,31 +215,8 @@ describe("getWorkerTelemetry", () => {
 
   it("別の worker（再生成後）には空の計測を返す", () => {
     const oldWorker = {};
-    getWorkerTelemetry(oldWorker).recordResponse(makeMove(1));
+    getWorkerTelemetry(oldWorker).recordGame(makeGame(1));
     const newWorker = {};
-    expect(getWorkerTelemetry(newWorker).snapshot().recentMoves).toEqual([]);
-  });
-});
-
-describe("extractEngineParams", () => {
-  it("ready ペイロードから params を取り出す", () => {
-    expect(extractEngineParams({ ready: true, params: engineParams })).toEqual(
-      engineParams,
-    );
-  });
-
-  it("params が無い古い bridge worker では undefined", () => {
-    expect(extractEngineParams({ ready: true })).toBeUndefined();
-  });
-
-  it("params の必須フィールドが欠けていれば undefined", () => {
-    expect(
-      extractEngineParams({ ready: true, params: { difficulty: "hard" } }),
-    ).toBeUndefined();
-  });
-
-  it("オブジェクト以外は undefined", () => {
-    expect(extractEngineParams(null)).toBeUndefined();
-    expect(extractEngineParams("ready")).toBeUndefined();
+    expect(getWorkerTelemetry(newWorker).snapshot().recentGames).toEqual([]);
   });
 });

--- a/scripts/lib/workerTelemetry.ts
+++ b/scripts/lib/workerTelemetry.ts
@@ -1,0 +1,170 @@
+/**
+ * bridge worker ごとの計測情報（#128 ハング診断強化）。
+ *
+ * ハングした worker は wasm 探索でスレッドがブロックされており、`postMessage` を
+ * 送っても応答できない（worker の event loop が回らない）。したがって
+ * **ハング時に取れる情報はメインスレッド側が保持しているものだけ**である。
+ * このモジュールは「メインスレッドが観測できる worker の状態」を worker 単位で
+ * 蓄積し、ハングダンプにそのままスナップショットとして載せられる形にする。
+ *
+ * 蓄積するもの:
+ * - worker 起動時の解決済みエンジンパラメータ（bridge worker の ready 通知に同梱）
+ * - 起動からの着手要求数
+ * - 応答が返ってこない「実行中の要求」（＝ハングした要求そのもの）
+ * - 直近 N 手の思考統計（depth/score/thinkingTime/nodes …）
+ *
+ * worker インスタンス（オブジェクト同一性）をキーにした WeakMap レジストリで
+ * 管理するため、worker 再生成時は自動的に新しい空の計測が使われる。
+ */
+
+/** 直近手として保持する件数（ダンプサイズと診断価値のバランス） */
+export const RECENT_MOVE_HISTORY_LIMIT = 8;
+
+/** bridge worker が ready 時に自己申告する解決済みパラメータ */
+export interface EngineParamsSnapshot {
+  worktreePath: string;
+  difficulty: string;
+  /** iterative deepening の上限深さ（DifficultyParams.depth） */
+  depth: number;
+  timeLimit: number;
+  maxNodes: number;
+  randomFactor: number;
+  randomCriticalScoreThreshold?: number;
+  evaluationOptions?: unknown;
+  /** 実際に使われた探索エンジン */
+  engine: "wasm" | "ts";
+  bookEnabled: boolean;
+  /** wasm が getStatsBuffer を export しているか（統計欠落の切り分け用） */
+  hasStatsBuffer: boolean;
+  /** 脅威プローブの状態（ON(default) / OFF(runtime) など） */
+  threatProbe: string;
+}
+
+/** 送信済みで応答待ちの着手要求 */
+export interface PendingRequestRecord {
+  requestId: number;
+  /** ベンチのタスク index（0-based）。runMatch 経由でのみ入る */
+  gameIdx?: number;
+  /** 何手目の要求か（1-based, opening 込み） */
+  moveNumber: number;
+  color: "black" | "white";
+  /** 非オープニング要求の通し番号（1-based）。moveSeed 導出に使う */
+  nonOpeningOrdinal?: number;
+  moveSeed?: number;
+  /** 要求送信時刻（ISO8601） */
+  sentAt: string;
+}
+
+/** 応答が返った手の思考統計 */
+export interface MoveStatRecord {
+  requestId: number;
+  gameIdx?: number;
+  moveNumber: number;
+  color: "black" | "white";
+  depth: number;
+  score: number;
+  /** worker 内で計測した思考時間 */
+  thinkingTimeMs: number;
+  /** メインスレッドで計測した往復時間（postMessage → 応答） */
+  roundTripMs: number;
+  /** wasm 探索統計（nodes/qSearchNodes/ttHits…）。古い wasm では undefined */
+  stats?: Record<string, number>;
+}
+
+/** ダンプに載せる worker 計測のスナップショット */
+export interface WorkerTelemetrySnapshot {
+  /** worker 起動からの着手要求数（ハングした要求を含む） */
+  requestCount: number;
+  engineParams?: EngineParamsSnapshot;
+  /** 応答待ちの要求。ハング時はこれがハングした要求そのもの */
+  pendingRequest?: PendingRequestRecord;
+  /** 直近 N 手の思考統計（古→新） */
+  recentMoves: MoveStatRecord[];
+}
+
+/**
+ * 1 worker 分の計測。メインスレッド側でのみ更新される。
+ */
+export class WorkerTelemetry {
+  private readonly historyLimit: number;
+  private requestCount = 0;
+  private engineParams: EngineParamsSnapshot | undefined = undefined;
+  private pendingRequest: PendingRequestRecord | undefined = undefined;
+  private readonly recentMoves: MoveStatRecord[] = [];
+
+  constructor(historyLimit: number = RECENT_MOVE_HISTORY_LIMIT) {
+    this.historyLimit = Math.max(1, historyLimit);
+  }
+
+  setEngineParams(params: EngineParamsSnapshot): void {
+    this.engineParams = params;
+  }
+
+  recordRequest(record: PendingRequestRecord): void {
+    this.requestCount += 1;
+    this.pendingRequest = record;
+  }
+
+  /** 応答受信。pending をクリアし、直近手リング（historyLimit 件）へ積む。 */
+  recordResponse(record: MoveStatRecord): void {
+    if (this.pendingRequest?.requestId === record.requestId) {
+      this.pendingRequest = undefined;
+    }
+    this.recentMoves.push(record);
+    while (this.recentMoves.length > this.historyLimit) {
+      this.recentMoves.shift();
+    }
+  }
+
+  /**
+   * 現在の計測をコピーして返す。応答なしで終わった要求は pendingRequest に
+   * 残るため、ハング時はこれがハングした要求の内容そのものになる。
+   */
+  snapshot(): WorkerTelemetrySnapshot {
+    return {
+      requestCount: this.requestCount,
+      engineParams: this.engineParams,
+      pendingRequest: this.pendingRequest,
+      recentMoves: [...this.recentMoves],
+    };
+  }
+}
+
+// ============================================================================
+// worker インスタンス単位のレジストリ
+// ============================================================================
+
+const registry = new WeakMap<object, WorkerTelemetry>();
+
+/**
+ * worker（またはテスト用の任意オブジェクト）に紐づく計測を返す。無ければ作る。
+ * worker を terminate → 再生成すると別オブジェクトになるため、計測も自動的に
+ * リセットされる（ハング後の respawn で古い統計が混ざらない）。
+ */
+export function getWorkerTelemetry(worker: object): WorkerTelemetry {
+  const existing = registry.get(worker);
+  if (existing) {
+    return existing;
+  }
+  const created = new WorkerTelemetry();
+  registry.set(worker, created);
+  return created;
+}
+
+/** ready 通知のペイロードから EngineParamsSnapshot を安全に取り出す（型ガード）。 */
+export function extractEngineParams(
+  payload: unknown,
+): EngineParamsSnapshot | undefined {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+  const { params } = payload as { params?: unknown };
+  if (typeof params !== "object" || params === null) {
+    return undefined;
+  }
+  const p = params as Partial<EngineParamsSnapshot>;
+  if (typeof p.difficulty !== "string" || typeof p.depth !== "number") {
+    return undefined;
+  }
+  return params as EngineParamsSnapshot;
+}

--- a/scripts/lib/workerTelemetry.ts
+++ b/scripts/lib/workerTelemetry.ts
@@ -1,24 +1,29 @@
 /**
  * bridge worker ごとの計測情報（#128 ハング診断強化）。
  *
- * ハングした worker は wasm 探索でスレッドがブロックされており、`postMessage` を
- * 送っても応答できない（worker の event loop が回らない）。したがって
- * **ハング時に取れる情報はメインスレッド側が保持しているものだけ**である。
- * このモジュールは「メインスレッドが観測できる worker の状態」を worker 単位で
- * 蓄積し、ハングダンプにそのままスナップショットとして載せられる形にする。
+ * ハングした worker はメッセージに応答できない（wasm 探索でスレッドが同期ブロック
+ * されており event loop が回らない）。したがって**ハング時に読み出せるのは
+ * メインスレッド側が保持している情報**と、共有メモリ経由の生存信号
+ * （`workerLiveness.ts`）だけである。このモジュールは前者を worker 単位に集約する。
  *
  * 蓄積するもの:
  * - worker 起動時の解決済みエンジンパラメータ（bridge worker の ready 通知に同梱）
  * - 起動からの着手要求数
  * - 応答が返ってこない「実行中の要求」（＝ハングした要求そのもの）
- * - 直近 N 手の思考統計（depth/score/thinkingTime/nodes …）
+ * - 直近 N 手の思考統計（depth/score/interrupted/thinkingTime/nodes …）
+ * - この worker が同一インスタンスのまま打ち終えた直近 M 局の棋譜
  *
  * worker インスタンス（オブジェクト同一性）をキーにした WeakMap レジストリで
  * 管理するため、worker 再生成時は自動的に新しい空の計測が使われる。
  */
+import type { ReplayMove } from "./hangReplay.ts";
+import type { LivenessChannel } from "./workerLiveness.ts";
 
 /** 直近手として保持する件数（ダンプサイズと診断価値のバランス） */
-export const RECENT_MOVE_HISTORY_LIMIT = 8;
+export const RECENT_MOVE_HISTORY_LIMIT = 32;
+
+/** 直近局として保持する件数（履歴再生の前段に使う） */
+export const RECENT_GAMES_HISTORY_LIMIT = 10;
 
 /** bridge worker が ready 時に自己申告する解決済みパラメータ */
 export interface EngineParamsSnapshot {
@@ -38,6 +43,12 @@ export interface EngineParamsSnapshot {
   hasStatsBuffer: boolean;
   /** 脅威プローブの状態（ON(default) / OFF(runtime) など） */
   threatProbe: string;
+  /**
+   * 注入された eval 重み（weight-bench / Texel）の指紋。
+   * 重みそのものはダンプを肥大化させるので、キー数とハッシュだけを持つ。
+   * replay 側で「同じ重みで再現しているか」を突き合わせるのに使う。
+   */
+  evalWeightsFingerprint?: { count: number; hash: string };
 }
 
 /** 送信済みで応答待ちの着手要求 */
@@ -50,6 +61,10 @@ export interface PendingRequestRecord {
   color: "black" | "white";
   /** 非オープニング要求の通し番号（1-based）。moveSeed 導出に使う */
   nonOpeningOrdinal?: number;
+  /**
+   * この要求で実際に worker へ渡した moveSeed。
+   * **replay 時はこの値が権威**（再導出はずれるとサイレントに別 seed になる）。
+   */
   moveSeed?: number;
   /** 要求送信時刻（ISO8601） */
   sentAt: string;
@@ -63,12 +78,29 @@ export interface MoveStatRecord {
   color: "black" | "white";
   depth: number;
   score: number;
+  /**
+   * 探索が時間/ノード上限で打ち切られたか。
+   * 「長考した手が走り切ったのか打ち切られたのか」を区別する唯一のフラグで、
+   * 時間制限が効いていない疑い（#128 の g3）の判定に必須。
+   */
+  interrupted: boolean;
   /** worker 内で計測した思考時間 */
   thinkingTimeMs: number;
   /** メインスレッドで計測した往復時間（postMessage → 応答） */
   roundTripMs: number;
   /** wasm 探索統計（nodes/qSearchNodes/ttHits…）。古い wasm では undefined */
   stats?: Record<string, number>;
+}
+
+/** この worker が打ち終えた 1 局（履歴再生の入力） */
+export interface RecentGameRecord {
+  gameIdx: number;
+  jushuName: string;
+  isABlack: boolean;
+  /** この局の PRNG seed（未指定 bench なら undefined） */
+  gameSeed?: number;
+  /** opening 3手を含む全着手（打たれた順、座標のみ） */
+  moves: ReplayMove[];
 }
 
 /** ダンプに載せる worker 計測のスナップショット */
@@ -80,24 +112,53 @@ export interface WorkerTelemetrySnapshot {
   pendingRequest?: PendingRequestRecord;
   /** 直近 N 手の思考統計（古→新） */
   recentMoves: MoveStatRecord[];
+  /** この worker が同一インスタンスのまま打ち終えた直近 M 局（古→新） */
+  recentGames: RecentGameRecord[];
+}
+
+/** 上限つきで push する（古いものから捨てる）。 */
+function pushCapped<T>(list: T[], item: T, limit: number): void {
+  list.push(item);
+  if (list.length > limit) {
+    list.splice(0, list.length - limit);
+  }
 }
 
 /**
  * 1 worker 分の計測。メインスレッド側でのみ更新される。
+ *
+ * @param historyLimit テスト専用の上書き。本番は既定値（RECENT_MOVE_HISTORY_LIMIT）を使う。
+ * @param gamesLimit テスト専用の上書き。本番は既定値（RECENT_GAMES_HISTORY_LIMIT）を使う。
  */
 export class WorkerTelemetry {
   private readonly historyLimit: number;
+  private readonly gamesLimit: number;
   private requestCount = 0;
   private engineParams: EngineParamsSnapshot | undefined = undefined;
   private pendingRequest: PendingRequestRecord | undefined = undefined;
   private readonly recentMoves: MoveStatRecord[] = [];
+  private readonly recentGames: RecentGameRecord[] = [];
+  private livenessChannel: LivenessChannel | undefined = undefined;
 
-  constructor(historyLimit: number = RECENT_MOVE_HISTORY_LIMIT) {
+  constructor(
+    historyLimit: number = RECENT_MOVE_HISTORY_LIMIT,
+    gamesLimit: number = RECENT_GAMES_HISTORY_LIMIT,
+  ) {
     this.historyLimit = Math.max(1, historyLimit);
+    this.gamesLimit = Math.max(1, gamesLimit);
   }
 
   setEngineParams(params: EngineParamsSnapshot): void {
     this.engineParams = params;
+  }
+
+  /** 生存信号（SharedArrayBuffer）の共有チャネルを覚える。 */
+  setLivenessChannel(channel: LivenessChannel): void {
+    this.livenessChannel = channel;
+  }
+
+  getLivenessChannel(): LivenessChannel | undefined {
+    return this.livenessChannel;
   }
 
   recordRequest(record: PendingRequestRecord): void {
@@ -107,13 +168,31 @@ export class WorkerTelemetry {
 
   /** 応答受信。pending をクリアし、直近手リング（historyLimit 件）へ積む。 */
   recordResponse(record: MoveStatRecord): void {
-    if (this.pendingRequest?.requestId === record.requestId) {
+    this.clearPending(record.requestId);
+    pushCapped(this.recentMoves, record, this.historyLimit);
+  }
+
+  /**
+   * 応答は返ったが着手ではなかった場合（worker のエラー応答）に pending を消す。
+   * 消し忘れるとダンプの pendingRequest が「ハングした要求」ではなくなる。
+   */
+  clearPending(requestId?: number): void {
+    if (
+      requestId === undefined ||
+      this.pendingRequest?.requestId === requestId
+    ) {
       this.pendingRequest = undefined;
     }
-    this.recentMoves.push(record);
-    while (this.recentMoves.length > this.historyLimit) {
-      this.recentMoves.shift();
-    }
+  }
+
+  /** この worker が 1 局打ち終えたことを記録する。 */
+  recordGame(game: RecentGameRecord): void {
+    pushCapped(this.recentGames, game, this.gamesLimit);
+  }
+
+  /** worker ペアが再生成された等で履歴が無効になったときに捨てる。 */
+  clearGames(): void {
+    this.recentGames.length = 0;
   }
 
   /**
@@ -126,6 +205,7 @@ export class WorkerTelemetry {
       engineParams: this.engineParams,
       pendingRequest: this.pendingRequest,
       recentMoves: [...this.recentMoves],
+      recentGames: [...this.recentGames],
     };
   }
 }
@@ -149,22 +229,4 @@ export function getWorkerTelemetry(worker: object): WorkerTelemetry {
   const created = new WorkerTelemetry();
   registry.set(worker, created);
   return created;
-}
-
-/** ready 通知のペイロードから EngineParamsSnapshot を安全に取り出す（型ガード）。 */
-export function extractEngineParams(
-  payload: unknown,
-): EngineParamsSnapshot | undefined {
-  if (typeof payload !== "object" || payload === null) {
-    return undefined;
-  }
-  const { params } = payload as { params?: unknown };
-  if (typeof params !== "object" || params === null) {
-    return undefined;
-  }
-  const p = params as Partial<EngineParamsSnapshot>;
-  if (typeof p.difficulty !== "string" || typeof p.depth !== "number") {
-    return undefined;
-  }
-  return params as EngineParamsSnapshot;
 }

--- a/scripts/replay-hang.ts
+++ b/scripts/replay-hang.ts
@@ -13,8 +13,13 @@
  *     --import ./scripts/register-loader.mjs scripts/replay-hang.ts <dump-path>
  *
  * オプション:
- *   --timeout-ms=<N>   watchdog タイムアウト（既定 60000ms）
- *   --verbose          レスポンス JSON を出力
+ *   --timeout-ms=<N>    watchdog タイムアウト（既定 60000ms）
+ *   --verbose           レスポンス JSON を出力
+ *   --replay-history    該当手の前に、同じ worker が直前に打った局（ダンプの
+ *                       recentGames, schemaVersion>=2）を同じ順で再生してから
+ *                       ハング局面を要求する。長時間稼働した worker の蓄積状態
+ *                       （wasm メモリ・アロケータ・内部ヒューリスティック）に
+ *                       依存する再現性を検証するためのモード（#128）。
  *
  * 出力:
  *   - dump のメタ情報（side/color/moveNumber/commit/eval options）
@@ -32,8 +37,14 @@ import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 
 import type { BoardState, Position } from "../src/types/game.ts";
-import type { HangDumpJson } from "./lib/hangDump.ts";
 
+import { applyMove } from "../src/logic/cpu/core/boardUtils.ts";
+import { createEmptyBoard } from "../src/logic/renjuRules/index.ts";
+import {
+  type HangDumpJson,
+  type HangDumpRecentGame,
+  hangSideColor,
+} from "./lib/hangDump.ts";
 import { buildBridgeCustomParams } from "./lib/match.ts";
 import { mixSeed } from "./lib/mulberry32.ts";
 
@@ -49,7 +60,17 @@ interface CliOptions {
    * 既定 ON（現場運用ではダンプ後に bench の finally で消えているのが普通）。
    */
   recreateWorktree: boolean;
+  /**
+   * #128: ハング局面の前に、同じ worker が直前に打った局（dump.recentGames）を
+   * 同じ順で再生する。TT/wasm メモリ等の蓄積状態を再現するため。
+   * schemaVersion 1 のダンプには recentGames が無いので警告して素通しする。
+   */
+  replayHistory: boolean;
 }
+
+const USAGE =
+  "Usage: replay-hang <dump-path> [--timeout-ms=60000] [--verbose] " +
+  "[--no-recreate-worktree] [--replay-history]";
 
 // ============================================================================
 // CLI
@@ -62,6 +83,7 @@ function parseArgs(): CliOptions {
     timeoutMs: 60000,
     verbose: false,
     recreateWorktree: true,
+    replayHistory: false,
   };
   for (const arg of args) {
     if (arg.startsWith("--timeout-ms=")) {
@@ -73,10 +95,10 @@ function parseArgs(): CliOptions {
       options.verbose = true;
     } else if (arg === "--no-recreate-worktree") {
       options.recreateWorktree = false;
+    } else if (arg === "--replay-history") {
+      options.replayHistory = true;
     } else if (arg === "--help" || arg === "-h") {
-      console.log(
-        "Usage: replay-hang <dump-path> [--timeout-ms=60000] [--verbose] [--no-recreate-worktree]",
-      );
+      console.log(USAGE);
       process.exit(0);
     } else if (arg.startsWith("--")) {
       console.error(`Error: 不明な引数: ${arg}`);
@@ -87,9 +109,7 @@ function parseArgs(): CliOptions {
   }
   if (options.dumpPath === "") {
     console.error("Error: ダンプファイルのパスを指定してください");
-    console.error(
-      "Usage: replay-hang <dump-path> [--timeout-ms=60000] [--verbose] [--no-recreate-worktree]",
-    );
+    console.error(USAGE);
     process.exit(1);
   }
   return options;
@@ -257,6 +277,9 @@ interface ReplayOutcome {
   errorMessage?: string;
 }
 
+/** リクエスト ID の採番（履歴再生で複数手を要求するため一意にする） */
+let nextRequestId = 1;
+
 function requestMoveWithWatchdog(
   worker: Worker,
   board: BoardState,
@@ -265,7 +288,7 @@ function requestMoveWithWatchdog(
   moveSeed: number | undefined,
 ): Promise<ReplayOutcome> {
   return new Promise<ReplayOutcome>((resolve) => {
-    const requestId = 1;
+    const requestId = nextRequestId++;
     const start = performance.now();
 
     const timer = setTimeout(() => {
@@ -307,6 +330,134 @@ function requestMoveWithWatchdog(
 }
 
 // ============================================================================
+// 履歴再生（--replay-history, #128）
+// ============================================================================
+
+/**
+ * v2 ダンプの worker 計測（#128）を人間向けに要約表示する。
+ * v1 ダンプには telemetry が無いので、その旨だけを 1 行で知らせる。
+ */
+function printTelemetry(dump: HangDumpJson): void {
+  const { telemetry } = dump.worker;
+  if (!telemetry) {
+    console.log(
+      `telemetry: (schemaVersion=${dump.schemaVersion} — worker 計測なし)`,
+    );
+    return;
+  }
+  const { engineParams, pendingRequest, recentMoves, requestCount } = telemetry;
+  console.log(`telemetry: worker 起動からの要求数=${requestCount}`);
+  if (engineParams) {
+    console.log(
+      `  engine=${engineParams.engine} depth=${engineParams.depth} timeLimit=${engineParams.timeLimit} maxNodes=${engineParams.maxNodes} threatProbe=${engineParams.threatProbe} statsBuffer=${engineParams.hasStatsBuffer}`,
+    );
+  }
+  if (pendingRequest) {
+    console.log(
+      `  ハングした要求: requestId=${pendingRequest.requestId} move#${pendingRequest.moveNumber} ${pendingRequest.color} moveSeed=${pendingRequest.moveSeed ?? "unset"} sentAt=${pendingRequest.sentAt}`,
+    );
+  }
+  if (recentMoves.length > 0) {
+    console.log(`  直前 ${recentMoves.length} 手の思考統計:`);
+    for (const m of recentMoves) {
+      const nodes = m.stats?.nodes;
+      console.log(
+        `    g${m.gameIdx ?? "?"} move#${m.moveNumber} ${m.color} depth=${m.depth} score=${m.score} t=${Math.round(m.thinkingTimeMs)}ms nodes=${nodes ?? "n/a"}`,
+      );
+    }
+  }
+  const recentGames = dump.recentGames ?? [];
+  console.log(
+    `  同一 worker の直前局: ${recentGames.length} 局${recentGames.length > 0 ? ` (g${recentGames.map((g) => g.gameIdx).join(", g")})` : ""}`,
+  );
+}
+
+/** 手番の色。開局手を含め黒→白→黒…と交互（連珠の手順そのもの）。 */
+function colorOfMoveIndex(index: number): "black" | "white" {
+  return index % 2 === 0 ? "black" : "white";
+}
+
+interface HistoryReplayResult {
+  /** 実際に worker に投げた手数 */
+  requestedMoves: number;
+  /** 履歴再生の途中でハングしたか（したならそこが新しい調査対象） */
+  hungAt?: { gameIdx: number; moveNumber: number; elapsedMs: number };
+  /**
+   * 履歴再生の途中で worker がエラー応答を返したか。
+   * ハング（無応答）とは区別する — 混同すると誤診断になる。
+   */
+  erroredAt?: { gameIdx: number; moveNumber: number; message: string };
+}
+
+/**
+ * ハングした worker が直前に打った局を、同じ worker インスタンスに同じ順で
+ * 打たせ直す。相手側 worker は不要（ハングした側の手番だけを要求すればよい）。
+ *
+ * 目的は「長時間稼働した worker の蓄積状態でのみハングする」仮説の検証。
+ * 単独再生（1手だけ）で再現しなかった #128 の実ダンプに対する次の一手。
+ */
+async function replayHistory(
+  worker: Worker,
+  dump: HangDumpJson,
+  games: HangDumpRecentGame[],
+  timeoutMs: number,
+): Promise<HistoryReplayResult> {
+  let requestedMoves = 0;
+  for (const game of games) {
+    const color = hangSideColor(dump.hang.side, game.isABlack);
+    let board: BoardState = createEmptyBoard();
+    let nonOpeningOrdinal = 0;
+    console.log(
+      `  g${game.gameIdx} ${game.jushuName} (${game.isABlack ? "A黒" : "A白"}) — ハング側=${color}, ${game.moves.length}手`,
+    );
+    for (const [index, move] of game.moves.entries()) {
+      const moveColor = colorOfMoveIndex(index);
+      if (!move.isOpening) {
+        nonOpeningOrdinal++;
+        if (moveColor === color) {
+          const moveSeed =
+            game.gameSeed === undefined
+              ? undefined
+              : mixSeed(game.gameSeed, nonOpeningOrdinal);
+          // 逐次実行が必須: 同一 worker に交互要求するので並列化できない
+          const outcome = await requestMoveWithWatchdog(
+            worker,
+            board,
+            color,
+            timeoutMs,
+            moveSeed,
+          );
+          requestedMoves++;
+          if (outcome.status === "timed-out") {
+            return {
+              requestedMoves,
+              hungAt: {
+                gameIdx: game.gameIdx,
+                moveNumber: index + 1,
+                elapsedMs: outcome.elapsedMs,
+              },
+            };
+          }
+          if (outcome.status === "error") {
+            return {
+              requestedMoves,
+              erroredAt: {
+                gameIdx: game.gameIdx,
+                moveNumber: index + 1,
+                message: outcome.errorMessage ?? "(不明なエラー)",
+              },
+            };
+          }
+        }
+      }
+      // 実際に打たれた手を適用する（worker の返した手ではなく棋譜どおりに進める）
+      board = applyMove(board, { row: move.row, col: move.col }, moveColor);
+    }
+  }
+  return { requestedMoves };
+}
+
+// ============================================================================
 // main
 // ============================================================================
 
@@ -344,7 +495,9 @@ async function main(): Promise<void> {
   console.log(
     `  seed: gameSeed=${dump.match.gameSeed ?? "unset"} → moveSeed=${moveSeed ?? "unset"} (nonOpeningOrdinal=${nonOpeningOrdinal})`,
   );
-  console.log(`watchdog: ${options.timeoutMs}ms\n`);
+  console.log(`watchdog: ${options.timeoutMs}ms`);
+  printTelemetry(dump);
+  console.log();
 
   if (options.recreateWorktree) {
     ensureWorktree(dump);
@@ -352,7 +505,54 @@ async function main(): Promise<void> {
 
   console.log(`bridge worker を起動中...`);
   const worker = await spawnBridgeWorker(dump);
-  console.log(`起動完了。1手要求を送信します...\n`);
+  console.log(`起動完了。`);
+
+  if (options.replayHistory) {
+    const recentGames = dump.recentGames ?? [];
+    if (recentGames.length === 0) {
+      console.warn(
+        `⚠ --replay-history 指定ですが、このダンプに recentGames がありません` +
+          `（schemaVersion=${dump.schemaVersion}、v2 未満の古いダンプ）。履歴再生をスキップします。`,
+      );
+    } else {
+      console.log(
+        `\n--- 履歴再生: 同一 worker に直前 ${recentGames.length} 局を打たせ直します ---`,
+      );
+      const historyStart = performance.now();
+      const history = await replayHistory(
+        worker,
+        dump,
+        recentGames,
+        options.timeoutMs,
+      );
+      if (history.hungAt) {
+        const s = (history.hungAt.elapsedMs / 1000).toFixed(2);
+        console.log(
+          `\n✗ HANG REPRODUCED（履歴再生中） g${history.hungAt.gameIdx} の ${history.hungAt.moveNumber} 手目で ${s}s 応答なし`,
+        );
+        console.log(
+          `  蓄積状態依存のハングが再現しました。この局面が根本原因調査の対象です。`,
+        );
+        worker.terminate();
+        process.exit(2);
+      }
+      if (history.erroredAt) {
+        console.log(
+          `\n⚠ 履歴再生中に worker がエラー応答: g${history.erroredAt.gameIdx} の ${history.erroredAt.moveNumber} 手目 — ${history.erroredAt.message}`,
+        );
+        console.log(
+          `  ハング（無応答）ではありません。履歴再生を中断したためハング局面の要求は行いません。`,
+        );
+        worker.terminate();
+        process.exit(1);
+      }
+      console.log(
+        `--- 履歴再生完了: ${history.requestedMoves} 手を要求 (${((performance.now() - historyStart) / 1000).toFixed(1)}s) ---\n`,
+      );
+    }
+  }
+
+  console.log(`ハング局面の1手要求を送信します...\n`);
 
   const outcome = await requestMoveWithWatchdog(
     worker,
@@ -378,6 +578,11 @@ async function main(): Promise<void> {
       `\n※ 再現せず。ダンプ時のハングは非決定的（TT/randomFactor/実行環境）か、` +
         `wasm 側の状態依存の可能性があります。`,
     );
+    if (!options.replayHistory) {
+      console.log(
+        `  次の一手: --replay-history を付けて同一 worker に直前局を打たせてから再試行してください（#128）。`,
+      );
+    }
     process.exit(0);
   }
   if (outcome.status === "timed-out") {

--- a/scripts/replay-hang.ts
+++ b/scripts/replay-hang.ts
@@ -4,30 +4,32 @@
  *
  * commit-bench の HANG_DUMPS_DIR に書かれた `hang-*.json` を読み、ハングした側と
  * 同じ worktree/難易度/randomFactor/evaluationOptions/bookEnabled で bridge worker
- * を起動して、記録されていた盤面・手番色で1手だけ要求する。
+ * を起動して、記録されていた盤面・手番色で 1 手だけ要求する。
+ *
+ * `--replay-history` を付けると、その 1 手の前に**同じ worker に棋譜を打たせ直す**。
+ * 既定は「ハングした局そのものの初手〜直前手」（v1 ダンプでも必ず持っている
+ * `moveHistory`）。`--replay-history=N` にすると、さらに前段としてダンプの
+ * `recentGames` から直近 N 局を先に再生する（v2 ダンプのみ）。
  *
  * 使い方:
- *   pnpm exec-script scripts/replay-hang.ts bench-results/hang-dumps/hang-XXX.json
- *   # または直接 node で:
- *   node --experimental-strip-types --disable-warning=ExperimentalWarning \
- *     --import ./scripts/register-loader.mjs scripts/replay-hang.ts <dump-path>
+ *   pnpm replay:hang bench-results/hang-dumps/hang-XXX.json
+ *   pnpm replay:hang bench-results/hang-dumps/hang-XXX.json --replay-history
+ *   pnpm replay:hang bench-results/hang-dumps/hang-XXX.json --replay-history=3
  *
  * オプション:
- *   --timeout-ms=<N>    watchdog タイムアウト（既定 60000ms）
- *   --verbose           レスポンス JSON を出力
- *   --replay-history    該当手の前に、同じ worker が直前に打った局（ダンプの
- *                       recentGames, schemaVersion>=2）を同じ順で再生してから
- *                       ハング局面を要求する。長時間稼働した worker の蓄積状態
- *                       （wasm メモリ・アロケータ・内部ヒューリスティック）に
- *                       依存する再現性を検証するためのモード（#128）。
+ *   --timeout-ms=<N>      1 手あたりの watchdog（既定: ダンプの bench.moveTimeoutMs）
+ *   --verbose             レスポンス JSON を出力
+ *   --no-recreate-worktree  worktree の作り直しを行わない
+ *   --replay-history[=N]  上記の履歴再生。N は先行して再生する過去局数（既定 0）
  *
  * 出力:
- *   - dump のメタ情報（side/color/moveNumber/commit/eval options）
- *   - watchdog タイムアウトまでに応答が返れば所要時間・返された着手・depth・score
- *   - 返らなければ "HANG (timed out)" を表示して非0終了
+ *   - dump のメタ情報（side/color/moveNumber/commit/eval options/telemetry）
+ *   - 履歴再生の進捗と所要時間見積もり
+ *   - watchdog までに応答が返れば所要時間・返された着手・depth・score
+ *   - 返らなければ "HANG REPRODUCED" を表示して非0終了
  *
- * このスクリプトはハング局面を再現できるかを確認するためのもので、bench 全体を
- * 走らせずに再現条件を絞り込む。
+ * 注意: `ensureWorktree` は `.git/worktrees-bench/` を作り直すため、**commit-bench の
+ * 走行中に実行してはいけない**（走行中の worktree を壊す）。
  */
 
 import { execSync } from "node:child_process";
@@ -37,22 +39,37 @@ import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 
 import type { BoardState, Position } from "../src/types/game.ts";
+import type { EngineParamsSnapshot } from "./lib/workerTelemetry.ts";
 
-import { applyMove } from "../src/logic/cpu/core/boardUtils.ts";
-import { createEmptyBoard } from "../src/logic/renjuRules/index.ts";
+import {
+  diffEngineParams,
+  isReadyMessage,
+  parseEngineParams,
+} from "./lib/bridgeWorkerProtocol.ts";
 import {
   type HangDumpJson,
-  type HangDumpRecentGame,
-  hangSideColor,
+  type HangDumpJsonV2,
+  isHangDumpV2,
 } from "./lib/hangDump.ts";
+import { deriveMoveSeed, nonOpeningOrdinalOf } from "./lib/hangReplay.ts";
+import {
+  type ReplayRequestOutcome,
+  type ReplayStage,
+  countPlannedRequests,
+  runReplayStages,
+} from "./lib/hangReplayRunner.ts";
 import { buildBridgeCustomParams } from "./lib/match.ts";
-import { mixSeed } from "./lib/mulberry32.ts";
+import { createLivenessChannel } from "./lib/workerLiveness.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/** ダンプの想定上限サイズ。超えたら warn（棋譜が異常に長い等の早期検知） */
+const DUMP_SIZE_WARN_BYTES = 8 * 1024 * 1024;
+
 interface CliOptions {
   dumpPath: string;
-  timeoutMs: number;
+  /** undefined ならダンプの bench.moveTimeoutMs を使う */
+  timeoutMs?: number;
   verbose: boolean;
   /**
    * ダンプ記録時の worktree が既に消えている場合、その sha から
@@ -61,29 +78,47 @@ interface CliOptions {
    */
   recreateWorktree: boolean;
   /**
-   * #128: ハング局面の前に、同じ worker が直前に打った局（dump.recentGames）を
-   * 同じ順で再生する。TT/wasm メモリ等の蓄積状態を再現するため。
-   * schemaVersion 1 のダンプには recentGames が無いので警告して素通しする。
+   * 履歴再生を行うか。ON なら必ず「ハング局の初手〜直前手」を再生する。
    */
   replayHistory: boolean;
+  /**
+   * さらに前段として再生する過去局数（dump.recentGames から新しい順に N 局）。
+   * v2 ダンプのみ有効。0 ならハング局のみ。
+   */
+  replayHistoryGames: number;
 }
 
 const USAGE =
-  "Usage: replay-hang <dump-path> [--timeout-ms=60000] [--verbose] " +
-  "[--no-recreate-worktree] [--replay-history]";
+  "Usage: replay-hang <dump-path> [--timeout-ms=N] [--verbose] " +
+  "[--no-recreate-worktree] [--replay-history[=N]]";
 
 // ============================================================================
 // CLI
 // ============================================================================
 
+function parseReplayHistoryArg(arg: string, options: CliOptions): void {
+  options.replayHistory = true;
+  const eq = arg.indexOf("=");
+  if (eq === -1) {
+    return;
+  }
+  const raw = arg.slice(eq + 1);
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed) || parsed < 0) {
+    console.error(`Error: --replay-history の値が不正です: ${raw}`);
+    process.exit(1);
+  }
+  options.replayHistoryGames = parsed;
+}
+
 function parseArgs(): CliOptions {
   const args = process.argv.slice(2);
   const options: CliOptions = {
     dumpPath: "",
-    timeoutMs: 60000,
     verbose: false,
     recreateWorktree: true,
     replayHistory: false,
+    replayHistoryGames: 0,
   };
   for (const arg of args) {
     if (arg.startsWith("--timeout-ms=")) {
@@ -95,8 +130,11 @@ function parseArgs(): CliOptions {
       options.verbose = true;
     } else if (arg === "--no-recreate-worktree") {
       options.recreateWorktree = false;
-    } else if (arg === "--replay-history") {
-      options.replayHistory = true;
+    } else if (
+      arg === "--replay-history" ||
+      arg.startsWith("--replay-history=")
+    ) {
+      parseReplayHistoryArg(arg, options);
     } else if (arg === "--help" || arg === "-h") {
       console.log(USAGE);
       process.exit(0);
@@ -118,8 +156,8 @@ function parseArgs(): CliOptions {
 /**
  * ダンプに書かれた worktreePath が存在しなければ、commit sha から作り直す。
  * commit-bench の createWorktree と同等（node_modules と wasm も揃える）。
- * 副作用で worktree を追加する。呼び出し元に removal は任せる（プロセス終了で
- * 残るが、次回 commit-bench が同じ label で作り直すときに --force で消える）。
+ *
+ * **commit-bench 走行中に呼ばないこと**（同じ worktree ディレクトリを操作する）。
  */
 function ensureWorktree(dump: HangDumpJson): void {
   const wt = dump.worker.worktreePath;
@@ -180,13 +218,25 @@ function loadDump(dumpPath: string): HangDumpJson {
     console.error(`Error: ダンプファイルが見つかりません: ${abs}`);
     process.exit(1);
   }
+  const { size } = fs.statSync(abs);
+  if (size > DUMP_SIZE_WARN_BYTES) {
+    console.warn(
+      `⚠ ダンプが想定より大きい (${(size / 1024 / 1024).toFixed(1)}MB)。読み込みに時間がかかります。`,
+    );
+  }
   const raw = fs.readFileSync(abs, "utf-8");
   const parsed = JSON.parse(raw) as HangDumpJson;
   if (parsed.type !== "hang-dump") {
     console.error(
-      `Error: type=hang-dump ではありません (got: ${parsed.type as string})`,
+      `Error: type=hang-dump ではありません (got: ${String(parsed.type)})`,
     );
     process.exit(1);
+  }
+  if (parsed.schemaVersion !== 1 && parsed.schemaVersion !== 2) {
+    console.warn(
+      `⚠ 未知の schemaVersion=${String(parsed.schemaVersion)}。v2 として読み込みますが、` +
+        `このスクリプトが古い可能性があります。`,
+    );
   }
   return parsed;
 }
@@ -195,7 +245,45 @@ function loadDump(dumpPath: string): HangDumpJson {
 // bridge worker 起動
 // ============================================================================
 
-function spawnBridgeWorker(dump: HangDumpJson): Promise<Worker> {
+interface SpawnedWorker {
+  worker: Worker;
+  /** ready 通知に載っていた実パラメータ（古い bridge worker なら undefined） */
+  engineParams?: EngineParamsSnapshot;
+}
+
+/**
+ * ダンプの engineParams（v2）から、replay worker に渡す customParams を組み立てる。
+ * v1 ダンプや engineParams 欠落時は、ダンプのトップレベル情報でフォールバックする。
+ */
+function buildReplayWorkerData(
+  dump: HangDumpJson,
+  engineParams: EngineParamsSnapshot | undefined,
+): Record<string, unknown> {
+  const customParams = buildBridgeCustomParams(
+    engineParams?.randomFactor ?? dump.worker.randomFactor,
+    (engineParams?.evaluationOptions as Record<string, unknown> | undefined) ??
+      dump.worker.evaluationOptions,
+    engineParams?.maxNodes,
+    engineParams?.depth,
+  );
+  return {
+    worktreePath: dump.worker.worktreePath,
+    difficulty: engineParams?.difficulty ?? dump.worker.difficulty,
+    customParams,
+    bookEnabled: engineParams?.bookEnabled ?? dump.worker.bookEnabled,
+    // engineParams.threatProbe は "ON(default)" / "OFF(runtime)" などの表示文字列。
+    // OFF で走っていたときだけ明示的に無効化する。
+    threatProbeEnabled: engineParams?.threatProbe.startsWith("OFF")
+      ? false
+      : undefined,
+    livenessChannel: createLivenessChannel(),
+  };
+}
+
+function spawnBridgeWorker(
+  dump: HangDumpJson,
+  dumpEngineParams: EngineParamsSnapshot | undefined,
+): Promise<SpawnedWorker> {
   const workerPath = path.join(__dirname, "cpu-bridge-worker.ts");
   const loaderPath = path.join(
     dump.worker.worktreePath,
@@ -210,19 +298,9 @@ function spawnBridgeWorker(dump: HangDumpJson): Promise<Worker> {
     process.exit(1);
   }
 
-  const customParams = buildBridgeCustomParams(
-    dump.worker.randomFactor,
-    dump.worker.evaluationOptions,
-  );
-
-  return new Promise<Worker>((resolve, reject) => {
+  return new Promise<SpawnedWorker>((resolve, reject) => {
     const worker = new Worker(workerPath, {
-      workerData: {
-        worktreePath: dump.worker.worktreePath,
-        difficulty: dump.worker.difficulty,
-        customParams,
-        bookEnabled: dump.worker.bookEnabled,
-      },
+      workerData: buildReplayWorkerData(dump, dumpEngineParams),
       execArgv: [
         "--experimental-strip-types",
         "--disable-warning=ExperimentalWarning",
@@ -237,15 +315,10 @@ function spawnBridgeWorker(dump: HangDumpJson): Promise<Worker> {
     }, 60000);
 
     const readyHandler = (msg: unknown): void => {
-      if (
-        typeof msg === "object" &&
-        msg !== null &&
-        "ready" in msg &&
-        (msg as { ready: unknown }).ready === true
-      ) {
+      if (isReadyMessage(msg)) {
         clearTimeout(initTimer);
         worker.off("message", readyHandler);
-        resolve(worker);
+        resolve({ worker, engineParams: parseEngineParams(msg) });
       }
     };
     worker.on("message", readyHandler);
@@ -270,11 +343,8 @@ interface MoveResponse {
   stats?: Record<string, number>;
 }
 
-interface ReplayOutcome {
-  status: "responded" | "timed-out" | "error";
-  elapsedMs: number;
+interface ReplayOutcome extends ReplayRequestOutcome {
   response?: MoveResponse;
-  errorMessage?: string;
 }
 
 /** リクエスト ID の採番（履歴再生で複数手を要求するため一意にする） */
@@ -330,21 +400,22 @@ function requestMoveWithWatchdog(
 }
 
 // ============================================================================
-// 履歴再生（--replay-history, #128）
+// 表示
 // ============================================================================
 
 /**
- * v2 ダンプの worker 計測（#128）を人間向けに要約表示する。
- * v1 ダンプには telemetry が無いので、その旨だけを 1 行で知らせる。
+ * v2 ダンプの worker 計測・生存信号・メインスレッド状態を人間向けに要約表示する。
+ * v1 ダンプにはこれらが無いので、その旨だけを 1 行で知らせる。
  */
-function printTelemetry(dump: HangDumpJson): void {
-  const { telemetry } = dump.worker;
-  if (!telemetry) {
+function printDiagnostics(dump: HangDumpJson): void {
+  if (!isHangDumpV2(dump)) {
     console.log(
-      `telemetry: (schemaVersion=${dump.schemaVersion} — worker 計測なし)`,
+      `telemetry: (schemaVersion=${dump.schemaVersion} — worker 計測なし。` +
+        `--replay-history はハング局の棋譜のみを再生します)`,
     );
     return;
   }
+  const { telemetry } = dump.worker;
   const { engineParams, pendingRequest, recentMoves, requestCount } = telemetry;
   console.log(`telemetry: worker 起動からの要求数=${requestCount}`);
   if (engineParams) {
@@ -358,116 +429,128 @@ function printTelemetry(dump: HangDumpJson): void {
     );
   }
   if (recentMoves.length > 0) {
-    console.log(`  直前 ${recentMoves.length} 手の思考統計:`);
+    console.log(`  直前 ${recentMoves.length} 手の思考統計（古→新）:`);
     for (const m of recentMoves) {
-      const nodes = m.stats?.nodes;
       console.log(
-        `    g${m.gameIdx ?? "?"} move#${m.moveNumber} ${m.color} depth=${m.depth} score=${m.score} t=${Math.round(m.thinkingTimeMs)}ms nodes=${nodes ?? "n/a"}`,
+        `    g${m.gameIdx ?? "?"} move#${m.moveNumber} ${m.color} depth=${m.depth} score=${m.score} t=${Math.round(m.thinkingTimeMs)}ms interrupted=${m.interrupted} nodes=${m.stats?.nodes ?? "n/a"}`,
       );
     }
   }
-  const recentGames = dump.recentGames ?? [];
+  const { liveness, mainThread } = dump.hang;
   console.log(
-    `  同一 worker の直前局: ${recentGames.length} 局${recentGames.length > 0 ? ` (g${recentGames.map((g) => g.gameIdx).join(", g")})` : ""}`,
+    `  liveness: ${liveness.verdict} timeChecks=${liveness.timeCheckCount} (+${liveness.timeCheckDeltaDuringSample} in ${liveness.sampleWindowMs}ms) lastAt=${liveness.lastTimeCheckAt ?? "n/a"}`,
   );
+  console.log(
+    `  mainThread: maxTimerLag=${mainThread.maxTimerLagMs}ms maxClockSkewJump=${mainThread.maxClockSkewJumpMs}ms samples=${mainThread.samples.length}`,
+  );
+  console.log(`  同一 worker の直前局: ${dump.recentGames.length} 局`);
 }
 
-/** 手番の色。開局手を含め黒→白→黒…と交互（連珠の手順そのもの）。 */
-function colorOfMoveIndex(index: number): "black" | "white" {
-  return index % 2 === 0 ? "black" : "white";
+function warnEngineParamsDiff(
+  dump: HangDumpJson,
+  actual: EngineParamsSnapshot | undefined,
+): void {
+  const expected = isHangDumpV2(dump)
+    ? dump.worker.telemetry.engineParams
+    : undefined;
+  if (!expected) {
+    console.warn(
+      "⚠ ダンプに engineParams がありません（v1 ダンプ or 旧 bridge worker）。" +
+        "replay の探索条件がダンプ時と一致している保証はありません。",
+    );
+    return;
+  }
+  if (!actual) {
+    console.warn(
+      "⚠ replay worker が params を返しませんでした（古い bridge worker）。突き合わせ不可。",
+    );
+    return;
+  }
+  const diffs = diffEngineParams(expected, actual);
+  if (diffs.length === 0) {
+    console.log("engineParams: ダンプと一致 ✓");
+    return;
+  }
+  console.warn("⚠ engineParams がダンプと一致しません（再現性に影響します）:");
+  for (const d of diffs) {
+    console.warn(
+      `    ${d.key}: dump=${JSON.stringify(d.expected)} replay=${JSON.stringify(d.actual)}`,
+    );
+  }
 }
 
-interface HistoryReplayResult {
-  /** 実際に worker に投げた手数 */
-  requestedMoves: number;
-  /** 履歴再生の途中でハングしたか（したならそこが新しい調査対象） */
-  hungAt?: { gameIdx: number; moveNumber: number; elapsedMs: number };
-  /**
-   * 履歴再生の途中で worker がエラー応答を返したか。
-   * ハング（無応答）とは区別する — 混同すると誤診断になる。
-   */
-  erroredAt?: { gameIdx: number; moveNumber: number; message: string };
+// ============================================================================
+// 履歴再生ステージの組み立て
+// ============================================================================
+
+/**
+ * 再生ステージを組み立てる。
+ *
+ * 1. `recentGames` から直近 N 局（古い順）— v2 ダンプのみ、`--replay-history=N` 指定時
+ * 2. ハングした局そのものの初手〜直前手（`moveHistory`）— v1 でも必ずある
+ */
+function buildStages(dump: HangDumpJson, historyGames: number): ReplayStage[] {
+  const stages: ReplayStage[] = [];
+  if (historyGames > 0 && isHangDumpV2(dump)) {
+    const games = (dump as HangDumpJsonV2).recentGames.slice(-historyGames);
+    for (const game of games) {
+      stages.push({
+        label: `g${game.gameIdx} ${game.jushuName} (${game.isABlack ? "A黒" : "A白"})`,
+        moves: game.moves,
+        isABlack: game.isABlack,
+        gameSeed: game.gameSeed,
+      });
+    }
+  }
+  stages.push({
+    label: `ハング局 g${dump.match.gameIdx} ${dump.match.jushuName} (${dump.match.isABlack ? "A黒" : "A白"}) 初手〜直前手`,
+    moves: dump.moveHistory.map((m) => ({
+      row: m.row,
+      col: m.col,
+      isOpening: m.isOpening,
+    })),
+    isABlack: dump.match.isABlack,
+    gameSeed: dump.match.gameSeed,
+  });
+  return stages;
 }
 
 /**
- * ハングした worker が直前に打った局を、同じ worker インスタンスに同じ順で
- * 打たせ直す。相手側 worker は不要（ハングした側の手番だけを要求すればよい）。
- *
- * 目的は「長時間稼働した worker の蓄積状態でのみハングする」仮説の検証。
- * 単独再生（1手だけ）で再現しなかった #128 の実ダンプに対する次の一手。
+ * ハング手に使う moveSeed。**権威は telemetry.pendingRequest.moveSeed**。
+ * 再導出はダンプ時と規則がずれるとサイレントに別 seed になるため、
+ * 記録があればそれを使い、無いときだけ導出にフォールバックする。
  */
-async function replayHistory(
-  worker: Worker,
-  dump: HangDumpJson,
-  games: HangDumpRecentGame[],
-  timeoutMs: number,
-): Promise<HistoryReplayResult> {
-  let requestedMoves = 0;
-  for (const game of games) {
-    const color = hangSideColor(dump.hang.side, game.isABlack);
-    let board: BoardState = createEmptyBoard();
-    let nonOpeningOrdinal = 0;
-    console.log(
-      `  g${game.gameIdx} ${game.jushuName} (${game.isABlack ? "A黒" : "A白"}) — ハング側=${color}, ${game.moves.length}手`,
-    );
-    for (const [index, move] of game.moves.entries()) {
-      const moveColor = colorOfMoveIndex(index);
-      if (!move.isOpening) {
-        nonOpeningOrdinal++;
-        if (moveColor === color) {
-          const moveSeed =
-            game.gameSeed === undefined
-              ? undefined
-              : mixSeed(game.gameSeed, nonOpeningOrdinal);
-          // 逐次実行が必須: 同一 worker に交互要求するので並列化できない
-          const outcome = await requestMoveWithWatchdog(
-            worker,
-            board,
-            color,
-            timeoutMs,
-            moveSeed,
-          );
-          requestedMoves++;
-          if (outcome.status === "timed-out") {
-            return {
-              requestedMoves,
-              hungAt: {
-                gameIdx: game.gameIdx,
-                moveNumber: index + 1,
-                elapsedMs: outcome.elapsedMs,
-              },
-            };
-          }
-          if (outcome.status === "error") {
-            return {
-              requestedMoves,
-              erroredAt: {
-                gameIdx: game.gameIdx,
-                moveNumber: index + 1,
-                message: outcome.errorMessage ?? "(不明なエラー)",
-              },
-            };
-          }
-        }
-      }
-      // 実際に打たれた手を適用する（worker の返した手ではなく棋譜どおりに進める）
-      board = applyMove(board, { row: move.row, col: move.col }, moveColor);
+function resolveHangMoveSeed(dump: HangDumpJson): {
+  moveSeed: number | undefined;
+  source: string;
+} {
+  if (isHangDumpV2(dump)) {
+    const pending = dump.worker.telemetry.pendingRequest;
+    if (pending && pending.requestId === dump.hang.requestId) {
+      return { moveSeed: pending.moveSeed, source: "telemetry.pendingRequest" };
     }
   }
-  return { requestedMoves };
+  const moves = dump.moveHistory.map((m) => ({
+    row: m.row,
+    col: m.col,
+    isOpening: m.isOpening,
+  }));
+  const ordinal = nonOpeningOrdinalOf(moves, dump.hang.moveNumber);
+  return {
+    moveSeed: deriveMoveSeed(dump.match.gameSeed, ordinal),
+    source: `再導出 (nonOpeningOrdinal=${ordinal})`,
+  };
 }
 
 // ============================================================================
 // main
 // ============================================================================
 
-async function main(): Promise<void> {
-  const options = parseArgs();
-  const dump = loadDump(options.dumpPath);
-
+function printHeader(dump: HangDumpJson, timeoutMs: number): void {
   console.log(`\n=== Hang Dump Replay ===`);
-  console.log(`dump: ${path.resolve(options.dumpPath)}`);
-  console.log(`timestamp: ${dump.timestamp}`);
+  console.log(
+    `timestamp: ${dump.timestamp} (schemaVersion=${dump.schemaVersion})`,
+  );
   console.log(
     `match: g${dump.match.gameIdx} ${dump.match.jushuName} (${dump.match.isABlack ? "A黒" : "A白"})`,
   );
@@ -481,85 +564,127 @@ async function main(): Promise<void> {
   console.log(
     `  difficulty=${dump.worker.difficulty} randomFactor=${dump.worker.randomFactor ?? "unset"} bookEnabled=${dump.worker.bookEnabled}`,
   );
+  console.log(`watchdog: ${timeoutMs}ms (ダンプの moveTimeoutMs 既定)`);
+  printDiagnostics(dump);
+}
+
+/** 直前手の思考時間から履歴再生の所要時間をざっくり見積もる。 */
+function estimateReplaySeconds(
+  dump: HangDumpJson,
+  plannedRequests: number,
+): number {
+  const fallbackMs = dump.bench.moveTimeoutMs / 6;
+  if (!isHangDumpV2(dump)) {
+    return (plannedRequests * fallbackMs) / 1000;
+  }
+  const { recentMoves } = dump.worker.telemetry;
+  if (recentMoves.length === 0) {
+    return (plannedRequests * fallbackMs) / 1000;
+  }
+  const avg =
+    recentMoves.reduce((sum, m) => sum + m.thinkingTimeMs, 0) /
+    recentMoves.length;
+  return (plannedRequests * avg) / 1000;
+}
+
+async function replayStagesOrExit(
+  worker: Worker,
+  dump: HangDumpJson,
+  options: CliOptions,
+  timeoutMs: number,
+): Promise<void> {
+  const stages = buildStages(dump, options.replayHistoryGames);
+  if (options.replayHistoryGames > 0 && !isHangDumpV2(dump)) {
+    console.warn(
+      `⚠ --replay-history=${options.replayHistoryGames} 指定ですが、v1 ダンプには recentGames が` +
+        `ありません。ハング局の棋譜だけを再生します。`,
+    );
+  }
+  const planned = countPlannedRequests(stages, dump.hang.side);
+  const etaSec = estimateReplaySeconds(dump, planned);
   console.log(
-    `  evaluationOptions: ${dump.worker.evaluationOptions ? JSON.stringify(dump.worker.evaluationOptions) : "(未指定)"}`,
+    `\n--- 履歴再生: ${stages.length} ステージ / ${planned} 手を要求（見積もり ≈ ${etaSec.toFixed(0)}s） ---`,
   );
-  // gameSeed とハング時の非オープニング要求番号から moveSeed を復元。
-  // ダンプ側でこれらが両方あれば、randomFactor の近傍ランダム化まで再現できる。
-  const nonOpeningOrdinal =
-    dump.hang.moveNumber - dump.moveHistory.filter((m) => m.isOpening).length;
-  const moveSeed =
-    dump.match.gameSeed !== undefined && nonOpeningOrdinal >= 1
-      ? mixSeed(dump.match.gameSeed, nonOpeningOrdinal)
-      : undefined;
+
+  const start = performance.now();
+  const result = await runReplayStages({
+    stages,
+    side: dump.hang.side,
+    request: ({ board, color, moveSeed }) =>
+      requestMoveWithWatchdog(worker, board, color, timeoutMs, moveSeed),
+    onStageStart: (stage, count) => {
+      console.log(`  [${stage.label}] ${count} 手`);
+    },
+    onRequestDone: (_stage, plannedRequest, outcome, doneCount) => {
+      if (doneCount % 10 === 0 || outcome.status !== "responded") {
+        console.log(
+          `    ${doneCount}/${planned} move#${plannedRequest.moveNumber} ${(outcome.elapsedMs / 1000).toFixed(1)}s ${outcome.status}`,
+        );
+      }
+    },
+  });
+
+  if (result.failure?.status === "timed-out") {
+    const s = (result.failure.elapsedMs / 1000).toFixed(2);
+    console.log(
+      `\n✗ HANG REPRODUCED（履歴再生中） [${result.failure.stageLabel}] の ${result.failure.moveNumber} 手目で ${s}s 応答なし`,
+    );
+    console.log(`  この局面が根本原因調査の対象です。`);
+    worker.terminate();
+    process.exit(2);
+  }
+  if (result.failure) {
+    console.log(
+      `\n⚠ 履歴再生中に worker がエラー応答: [${result.failure.stageLabel}] の ${result.failure.moveNumber} 手目 — ${result.failure.errorMessage ?? "(不明)"}`,
+    );
+    console.log(`  ハング（無応答）ではありません。ここで中断します。`);
+    worker.terminate();
+    process.exit(1);
+  }
   console.log(
-    `  seed: gameSeed=${dump.match.gameSeed ?? "unset"} → moveSeed=${moveSeed ?? "unset"} (nonOpeningOrdinal=${nonOpeningOrdinal})`,
+    `--- 履歴再生完了: ${result.requestedMoves} 手 (${((performance.now() - start) / 1000).toFixed(1)}s) ---\n`,
   );
-  console.log(`watchdog: ${options.timeoutMs}ms`);
-  printTelemetry(dump);
-  console.log();
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+  const dump = loadDump(options.dumpPath);
+  const timeoutMs = options.timeoutMs ?? dump.bench.moveTimeoutMs;
+
+  console.log(`dump: ${path.resolve(options.dumpPath)}`);
+  printHeader(dump, timeoutMs);
+
+  const hangSeed = resolveHangMoveSeed(dump);
+  console.log(
+    `  ハング手の moveSeed=${hangSeed.moveSeed ?? "unset"} (${hangSeed.source})`,
+  );
 
   if (options.recreateWorktree) {
     ensureWorktree(dump);
   }
 
-  console.log(`bridge worker を起動中...`);
-  const worker = await spawnBridgeWorker(dump);
+  console.log(`\nbridge worker を起動中...`);
+  const dumpEngineParams = isHangDumpV2(dump)
+    ? dump.worker.telemetry.engineParams
+    : undefined;
+  const { worker, engineParams } = await spawnBridgeWorker(
+    dump,
+    dumpEngineParams,
+  );
   console.log(`起動完了。`);
+  warnEngineParamsDiff(dump, engineParams);
 
   if (options.replayHistory) {
-    const recentGames = dump.recentGames ?? [];
-    if (recentGames.length === 0) {
-      console.warn(
-        `⚠ --replay-history 指定ですが、このダンプに recentGames がありません` +
-          `（schemaVersion=${dump.schemaVersion}、v2 未満の古いダンプ）。履歴再生をスキップします。`,
-      );
-    } else {
-      console.log(
-        `\n--- 履歴再生: 同一 worker に直前 ${recentGames.length} 局を打たせ直します ---`,
-      );
-      const historyStart = performance.now();
-      const history = await replayHistory(
-        worker,
-        dump,
-        recentGames,
-        options.timeoutMs,
-      );
-      if (history.hungAt) {
-        const s = (history.hungAt.elapsedMs / 1000).toFixed(2);
-        console.log(
-          `\n✗ HANG REPRODUCED（履歴再生中） g${history.hungAt.gameIdx} の ${history.hungAt.moveNumber} 手目で ${s}s 応答なし`,
-        );
-        console.log(
-          `  蓄積状態依存のハングが再現しました。この局面が根本原因調査の対象です。`,
-        );
-        worker.terminate();
-        process.exit(2);
-      }
-      if (history.erroredAt) {
-        console.log(
-          `\n⚠ 履歴再生中に worker がエラー応答: g${history.erroredAt.gameIdx} の ${history.erroredAt.moveNumber} 手目 — ${history.erroredAt.message}`,
-        );
-        console.log(
-          `  ハング（無応答）ではありません。履歴再生を中断したためハング局面の要求は行いません。`,
-        );
-        worker.terminate();
-        process.exit(1);
-      }
-      console.log(
-        `--- 履歴再生完了: ${history.requestedMoves} 手を要求 (${((performance.now() - historyStart) / 1000).toFixed(1)}s) ---\n`,
-      );
-    }
+    await replayStagesOrExit(worker, dump, options, timeoutMs);
   }
 
   console.log(`ハング局面の1手要求を送信します...\n`);
-
   const outcome = await requestMoveWithWatchdog(
     worker,
     dump.board,
     dump.hang.color,
-    options.timeoutMs,
-    moveSeed,
+    timeoutMs,
+    hangSeed.moveSeed,
   );
   worker.terminate();
 
@@ -569,18 +694,18 @@ async function main(): Promise<void> {
     const r = outcome.response!;
     console.log(`✓ RESPONDED in ${elapsedS}s`);
     console.log(
-      `  move: (${r.position.row}, ${r.position.col}) score=${r.score} depth=${r.depth} thinkingTimeMs=${Math.round(r.thinkingTimeMs)}`,
+      `  move: (${r.position.row}, ${r.position.col}) score=${r.score} depth=${r.depth} interrupted=${r.interrupted} thinkingTimeMs=${Math.round(r.thinkingTimeMs)}`,
     );
     if (options.verbose && r.stats) {
       console.log(`  stats: ${JSON.stringify(r.stats)}`);
     }
     console.log(
-      `\n※ 再現せず。ダンプ時のハングは非決定的（TT/randomFactor/実行環境）か、` +
-        `wasm 側の状態依存の可能性があります。`,
+      `\n※ 再現せず。ダンプ時のハングは非決定的（実行環境・タイミング）か、` +
+        `worker の探索そのものではない可能性があります。`,
     );
     if (!options.replayHistory) {
       console.log(
-        `  次の一手: --replay-history を付けて同一 worker に直前局を打たせてから再試行してください（#128）。`,
+        `  次の一手: --replay-history（さらに --replay-history=N で過去 N 局も）を付けて再試行してください（#128）。`,
       );
     }
     process.exit(0);


### PR DESCRIPTION
## 概要

#128（commit-bench で稀に発生する「Worker move request timeout」）の**診断強化**。次に起きたときに原因を特定できるだけの情報をダンプに載せ、`replay:hang` を実際に使える再現手段にする。探索エンジン本体（`zig/src`）は無変更。

## 前提の訂正（実ダンプ 2 件の読み解き）

レビューで実ダンプを読み直した結果、**2 件は別現象**と判明したので切り分けて起票しました。

- **g3（A側 46手目）はハングではなく時間制限の超過** → #147
  hard は `timeLimit=10000` / `absolute_time_limit` 10s なのに直前手が 29.6s、その前が 11.5s。30s タイムアウトは「10s 制限を 3 倍超過する探索がもう一段伸びた」裾。`maxNodes=1M` に対し初手 919k nodes/5.9s なので、メイン探索のノード計上外（pre-search / VCF / VCT / quiescence）に時間が落ちている疑い。
- **g172（B側 6手目）だけが真の外れ値** → #148
  局開始からの `elapsedMs` が「各手の思考時間合計 + 30s」より **38.7 分**長い。worker の探索ではなくメインスレッド停止／プロセス・マシンのサスペンドの signature。

また `requestId` はプロセス全体の通し番号なので「265 要求後に発生」は誤読でした（per-worker の要求数は本 PR の telemetry で初めて分かります）。エンジン側に探索間で持ち越される状態はほぼ無い（TT は毎回 `ttClear`、history/killers はローカル、board も再初期化）ため、`--replay-history` は「wasm メモリ蓄積の再現」ではなく**機序不明のまま総当たりで潰す再現手段**という位置づけです。

## 変更内容

### 1. ハング中でも読める情報を増やす

ハングした worker はメッセージに応答できない。そこで **(a) メインスレッド側が保持している情報**と **(b) 共有メモリ経由の生存信号**の 2 系統で観測する。

- `scripts/lib/workerTelemetry.ts`（新規）: worker インスタンスをキーにした `WeakMap` レジストリ。起動時の解決済みパラメータ／要求数／応答待ちの要求／**直近 32 手**の思考統計（`interrupted` 込み）／同一 worker が打ち終えた**直近 10 局**を保持。worker 再生成で自動リセット。
- `scripts/lib/workerLiveness.ts`（新規）: `SharedArrayBuffer` + `Atomics`。wasm は時間制限判定のたびに JS の `getTimestampMsExternal` を呼び返すので、その呼び出しを包んで計上すれば、**Zig 無改造で**「探索が走り続けている（`searching`）」か「探索ループの外で固まっている（`stalled`）」かを判定できる。
- `scripts/lib/eventLoopSampler.ts`（新規）: メインスレッドの timer lag と `Date.now()−performance.now()` ドリフトを 1s 間隔でサンプリング。**「忙しかった」のか「眠っていた」のか**を切り分ける（g172 クラス用）。
- `scripts/lib/bridgeWorkerProtocol.ts`（新規）: ready 封筒の型ガードと `engineParams` の突き合わせ、eval 重みの指紋（順序非依存ハッシュ）。

### 2. `--replay-history` を実効化

- **既定はハング局そのものの初手〜直前手**（`moveHistory`。v1 ダンプにも必ずある）。従来案は `recentGames` のみを見ており、実データ 2 件では完全に no-op でした。
- `--replay-history=N` で、さらに前段として `recentGames` から直近 N 局を先に再生（v2 のみ）。
- **moveSeed の権威は `telemetry.pendingRequest.moveSeed`**。再導出はずれるとサイレントに別 seed で「再現せず」になるため、記録があれば必ずそれを使う。
- 導出規則（`deriveGameSeed` / `deriveMoveSeed` / `colorOfMoveIndex` / `sideColor`）を `scripts/lib/hangReplay.ts` に集約（3 箇所の重複を解消）し、実行部は `scripts/lib/hangReplayRunner.ts` に分離してテスト可能に。
- ダンプの `engineParams` から replay worker の `customParams`（maxNodes / depth / evalOptions / threatProbe）を組み立て、replay worker の `ready.params` と突き合わせて**差分を warn**。
- watchdog 既定を **ダンプの `bench.moveTimeoutMs`（30s）** に変更（従来 60s では、ベンチで「ハング」扱いになった 35〜59s の手を正常通過させてしまう）。
- 所要時間見積もりと進捗表示、`timed-out` と `error` の区別。

### 3. ダンプ schemaVersion 1 → 2

`HangDumpJson` を `schemaVersion: 1 | 2` の discriminated union にし、v1 ダンプを narrowing で安全に扱えるようにしました。

| パス | 内容 |
| --- | --- |
| `worker.telemetry.requestCount` | **per-worker** の着手要求数 |
| `worker.telemetry.engineParams` | `difficulty` / `depth` / `timeLimit` / `maxNodes` / `randomFactor` / `evaluationOptions` / `engine` / `bookEnabled` / `hasStatsBuffer` / `threatProbe` / `evalWeightsFingerprint` |
| `worker.telemetry.pendingRequest` | ハングした要求そのもの（`moveSeed` 含む＝replay の権威） |
| `worker.telemetry.recentMoves` | 直近 32 手（`depth` / `score` / **`interrupted`** / `thinkingTimeMs` / `roundTripMs` / wasm `stats`） |
| `worker.telemetry.recentGames`, `recentGames` | 同一 worker が打ち終えた直近 10 局 |
| `hang.liveness` | `verdict`（searching / stalled / never-started / unavailable）、`timeCheckCount`、`lastTimeCheckAt`、サンプル窓での増分 |
| `hang.mainThread` | `maxTimerLagMs` / `maxClockSkewJumpMs` / 直近 60 サンプル |
| `notes` | 何が取れて何が取れないかの説明 |

## 検証（済み）

- `pnpm check-fix`: 0 warnings / 0 errors
- `pnpm test`（unit + scripts）: **128 ファイル / 1968 件 緑**。新規 62 件（`hangReplay` 20 / `hangReplayRunner` 8 / `workerLiveness` 12 / `bridgeWorkerProtocol` 18 ＋ `workerTelemetry` `hangDump` 拡充）
- lefthook pre-commit（check-fix / vitest / zig-test）全緑
- **実 worker での動作確認**（bench を起動せず、自分の worktree を対象に easy / 短時間で 1 回）: worker 起動 → 生存信号チャネル配線 → `engineParams` 差分 warn → 2 ステージの履歴再生 → ハング局面要求 → `interrupted` 付き応答、まで通ることを確認
- 合成 v1 / v2 ダンプで CLI の後方互換（v1 は telemetry 無し表示・履歴はハング局のみ）を確認

## ベンチ完了後に実行すべき検証手順

**別プロセスで commit-bench 走行中のため、以下は未実施です。**

```bash
# 1. HANG_INJECT で人工ハングを起こし、新ダンプ項目が入ることを確認
#    （--max-games=8 / 6局目に注入 = recentGames が溜まった状態で履歴再生本体を踏める）
HANG_INJECT=6:2 pnpm commit:bench --difficulty=easy --jobs=1 --max-games=8 --move-timeout-ms=5000

#    → bench-results/hang-dumps/hang-*.json に schemaVersion=2 と
#      worker.telemetry.{requestCount,engineParams,pendingRequest,recentMoves[].interrupted,recentGames}
#      / hang.liveness / hang.mainThread / notes が入っていること
#    → コンソールに liveness verdict と mainThread の lag が出ること
#      （HANG_INJECT は worker が応答を返さないだけなので verdict は stalled 系になるはず）

# 2. 履歴再生（bench が完全に止まってから実行すること）
pnpm replay:hang bench-results/hang-dumps/hang-XXXX.json --replay-history=3
```

> ⚠️ `replay:hang` の `ensureWorktree` は `.git/worktrees-bench/` を作り直します。**commit-bench 走行中に実行すると走行中の worktree を壊します**。必ずベンチ終了後に。

## 留意点

- 本 PR は根治ではなく診断強化のため `Refs #128`（close は根治まで保留）。
- `HangMatchInfo` は元の形に戻り、`recentGames` は telemetry 側に一本化されています（実装が 2 つに割れないように）。`onHang` を渡す呼び出し元は `commit-bench.ts` のみ（`weight-bench.ts` は未使用）。

Refs #128
Refs #147
Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
