### PR TITLE
fix: 静止探索で黒の禁手をフィルタする (#142)

### DIFF
--- a/docs/plans/issue-142-quiescence-forbidden-2026-08-23.md
+++ b/docs/plans/issue-142-quiescence-forbidden-2026-08-23.md
@@ -1,0 +1,84 @@
+# #142 設計メモ: 静止探索（quiescence）で黒の禁手をフィルタする（2026-08-23、オーケストレータ作成）
+
+## 目的
+
+`zig/src/quiescence.zig` の `generateTacticalMoves` / `quiescenceSearch` は黒の禁手（三三・四四・長連）を一切見ずに着手する。黒の禁手着手は連珠では黒の負け（打てない）なので、(a) 黒が「打てない四」で自分の評価を稼ぐ、(b) 白の四に対する黒のブロック点が禁手なのに「受けられた」扱いになる、の 2 つの誤評価がある。#141 で葉評価の FIVE 暴れは消えたが着手自体は残る。
+
+## 現状の構造（quiescence.zig:139-190, 193-330）
+
+1. `generateTacticalMoves` (1): 相手の直前手が四なら `getFourDefensePosition` の `.block` のみを返す（`.unstoppable` は (2) に落ちて自分の四＝カウンター四を探す）。
+2. (2): near-mask 内の空点を仮配置し `createsFour` なら候補。
+3. `quiescenceSearch`: stand-pat → 候補を `incremental_eval.placeStone` で置いて再帰。
+
+## 不変条件（連珠ルール）
+
+- 黒の着手は `checkFive`（ちょうど五）なら禁手でも合法（五が禁手に優先、`move_gen.zig:91-100` と同じ流儀）。
+- 黒の四四・三三・長連点は着手不可。
+- 白に禁手はない。
+
+## 変更
+
+### A. (1) 強制ブロックが黒の禁手のとき
+
+- `color == .black` かつ `dp` で `!forbidden.checkFive(cells, dp.row, dp.col, .black)` かつ `forbidden.checkForbiddenMove(cells, dp.row, dp.col) != .none` → 黒は受けられない＝次に白が五。
+- 戻り値で「合法な受けなし（forced loss）」を呼び出し側に伝える。API 案: `generateTacticalMoves` の戻り値を `struct { count: u16, forced_loss: bool }` に（または out パラメータ）。
+- `quiescenceSearch` 側: `forced_loss` なら現手番（`current_color`）の負けスコアを返す。スコア規約は `minimax.zig:451-453` の終局（`scores.FIVE` / `-scores.FIVE`、perspective 基準）に合わせる: `current_color == perspective` なら `-scores.FIVE`、そうでなければ `+scores.FIVE`（必要なら ply 補正は minimax の流儀に従う。無ければ無しで可）。
+- 注意: stand-pat による α-β カットはこの判定より**前**にあるが、forced loss は stand-pat より悪いので順序はそのままでよい（stand-pat ≥ beta で切る場合はその枝はどのみち使われない）。ただし厳密には「受けられない＝負け」が stand-pat より優先されるべきなので、`forced_loss` 判定を stand-pat の**前**に置くのが正しい（= `generateTacticalMoves` を先に呼ぶか、(1) 部分だけ先に評価する）。実装は (1) の判定を独立関数 `forcedBlockOrLoss(cells, color, last_move) -> enum{ none, block: Position, forced_loss }` に切り出し、stand-pat 前に評価する。
+
+### B. (2) 自分の四を作る手が黒の禁手のとき
+
+- `is_four` かつ `color == .black` のとき、石を戻した後に `checkFive`（真なら候補に残す）→ `checkForbiddenMove != .none` なら候補から除外。
+- コストは `is_four` のときだけ（候補の大半は四でない）。`createsFour` は SSoT（五点ベース）なので長連の偽四はすでに除外済み；残るのは四四（同時に別方向の四）・四と三三の共存（四+三三は三三で禁手）・四と長連の共存。
+
+### C. 変更しないもの
+
+- `.unstoppable`（活四）で黒がカウンター四を探す経路: B のフィルタが効く。
+- TS 側: quiescence は Zig 専用（TS 削除済み）なのでパリティ対象なし。`src/logic/cpu/search/` に対応物がないことを確認してコメントに記す。
+
+## テスト（Zig、先に赤）
+
+1. 白の四（止め四、受け 1 点）に対し黒の受け点が四四点 → `quiescenceSearch(黒手番)` が黒の負けスコア（`-scores.FIVE`、perspective=黒）を返す。修正前は受けを打って stand-pat 付近を返す（赤）。
+2. 同じ形で受け点が黒の五点でもある（禁手だが五優先）→ 受けが生成され、結果は黒有利（五）。
+3. 黒の四を作る点が四四点 → `generateTacticalMoves(黒)` の候補に含まれない。同じ形で白なら含まれる（白に禁手なし）。
+4. 既存テスト（`quiescence.zig` 内 + `reviewSnapshot`）が緑。スナップショット変化があれば理由を明記。
+
+## リスク / 計測
+
+- q-search は対局 CPU の葉で走る → 挙動変化。黒の禁手着手が出現する局面は密局面の一部。commit-bench（オーケストレータ）で Elo 確認。
+- `checkForbiddenMove` は (1) で高々 1 回／ノード、(2) で四候補ごと。NPS への影響は小さい見込み。性能レビューで確認。
+
+## 成果物
+
+- `docs/plans/issue-142-quiescence-forbidden-2026-08-23.md` にこのメモを保存してコミット。
+- PR（base development）、`Closes #142`。
+
+---
+
+## 実装時の追記（2026-08-23、実装担当）
+
+### 追記 1: 「打てるか」述語は `forbidden.isPlayable` に SSoT 化した
+
+本メモ作成後に `development` へ #146 / #145（PR #149）が入り、`vct.zig` に
+`blockIsPlayable`（`checkFive` → `checkForbiddenMove` の順で「攻め側が黒でもその点に
+打てるか」を判定）が追加されていた。A / B で必要な述語はこれと**同一**なので、
+新規に書き下ろさず `forbidden.zig` に `pub fn isPlayable(cells, row, col, color) bool` として
+切り出し、`vct.blockIsPlayable` はそこへ委譲する形にした（`quiescence.zig` から
+`vct.zig` を import すると循環になるため、共通の下位モジュールである `forbidden.zig` が
+置き場として正しい）。`move_gen.zig` の黒番候補フィルタも同じ順序を手書きしていたので
+同じ述語に載せ替えた。これで「黒が打てる点か」の定義は 1 箇所になる。
+
+### 追記 2: `generateTacticalMoves` は `forced` を引数で受け取る
+
+`forcedBlockOrLoss` を stand-pat の前に評価する以上、`generateTacticalMoves` が
+同じ判定をもう一度やるのは無駄（`getFourDefensePosition` 4 方向 + 禁手判定が
+1 ノードあたり 2 回走る）。そこで `generateTacticalMoves(cells, color, forced, buf)` と
+シグネチャを変え、呼び出し側が 1 回だけ計算した結果を渡す形にした。
+`generateTacticalMoves` の外部呼び出し元は存在しなかった（`quiescence.zig` 内とテストのみ）。
+
+### 追記 3: TS 側に quiescence の対応物がないことの確認
+
+`src/` 配下で quiescence 相当の実装は存在しない（`grep -rl quiescence src/` の
+ヒットは `threatMoves.ts` / `threatPatterns.ts` / `threatLoader.ts` などの
+「TS 版 quiescence.ts に対応」というコメント上の言及と、四受け点のパリティテスト
+`fourDefenseParity.wasm.test.ts` のみ）。静止探索本体は Zig 単一実装なので、
+本 PR にパリティ対象はない。この旨を `quiescence.zig` のコメントに明記した。

--- a/zig/src/forbidden.zig
+++ b/zig/src/forbidden.zig
@@ -350,6 +350,25 @@ pub fn checkForbiddenMove(cells: []Cell, row: u8, col: u8) ForbiddenType {
     return checkForbiddenMoveRecursive(cells, row, col, &ctx);
 }
 
+/// その空点に `color` が実際に着手できるか（「打てる点か」の SSoT）
+///
+/// - 白: 禁手が無いので常に打てる。
+/// - 黒: 五連ができる点は禁手に優先して合法。それ以外は三三・四四・長連なら打てない。
+///
+/// `checkForbiddenMoveInternal` 自身も五連を `.none` に落とすので `checkFive` を
+/// 先に見なくても結果は同じだが、重い禁手判定を短絡できるので順序はこのまま
+/// （`move_gen.zig` の黒番候補フィルタが以前から使っている順序）。
+///
+/// **対象が空点のうちに呼ぶこと**（`checkForbiddenMove` は空でないマスに `.none` を返す）。
+///
+/// 呼び出し元: `move_gen.generateMoves`（候補生成）/ `vct.blockIsPlayable`（issue #146）/
+/// `quiescence.forcedBlockOrLoss`・`quiescence.generateTacticalMoves`（issue #142）。
+pub fn isPlayable(cells: []Cell, row: u8, col: u8, color: Cell) bool {
+    if (color != .black) return true;
+    if (checkFive(cells, row, col, .black)) return true;
+    return checkForbiddenMove(cells, row, col) == .none;
+}
+
 // === Zig unit tests ===
 
 test "checkFive: 5連検出" {

--- a/zig/src/move_gen.zig
+++ b/zig/src/move_gen.zig
@@ -45,11 +45,6 @@ pub const GenerateMovesOptions = struct {
     skip_forbidden_check: bool = false,
 };
 
-/// 五連チェック（forbidden.zig の checkFive を使用）
-fn checkFive(cells: []const Cell, row: u8, col: u8, color: Cell) bool {
-    return forbidden.checkFive(cells, row, col, color);
-}
-
 /// 候補手を生成
 pub fn generateMoves(cells: []Cell, color: Cell, options: GenerateMovesOptions) MoveList {
     var moves = MoveList.init();
@@ -87,17 +82,10 @@ pub fn generateMoves(cells: []Cell, color: Cell, options: GenerateMovesOptions) 
             // 既存石の周囲でなければスキップ
             if (!threats.isNearFromMask(near_mask, row, col)) continue;
 
-            // 黒番の場合は禁手チェック
+            // 黒番の場合は禁手チェック（五連は禁手に優先＝`forbidden.isPlayable` が
+            // 「打てる点か」の SSoT。vct / quiescence も同じ述語を使う）
             if (is_black and !options.skip_forbidden_check) {
-                // 五連が作れる場合は禁手でも候補に含める
-                if (checkFive(cells, row, col, .black)) {
-                    moves.push(.{ .row = row, .col = col });
-                    continue;
-                }
-
-                // 禁手チェック
-                const forbidden_result = forbidden.checkForbiddenMove(cells, row, col);
-                if (forbidden_result != .none) continue;
+                if (!forbidden.isPlayable(cells, row, col, .black)) continue;
             }
 
             moves.push(.{ .row = row, .col = col });

--- a/zig/src/quiescence.zig
+++ b/zig/src/quiescence.zig
@@ -134,24 +134,73 @@ pub fn getFourDefensePosition(cells: []const Cell, last_row: u8, last_col: u8, c
     return .not_four;
 }
 
+/// 相手の四に対する「強制ブロック」の判定結果（issue #142）
+///
+/// 以前は `generateTacticalMoves` が「受け 1 点」と「受けなし」を同じ
+/// `count == 0 / 1` に潰していたため、**黒の受け点が禁手で打てない**ケースが
+/// 「脅威手なし＝静止した局面」として stand-pat で評価されていた。
+/// 実際には受けられない＝次に相手が五を作るので、その局面は現手番の負けである。
+pub const ForcedBlock = union(enum) {
+    /// 相手の直前手は四ではない（または活四で 1 点では受からない）→ 通常の四追いに進む
+    none,
+    /// 止め四。この 1 点で受かる（かつ攻め側がそこに打てる）
+    block: Position,
+    /// 止め四だが受け点が黒の禁手 → 受けられない＝現手番の負け
+    forced_loss,
+};
+
+/// 相手の直前手が止め四のとき、その受けが打てるかを判定する（issue #142）
+///
+/// `color` は**受ける側（現手番）**の色。`last_move` は相手の直前手。
+///
+/// 黒は三三・四四・長連の点に打てないので、受け点が禁手なら黒には合法な受けが
+/// 存在しない。連珠のルール上そこに打つことは「できない」（打てば反則負け）ので、
+/// 受け点を打った局面を探索するのは誤り。`.forced_loss` を返して呼び出し側に
+/// 終局として扱わせる。
+///
+/// 五連は禁手に優先するので、受け点が黒の五点でもある場合は打てる
+/// （`forbidden.isPlayable` が `checkFive` を先に見る。`move_gen.zig` の
+/// 黒番候補フィルタ・`vct.zig` の `blockIsPlayable` と同一の述語＝SSoT）。
+///
+/// `.unstoppable`（活四）は 1 点では受からないので `.none` を返し、従来どおり
+/// (2) のカウンター四探索に落とす（issue #142 の対象外・挙動不変）。
+pub fn forcedBlockOrLoss(cells: []Cell, color: Cell, last_move: ?Position) ForcedBlock {
+    const lm = last_move orelse return .none;
+    const defense_pos = getFourDefensePosition(cells, lm.row, lm.col, color.opposite());
+    const dp = defense_pos.blockPos() orelse return .none;
+    if (!forbidden.isPlayable(cells, dp.row, dp.col, color)) return .forced_loss;
+    return .{ .block = dp };
+}
+
 /// 脅威手（四を作る手 + 相手の四へのブロック）を生成
-/// TS版 quiescence.ts の generateTacticalMoves に対応
+///
+/// `forced` は呼び出し側が `forcedBlockOrLoss` で 1 度だけ計算した結果を渡す
+/// （`quiescenceSearch` は stand-pat の前に同じ判定が必要なので、ここで再計算すると
+/// 1 ノードあたり `getFourDefensePosition` + 禁手判定が 2 回走ってしまう）。
+/// `.forced_loss` は呼び出し側が終局として先に処理する想定なので、ここでは
+/// 「合法な脅威手なし」＝ 0 を返す。
+///
+/// TS 側に静止探索の対応物は存在しない（探索本体は Zig 単一実装。TS の
+/// `search/threatPatterns.ts` などは四の受け点プリミティブのみで、そちらは
+/// `fourDefenseParity.wasm.test.ts` でパリティを取っている）。
 pub fn generateTacticalMoves(
     cells: []Cell,
     color: Cell,
-    last_move: ?Position,
+    forced: ForcedBlock,
     result_buf: *[225]Position,
 ) u16 {
-    const opponent_color = color.opposite();
     var count: u16 = 0;
 
     // 1. 相手の直前手が四を作っていれば → ブロック手のみ
-    if (last_move) |lm| {
-        const defense_pos = getFourDefensePosition(cells, lm.row, lm.col, opponent_color);
-        if (defense_pos.blockPos()) |dp| {
+    switch (forced) {
+        .block => |dp| {
             result_buf[0] = dp;
             return 1;
-        }
+        },
+        // 受けられない（黒の禁手）→ 呼び出し側が終局として扱う。ここで四追いを
+        // 続けると「受けずに自分の四で反撃できる」ことになり誤り。
+        .forced_loss => return 0,
+        .none => {},
     }
 
     // 2. 自分が四を作れる手を列挙
@@ -171,10 +220,15 @@ pub fn generateTacticalMoves(
             cells[idx] = .empty;
             bitboard.removeStone(r, c);
 
-            if (is_four) {
-                result_buf[count] = .{ .row = r, .col = c };
-                count += 1;
-            }
+            if (!is_four) continue;
+            // 黒の禁手点は打てないので候補から外す（issue #142）。
+            // `createsFour` は五点ベース（issue #124）なので長連だけの偽四は
+            // すでに落ちている。ここで残るのは四四・四と三三の共存など。
+            // コストは四候補にしか掛からない（大半の空点は `is_four == false`）。
+            if (!forbidden.isPlayable(cells, r, c, color)) continue;
+
+            result_buf[count] = .{ .row = r, .col = c };
+            count += 1;
         }
     }
     return count;
@@ -259,6 +313,20 @@ pub fn quiescenceSearch(
         return incremental_eval.getEvaluation(cells, perspective, eval_opts);
     }
 
+    // 現在の手番
+    const current_color = if (is_maximizing) perspective else perspective.opposite();
+
+    // 終端条件: 相手の止め四に対する受けが黒の禁手 → 受けられない＝現手番の負け（issue #142）。
+    //
+    // stand-pat の**前**に置く。stand-pat は「何もしなければこの評価」という仮定だが、
+    // ここでは「何もしない」ことが許されない（次に相手が五を作る）ので、静的評価より
+    // 終局判定が優先される。スコア規約は `minimax.zig` の終端条件（五連完成）と同じで
+    // perspective 基準・ply 補正なし。
+    const forced = forcedBlockOrLoss(cells, current_color, last_move);
+    if (forced == .forced_loss) {
+        return if (current_color == perspective) -scores.FIVE else scores.FIVE;
+    }
+
     // Stand-pat: 何もしない場合の評価（インクリメンタル評価を使用）
     const stand_pat = incremental_eval.getEvaluation(cells, perspective, eval_opts);
 
@@ -279,10 +347,9 @@ pub fn quiescenceSearch(
         return stand_pat;
     }
 
-    // 脅威手生成
-    const current_color = if (is_maximizing) perspective else perspective.opposite();
+    // 脅威手生成（`forced` は stand-pat 前に計算済みのものを再利用する）
     var move_buf: [225]Position = undefined;
-    const move_count = generateTacticalMoves(cells, current_color, last_move, &move_buf);
+    const move_count = generateTacticalMoves(cells, current_color, forced, &move_buf);
 
     if (move_count == 0) {
         return stand_pat;
@@ -405,9 +472,166 @@ test "generateTacticalMoves finds four moves" {
     bitboard.initFromCells(&cells);
 
     var buf: [225]Position = undefined;
-    const count = generateTacticalMoves(&cells, .black, null, &buf);
+    const count = generateTacticalMoves(&cells, .black, .none, &buf);
     // (7,4) と (7,8) が四を作る
     try std.testing.expect(count >= 2);
+}
+
+// --- issue #142: 静止探索の黒禁手フィルタ ---
+
+/// 候補列に指定の点が含まれるか
+fn containsMove(buf: []const Position, count: u16, row: u8, col: u8) bool {
+    for (buf[0..count]) |m| {
+        if (m.row == row and m.col == col) return true;
+    }
+    return false;
+}
+
+/// 黒が (7,7) に打つと縦と斜めの二方向で四になる（＝四四の禁手点）配置。
+///
+/// - 縦: (4,7) (5,7) (6,7) ＋ (7,7) → 四
+/// - 斜め ↘: (4,4) (5,5) (6,6) ＋ (7,7) → 四
+///
+/// どちらも「4 石 + 空 1」の窓が 1 セットしかない（＝各方向 1 つの四）ので
+/// 合計 2 つの四 ＝ 四四。五連にはならない。
+fn setupBlackDoubleFourAt77(cells: []Cell) void {
+    cells[4 * BOARD_SIZE + 7] = .black;
+    cells[5 * BOARD_SIZE + 7] = .black;
+    cells[6 * BOARD_SIZE + 7] = .black;
+    cells[4 * BOARD_SIZE + 4] = .black;
+    cells[5 * BOARD_SIZE + 5] = .black;
+    cells[6 * BOARD_SIZE + 6] = .black;
+}
+
+/// 白の止め四 (7,3)-(7,6)（(7,2) は黒で塞がれている）＝受けは (7,7) の 1 点のみ。
+fn setupWhiteBlockedFourRow7(cells: []Cell) void {
+    cells[7 * BOARD_SIZE + 2] = .black; // 左端を塞ぐ
+    cells[7 * BOARD_SIZE + 3] = .white;
+    cells[7 * BOARD_SIZE + 4] = .white;
+    cells[7 * BOARD_SIZE + 5] = .white;
+    cells[7 * BOARD_SIZE + 6] = .white;
+}
+
+const test_eval_options = evaluate.EvalOptions{
+    .enable_leaf_mise = false,
+    .last_mover_is_perspective = .unset,
+    .single_four_penalty_multiplier = 100,
+    .connectivity_bonus = scores.CONNECTIVITY_BONUS,
+};
+
+/// テスト用に quiescenceSearch を黒視点・黒手番で走らせる
+fn runQuiescenceAsBlack(cells: []Cell, last_move: ?Position) i32 {
+    incremental_eval.initFromBoard(cells, .{
+        .connectivity_bonus = scores.CONNECTIVITY_BONUS,
+        .single_four_penalty_multiplier = 100,
+    });
+    var stats = QSearchStats{};
+    var timeout_flag = false;
+    var node_counter: u32 = 0;
+    var tt = tt_mod.TranspositionTable{
+        .entries = &tt_mod.global_tt_storage,
+        .current_generation = 0,
+    };
+    tt.clear();
+
+    return quiescenceSearch(
+        cells,
+        0,
+        true, // is_maximizing（黒視点の黒手番）
+        .black,
+        -scores.INFINITY,
+        scores.INFINITY,
+        last_move,
+        test_eval_options,
+        MAX_QUIESCENCE_DEPTH,
+        &stats,
+        .{ .node_counter = &node_counter, .no_time_limit = true, .timeout_flag = &timeout_flag },
+        &tt,
+    );
+}
+
+test "issue #142: 白の止め四の受け点が黒の四四なら受けられない＝黒の負け" {
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    setupWhiteBlockedFourRow7(&cells);
+    setupBlackDoubleFourAt77(&cells);
+    bitboard.initFromCells(&cells);
+
+    // 前提の確認: 受けは (7,7) の 1 点で、そこは黒の禁手（四四）
+    try std.testing.expectEqual(
+        Position{ .row = 7, .col = 7 },
+        getFourDefensePosition(&cells, 7, 6, .white).blockPos().?,
+    );
+    try std.testing.expect(!forbidden.checkFive(&cells, 7, 7, .black));
+    try std.testing.expect(forbidden.checkForbiddenMove(&cells, 7, 7) != .none);
+
+    try std.testing.expectEqual(ForcedBlock.forced_loss, forcedBlockOrLoss(&cells, .black, .{ .row = 7, .col = 6 }));
+
+    // 受けられない＝次に白が五。黒視点・黒手番なので -FIVE。
+    try std.testing.expectEqual(-scores.FIVE, runQuiescenceAsBlack(&cells, .{ .row = 7, .col = 6 }));
+}
+
+test "issue #142: 受け点が黒の五点なら禁手でも打てる（五が禁手に優先）" {
+    ll.init();
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    setupWhiteBlockedFourRow7(&cells);
+    // (7,7) は縦 (3,7)-(6,7) の五点。加えて斜め 2 方向で四を作る（＝五連が無ければ四四）。
+    cells[3 * BOARD_SIZE + 7] = .black;
+    cells[4 * BOARD_SIZE + 7] = .black;
+    cells[5 * BOARD_SIZE + 7] = .black;
+    cells[6 * BOARD_SIZE + 7] = .black;
+    cells[4 * BOARD_SIZE + 4] = .black; // ↘ の三
+    cells[5 * BOARD_SIZE + 5] = .black;
+    cells[6 * BOARD_SIZE + 6] = .black;
+    cells[4 * BOARD_SIZE + 10] = .black; // ↙ の三
+    cells[5 * BOARD_SIZE + 9] = .black;
+    cells[6 * BOARD_SIZE + 8] = .black;
+    bitboard.initFromCells(&cells);
+
+    // 前提: (7,7) は黒の五点（＝禁手判定は .none に落ちる）
+    try std.testing.expect(forbidden.checkFive(&cells, 7, 7, .black));
+
+    const forced = forcedBlockOrLoss(&cells, .black, .{ .row = 7, .col = 6 });
+    try std.testing.expectEqual(Position{ .row = 7, .col = 7 }, forced.block);
+
+    var buf: [225]Position = undefined;
+    try std.testing.expectEqual(@as(u16, 1), generateTacticalMoves(&cells, .black, forced, &buf));
+    try std.testing.expectEqual(Position{ .row = 7, .col = 7 }, buf[0]);
+
+    // 受けられる＝負け確定ではない（黒は受けて五を作れる）
+    try std.testing.expect(runQuiescenceAsBlack(&cells, .{ .row = 7, .col = 6 }) > -scores.FIVE);
+}
+
+test "issue #142: 黒の四四点は四候補から除外される（白は除外しない）" {
+    ll.init();
+    var buf: [225]Position = undefined;
+
+    // 黒: (7,7) は四を作るが四四の禁手 → 候補に含まれない
+    var black_cells = [_]Cell{.empty} ** CELL_COUNT;
+    setupBlackDoubleFourAt77(&black_cells);
+    bitboard.initFromCells(&black_cells);
+    // 前提: (7,7) は四を作る点（＝フィルタが無ければ候補に入る）だが禁手
+    black_cells[7 * BOARD_SIZE + 7] = .black;
+    bitboard.placeStone(7, 7, .black);
+    const black_is_four = createsFour(&black_cells, 7, 7, .black);
+    black_cells[7 * BOARD_SIZE + 7] = .empty;
+    bitboard.removeStone(7, 7);
+    try std.testing.expect(black_is_four);
+    try std.testing.expectEqual(forbidden.ForbiddenType.double_four, forbidden.checkForbiddenMove(&black_cells, 7, 7));
+
+    const black_count = generateTacticalMoves(&black_cells, .black, .none, &buf);
+    try std.testing.expect(!containsMove(&buf, black_count, 7, 7));
+
+    // 白: 同じ形でも白に禁手は無いので候補に含まれる
+    var white_cells = [_]Cell{.empty} ** CELL_COUNT;
+    setupBlackDoubleFourAt77(&white_cells);
+    for (&white_cells) |*cell| {
+        if (cell.* == .black) cell.* = .white;
+    }
+    bitboard.initFromCells(&white_cells);
+
+    const white_count = generateTacticalMoves(&white_cells, .white, .none, &buf);
+    try std.testing.expect(containsMove(&buf, white_count, 7, 7));
 }
 
 test "quiescenceSearch stand-pat on empty" {

--- a/zig/src/vct.zig
+++ b/zig/src/vct.zig
@@ -524,18 +524,18 @@ fn blockThreatContinues(
 /// この関数は攻め側の非対称を解消するもの。
 ///
 /// 五連を作る点は禁手に優先して勝ちなので `checkFive` で先に許可する
-/// （`minimax.zig` の遅延禁手判定と同じ順序。`checkForbiddenMove` 自身も五連を
-/// `.none` に落とすので結果は同じだが、重い判定を先に短絡できる）。
+/// （`minimax.zig` の遅延禁手判定と同じ順序）。
 ///
 /// 長連になる点は従来 `checkDefenseCounterThreat` が `.none` を返すことで
 /// **偶然**弾かれていた（長連方向は五として数えられない）。ここで明示的に弾く。
 ///
 /// **ブロック石を置く前**（対象が空点のうち）に呼ぶこと。
 /// `checkForbiddenMove` は空でないマスに対しては `.none` を返す。
+///
+/// 判定そのものは `forbidden.isPlayable`（「打てる点か」の SSoT）に委譲する。
+/// 同じ述語を `move_gen` の候補生成と `quiescence`（issue #142）も使う。
 fn blockIsPlayable(cells: []Cell, bp: Position, color: Cell) bool {
-    if (color != .black) return true;
-    if (forbidden.checkFive(cells, bp.row, bp.col, .black)) return true;
-    return forbidden.checkForbiddenMove(cells, bp.row, bp.col) == .none;
+    return forbidden.isPlayable(cells, bp.row, bp.col, color);
 }
 
 /// カウンター四をブロックしたあとの分岐（issue #145）


### PR DESCRIPTION
設計メモ: [`docs/plans/issue-142-quiescence-forbidden-2026-08-23.md`](https://github.com/ef81sp/holorenju/blob/fix/issue-142-quiescence-forbidden/docs/plans/issue-142-quiescence-forbidden-2026-08-23.md)（オーケストレータ作成、実装時の差分を末尾に追記）

## 原因

`zig/src/quiescence.zig` は黒の禁手（三三・四四・長連）を一切見ていなかった（`grep checkForbiddenMove` が空）。主探索 `minimax.zig` には遅延禁手判定があるが、静止探索には対応物が無い。実害は 2 つ:

- **(a) 打てない四で評価を稼ぐ**: 四候補列挙（`generateTacticalMoves` の 2.）が黒の四四点・四と三三が共存する点をそのまま候補にしていた。
- **(b) 受けられない四を「受けた」ことにする**: 相手の止め四に対する受け 1 点が黒の禁手でも、そこに着手して探索を続けていた。連珠のルールではそこには打てない＝受けられない＝負けなので、`stand-pat` 付近の穏当なスコアが返るのは誤り。

#132 / PR #141 で葉評価の `FIVE` 暴れ（黒の長連を五と数える）は消えたが、**着手そのもの**は残っていた（issue #142 として切り出されていたもの）。

## 再現局面

（左下原点・8 行目に白の止め四）

- 白 `D8 E8 F8 G8` の四、左端 `C8` は黒 → **受けは `H8` の 1 点のみ**
- 黒は `H9 H10 H11`（縦の三）と `G9 F10 E11`（斜めの三）を持つ
- → `H8` は黒の**四四＝禁手**で打てない

修正前は `H8` を打って探索を続けていた（`forcedBlockOrLoss` 相当の判定が無く `.block` を返していた）。修正後は `-FIVE`（黒視点・黒手番）を返す。

## 変更

### `zig/src/quiescence.zig`

- `ForcedBlock`（`none` / `block: Position` / `forced_loss`）と `forcedBlockOrLoss()` を切り出した。従来は「受け 1 点」と「受けなし」が `count == 1 / 0` に潰れていて、**受けられない**局面が「脅威手なし＝静止」として stand-pat 評価されていた。
- `quiescenceSearch` は `forcedBlockOrLoss` を **stand-pat の前**に評価する。stand-pat は「何もしなければこの評価」という仮定だが、ここでは「何もしない」ことが許されない（次に相手が五）ので終局判定が優先される。スコア規約は `minimax.zig` の終端条件（五連完成）と揃え、perspective 基準で `-scores.FIVE` / `+scores.FIVE`（ply 補正なし）。
- 四候補列挙で黒の禁手点を除外。コストは `is_four == true` の候補にしか掛からない（大半の空点は四にならない）。`createsFour` は五点ベース（#124）なので長連だけの偽四は既に落ちており、ここで残るのは四四・四と三三の共存など。
- `generateTacticalMoves` のシグネチャを `(cells, color, forced, buf)` に変更（呼び出し元が 1 度計算した `forced` を渡す。そうしないと 1 ノードあたり `getFourDefensePosition` + 禁手判定が 2 回走る）。外部呼び出し元は無かった。
- `.unstoppable`（活四）の経路は変更なし。従来どおりカウンター四探索に落ちる（そこには (a) のフィルタが効く）。

### `zig/src/forbidden.zig` — SSoT 化

「その空点に黒が打てるか」の述語 `isPlayable(cells, row, col, color)`（白は常に true、黒は `checkFive` が真なら五優先で true、それ以外は `checkForbiddenMove == .none`）を追加した。同じ判定を手書きしていた次の 2 箇所を載せ替えた:

- `move_gen.generateMoves` の黒番候補フィルタ（未使用になったローカル `checkFive` ラッパーを削除）
- `vct.blockIsPlayable`（#146 で追加されたもの）

これで「黒が打てる点か」の定義が 1 箇所になり、quiescence も同じ述語を使う。

## TS 側

静止探索の対応物は TS に存在しない（探索本体は Zig 単一実装）。`src/logic/cpu/search/threatPatterns.ts` などは四の受け点プリミティブのみで、そちらは `fourDefenseParity.wasm.test.ts` でパリティが取られている。**本 PR にパリティ対象は無い**（その旨を `quiescence.zig` のコメントに明記）。

## テスト

TDD（先に赤を確認）。`zig/src/quiescence.zig` に 3 本追加:

1. 白の止め四の受け点が黒の四四 → `forcedBlockOrLoss` が `.forced_loss`、`quiescenceSearch`（黒視点・黒手番）が `-FIVE`。**修正前は赤**（`expected .forced_loss, found .block`）。
2. 受け点が黒の五点でもある（禁手だが五優先） → 受けが生成され、`-FIVE` は返さない。回帰ガード（修正前後で緑）。
3. 黒の四四点は四候補から除外される／同じ形でも白なら含まれる。**修正前は赤**。

結果:

- `cd zig && zig build test`: 緑
- `pnpm test`: 130 files / 1977 tests 緑
- `pnpm check-fix`: 緑
- **`reviewSnapshot` は変化なし**（27 tests 緑、スナップショットファイルの差分ゼロ）。振り返り解析は主探索・VCF/VCT 経路が支配的で、今回の変更は静止探索の葉に閉じているため。

## 対局 CPU への影響（**要 bench**）

静止探索は対局 CPU の葉で走るので**挙動が変わる**:

- 黒の禁手点が四候補から消えるぶん q 木は細くなる（NPS はわずかに改善方向のはず。`checkForbiddenMove` は四候補にしか掛からない）
- 受けられない四を負けとして即返すので、密局面の葉評価が正しくなる（黒の被詰みを過小評価しなくなる）

方向としては正しい修正だが Elo 中立とは限らないので、マージ前に commit-bench での確認をお願いします。

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
