### PR TITLE
fix(zig): 探索の絶対デッドラインをグローバル化して天井を保証する (#147)

### DIFF
--- a/docs/plans/issue-147-absolute-deadline-2026-08-23.md
+++ b/docs/plans/issue-147-absolute-deadline-2026-08-23.md
@@ -1,6 +1,7 @@
 # #147 設計メモ: 探索の絶対デッドラインをグローバル化する（2026-08-23、オーケストレータ作成）
 
 ## 背景（調査結果、issue #147 コメント参照）
+
 - g3 の 29.6s/31.8s は `threatProbe` の VCT 単発呼び出しが時計を見ずに走り切っていたもので、**#136（攻め手ごとの `bump()`+`exceeded()`）で解消済み**（同局面 10.0s/1.7s/1.1s、g3 全 36 局面で超過は最大 +170ms）。
 - 残る構造的な穴:
   1. `findVCFSequence` / `findVCTSequence` のエントリが `start_time` を**リセット**するため、入れ子ごとに予算が復活する（プローブ 50ms → 実測最大 141ms、pre-search VCT 300ms → 494ms）。
@@ -9,7 +10,9 @@
 - threatProbe VCT が思考時間の 50〜90% を占める「予算配分」の問題は **#137（較正）** で扱う（本メモの範囲外）。
 
 ## 方針（本 PR = A + C）
+
 ### A. 絶対デッドラインのグローバル化
+
 - `zig/src/vcf.zig`（`TimeLimiter` 定義）または新規 `zig/src/deadline.zig` に `pub var g_absolute_deadline_ms: i64 = 0;`（0 = 無効）を置く。
 - `zig/src/search.zig` `findBestMoveIterative`（または `main.zig` の `findBestMove` export）の入口で `g_absolute_deadline_ms = now + absolute_time_limit`（`no_time_limit`／解析モードなら 0）、出口（defer）で 0 に戻す。
 - `TimeLimiter.exceeded()`（#136 でメソッド化済み）を「従来条件 OR（`g_absolute_deadline_ms != 0` かつ `now >= g_absolute_deadline_ms`）」に。時刻取得は既存の `getTimestampMsExternal` を使う（`time_limit == 0` の短絡より前に deadline を見ること。ただし時刻取得コストを増やさないため、`exceeded()` が既に時刻を取るパスでは同じ値を使う）。
@@ -17,12 +20,15 @@
 - 振り返り（review）経路: `no_time_limit` / `timeLimit: 10_000` など既存の設定で `absolute_time_limit` がどう渡るか確認し、**振り返りの挙動を変えない**（グローバルは対局 `findBestMove` でのみ設定。振り返りの `findVCTSequence` 直接呼び出しはグローバル 0 のまま）。
 
 ### C. `mise_vcf.zig` の壁時計無制限 limiter
+
 - A のグローバル deadline が効けば実質カバーされる。加えて、可能なら親 limiter の `start_time`/`time_limit` を継承する（#135 のプローブと同じ流儀）。継承で探索結果が変わるなら **本 PR では A のみ**にして、継承は B（別 PR、bench 付き）に送る。
 
 ### B（別 PR、#137 と同時に bench）
+
 - `findVCFSequence` / `findVCTSequence` のエントリで `start_time` をリセットせず親から継承（予算復活の解消）。threatProbe の予算を `min(50, 残り時間)` に。探索の中身が変わるため commit-bench 必須。
 
 ## 不変条件・テスト（Zig、先に赤）
+
 1. `g_absolute_deadline_ms` を過去の時刻にセットした状態で `findVCTSequence`（無制限 limiter）を呼ぶと即座に打ち切られる（found=false、nodes 小）。
 2. `g_absolute_deadline_ms = 0` なら従来どおり（既存テスト全緑）。
 3. `findBestMove` の出口で必ず 0 に戻る（defer。エラー/早期 return を含む）。
@@ -30,9 +36,70 @@
 5. g3 の 3 局面（調査スクリプト `scripts/investigate-147/` を参考）で 10s 超過が +数百 ms 以内のまま（悪化しない）。
 
 ## リスク
+
 - 時刻取得の頻度は変えない（既存の `exceeded()` 呼び出し位置のみ）ので NPS 影響なし。
 - 対局の打ち切りが「より確実に 10s」になるだけで探索の中身は不変 → Elo 中立の見込み（念のため commit-bench は B と合わせて 1 本）。
 
 ## 成果物
+
 - `docs/plans/issue-147-absolute-deadline-2026-08-23.md` としてこのメモを保存しコミット。
 - PR（base development）、本文に調査結果の要約と「29.6s は #136 で解消済み、本 PR は天井の保証」を明記。`Closes #147`。
+
+---
+
+## 実装メモ（実装時に確定した差分・2026-08-23）
+
+### 置き場所と型
+
+- 新規 `zig/src/deadline.zig` に置いた（`vcf.zig` 内だと `search.zig` → `vcf.zig` の依存方向に対して
+  「時計」という横断的関心が VCF モジュールにぶら下がるため）。
+- 型は `i64` ではなく **`u32`**。`getTimestampMsExternal()` が `u32`（`Math.round(performance.now())`）で、
+  `TimeLimiter.start_time` / `ctx.absolute_deadline` も既に `u32` なので、時間軸を揃えた。
+
+### 時計の SSoT 化
+
+`vcf.zig` / `vct.zig` / `search.zig` / `minimax.zig` / `quiescence.zig` にそれぞれ重複していた
+`extern fn getTimestampMsExternal` + `getTimestampMs()`（ネイティブでは 0）を、
+`deadline.nowMs()` への委譲に一本化した。副産物として **ネイティブテストで擬似時計
+（`deadline.test_now_ms`）を注入できる**ようになり、不変条件 1〜3 をネイティブの
+`zig build test` で検証できる（wasm 実行が要らない）。
+
+### デッドラインを立てる位置
+
+設計メモは「`findBestMoveIterative` の入口」だったが、実際には
+**`start_time` 取得の直後（事前探索 `findPreSearchMove` より前）** に立てた。
+事前探索は独自 limiter で回り、`mise_vcf.zig` の壁時計無制限 limiter もそこから呼ばれるので、
+時間制限を計算していた元の位置（L440 付近）より後ろだと事前探索が天井の外に出てしまう。
+`absolute_deadline` の計算はその 1 箇所に移し、`ctx.absolute_deadline` にも同じ値を配る（値の SSoT）。
+
+### quiescence
+
+`quiescence.QLimits` の構築箇所は `minimax.qLimitsFrom` の 1 つだけで、
+`ctx.absolute_deadline`（＝グローバルと同じ値）を受け取っている。二重管理にならないので
+判定ロジックはそのまま（設計メモどおり変更不要）。
+
+### C（`mise_vcf.zig`）
+
+親 limiter の継承は**行っていない**（探索結果が変わるため B に送る）。
+グローバルの網で止まることを `mise_vcf.zig` のテストで固定した。
+
+### テスト
+
+- `deadline.zig`: グローバルの基本挙動（4 件）。
+- `vcf.zig`: `TimeLimiter.exceeded()` のデッドライン OR（3 件）＋ `findVCFSequence` 即打ち切り。
+- `vct.zig`: `findVCTSequence` 即打ち切り（壁時計無制限で呼んでも止まる）。
+- `mise_vcf.zig`: `findMiseVCFMove`（`time_limit = 0` の limiter 2 箇所）が止まる。
+- `search.zig`: 出口で必ず 0（通常経路・事前探索の即決による早期 return）／`no_time_limit` では立てない。
+
+いずれも「デッドライン無しなら成立する」ことを同じテスト内で先に assert しているので、
+グローバルが効いていなければ落ちる。
+
+### g3 の計測（単一スレッド直接呼び出し、`absolute_time_limit` = 10s）
+
+| 局面        | development（調査時） | 本 PR        |
+| ----------- | --------------------- | ------------ |
+| 44 手目(白) | 10,040ms              | **10,000ms** |
+| 45 手目(黒) | 1,700ms               | 1,663ms      |
+| 46 手目(白) | 1,100ms               | 990ms        |
+
+超過は悪化しておらず、10s 制限に張り付く局面はむしろぴったり 10,000ms に収まった。

--- a/docs/plans/issue-147-absolute-deadline-2026-08-23.md
+++ b/docs/plans/issue-147-absolute-deadline-2026-08-23.md
@@ -1,0 +1,38 @@
+# #147 設計メモ: 探索の絶対デッドラインをグローバル化する（2026-08-23、オーケストレータ作成）
+
+## 背景（調査結果、issue #147 コメント参照）
+- g3 の 29.6s/31.8s は `threatProbe` の VCT 単発呼び出しが時計を見ずに走り切っていたもので、**#136（攻め手ごとの `bump()`+`exceeded()`）で解消済み**（同局面 10.0s/1.7s/1.1s、g3 全 36 局面で超過は最大 +170ms）。
+- 残る構造的な穴:
+  1. `findVCFSequence` / `findVCTSequence` のエントリが `start_time` を**リセット**するため、入れ子ごとに予算が復活する（プローブ 50ms → 実測最大 141ms、pre-search VCT 300ms → 494ms）。
+  2. `mise_vcf.zig` に production で壁時計無制限（`time_limit=0`、ノード上限のみ）の limiter が 2 箇所。
+  3. `absolute_time_limit` は「見る場所に到達しない区間」があると効かない（#136 前の事故の型）。将来同種の回帰を構造的に防ぐ網がない。
+- threatProbe VCT が思考時間の 50〜90% を占める「予算配分」の問題は **#137（較正）** で扱う（本メモの範囲外）。
+
+## 方針（本 PR = A + C）
+### A. 絶対デッドラインのグローバル化
+- `zig/src/vcf.zig`（`TimeLimiter` 定義）または新規 `zig/src/deadline.zig` に `pub var g_absolute_deadline_ms: i64 = 0;`（0 = 無効）を置く。
+- `zig/src/search.zig` `findBestMoveIterative`（または `main.zig` の `findBestMove` export）の入口で `g_absolute_deadline_ms = now + absolute_time_limit`（`no_time_limit`／解析モードなら 0）、出口（defer）で 0 に戻す。
+- `TimeLimiter.exceeded()`（#136 でメソッド化済み）を「従来条件 OR（`g_absolute_deadline_ms != 0` かつ `now >= g_absolute_deadline_ms`）」に。時刻取得は既存の `getTimestampMsExternal` を使う（`time_limit == 0` の短絡より前に deadline を見ること。ただし時刻取得コストを増やさないため、`exceeded()` が既に時刻を取るパスでは同じ値を使う）。
+- quiescence の `limits`（timeout_flag / deadline）は既に ctx 共有で健全 → 変更不要。ただし `quiescence` が独自に deadline を見ている箇所があれば、それも同じグローバルを参照させて二重管理を避ける（SSoT）。
+- 振り返り（review）経路: `no_time_limit` / `timeLimit: 10_000` など既存の設定で `absolute_time_limit` がどう渡るか確認し、**振り返りの挙動を変えない**（グローバルは対局 `findBestMove` でのみ設定。振り返りの `findVCTSequence` 直接呼び出しはグローバル 0 のまま）。
+
+### C. `mise_vcf.zig` の壁時計無制限 limiter
+- A のグローバル deadline が効けば実質カバーされる。加えて、可能なら親 limiter の `start_time`/`time_limit` を継承する（#135 のプローブと同じ流儀）。継承で探索結果が変わるなら **本 PR では A のみ**にして、継承は B（別 PR、bench 付き）に送る。
+
+### B（別 PR、#137 と同時に bench）
+- `findVCFSequence` / `findVCTSequence` のエントリで `start_time` をリセットせず親から継承（予算復活の解消）。threatProbe の予算を `min(50, 残り時間)` に。探索の中身が変わるため commit-bench 必須。
+
+## 不変条件・テスト（Zig、先に赤）
+1. `g_absolute_deadline_ms` を過去の時刻にセットした状態で `findVCTSequence`（無制限 limiter）を呼ぶと即座に打ち切られる（found=false、nodes 小）。
+2. `g_absolute_deadline_ms = 0` なら従来どおり（既存テスト全緑）。
+3. `findBestMove` の出口で必ず 0 に戻る（defer。エラー/早期 return を含む）。
+4. 振り返り経路（`reviewSnapshot.test.ts`）無変化。
+5. g3 の 3 局面（調査スクリプト `scripts/investigate-147/` を参考）で 10s 超過が +数百 ms 以内のまま（悪化しない）。
+
+## リスク
+- 時刻取得の頻度は変えない（既存の `exceeded()` 呼び出し位置のみ）ので NPS 影響なし。
+- 対局の打ち切りが「より確実に 10s」になるだけで探索の中身は不変 → Elo 中立の見込み（念のため commit-bench は B と合わせて 1 本）。
+
+## 成果物
+- `docs/plans/issue-147-absolute-deadline-2026-08-23.md` としてこのメモを保存しコミット。
+- PR（base development）、本文に調査結果の要約と「29.6s は #136 で解消済み、本 PR は天井の保証」を明記。`Closes #147`。

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -224,7 +224,15 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    const test_deadline = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/deadline.zig"),
+            .target = native_target,
+        }),
+    });
+
     const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&b.addRunArtifact(test_deadline).step);
     test_step.dependOn(&b.addRunArtifact(test_board).step);
     test_step.dependOn(&b.addRunArtifact(test_patterns).step);
     test_step.dependOn(&b.addRunArtifact(test_evaluate).step);

--- a/zig/src/deadline.zig
+++ b/zig/src/deadline.zig
@@ -1,0 +1,102 @@
+/// 探索全体の「絶対デッドライン」を保持するグローバル（issue #147）
+///
+/// ## なぜグローバルか
+///
+/// `absolute_time_limit` は元々 `SearchContext.absolute_deadline` としてメイン探索と
+/// quiescence だけが見ていた。ところが VCF/VCT/ミセ探索は独自の `TimeLimiter` で回り、
+/// しかも `findVCFSequence` / `findVCTSequence` のエントリで `start_time` をリセットする
+/// ため、「入れ子ごとに予算が復活する」「時計を見る場所に到達しない長い区間がある」という
+/// 二つの穴があった（#128 のダンプ g3 で 1 手 29.6s / 31.8s）。
+///
+/// 個別の limiter に親の残り時間を継承させる案（設計メモの B）は探索の中身が変わるため
+/// Elo 検証が要る。本モジュールは **探索の中身を変えずに天井だけを保証する**：
+/// 対局の `findBestMove`（= `search.findBestMoveIterative`）の入口で絶対デッドラインを
+/// ここに立て、出口で必ず 0 に戻す。`TimeLimiter.exceeded()` は自前の予算に加えて
+/// このデッドラインも見るので、将来 VCT に新しい再帰が増えても自動的に守られる。
+///
+/// ## 値の SSoT
+///
+/// `search.findBestMoveIterative` が計算した `absolute_deadline` を
+/// `ctx.absolute_deadline`（メイン探索・quiescence が参照）と本グローバル
+/// （`TimeLimiter` が参照）の両方に配る。計算箇所は 1 つなので二重管理にならない。
+///
+/// ## 無効化
+///
+/// `0` = 無効。`no_time_limit`（計測モード・振り返りの無制限探索）では 0 のままにする。
+/// 振り返りの `findVCTSequence` などの直接呼び出しは `findBestMoveIterative` を通らない
+/// ので、グローバルは 0 のまま＝挙動不変。
+const builtin = @import("builtin");
+
+/// 絶対デッドライン（`getTimestampMsExternal` と同じ時間軸の ms）。0 = 無効。
+pub var g_absolute_deadline_ms: u32 = 0;
+
+/// ネイティブテスト用の擬似時計（wasm では未使用）。0 = 時間制限を評価しない。
+pub var test_now_ms: u32 = 0;
+
+extern fn getTimestampMsExternal() u32;
+
+/// 壁時計（ms）。ネイティブ（テスト）では `test_now_ms` を返す。
+pub fn nowMs() u32 {
+    if (builtin.cpu.arch == .wasm32) {
+        return getTimestampMsExternal();
+    }
+    return test_now_ms;
+}
+
+/// 絶対デッドラインを立てる（0 を渡すと無効）
+pub fn set(deadline_ms: u32) void {
+    g_absolute_deadline_ms = deadline_ms;
+}
+
+/// 絶対デッドラインを解除する
+pub fn clear() void {
+    g_absolute_deadline_ms = 0;
+}
+
+/// 与えられた現在時刻が絶対デッドラインを超えているか
+///
+/// 時刻を引数で受けるのは、呼び出し側が既に取得済みの時刻を使い回して
+/// **時刻取得の頻度を増やさない**ため（NPS への影響を避ける）。
+/// `now == 0` はネイティブテスト（時計なし）を意味し、常に false。
+pub fn exceededAt(now: u32) bool {
+    const d = g_absolute_deadline_ms;
+    if (d == 0) return false;
+    if (now == 0) return false;
+    return now >= d;
+}
+
+/// 現在時刻を取得して判定する版（時刻を持っていない呼び出し側用）
+pub fn exceeded() bool {
+    if (g_absolute_deadline_ms == 0) return false;
+    return exceededAt(nowMs());
+}
+
+// === Tests ===
+
+const testing = @import("std").testing;
+
+test "デフォルトは無効" {
+    clear();
+    try testing.expect(!exceeded());
+    try testing.expect(!exceededAt(999_999));
+}
+
+test "デッドラインを過ぎていれば true" {
+    set(1000);
+    defer clear();
+    try testing.expect(exceededAt(1000));
+    try testing.expect(exceededAt(5000));
+    try testing.expect(!exceededAt(999));
+}
+
+test "now == 0（ネイティブの時計なし）は常に false" {
+    set(1);
+    defer clear();
+    try testing.expect(!exceededAt(0));
+}
+
+test "clear で無効に戻る" {
+    set(1);
+    clear();
+    try testing.expect(!exceededAt(5000));
+}

--- a/zig/src/minimax.zig
+++ b/zig/src/minimax.zig
@@ -4,6 +4,7 @@
 /// TS版 minimaxCore.ts に対応
 const bitboard = @import("bitboard.zig");
 const board_mod = @import("board.zig");
+const deadline = @import("deadline.zig");
 const evaluate = @import("evaluate.zig");
 const forbidden = @import("forbidden.zig");
 const incremental_eval = @import("incremental_eval.zig");
@@ -989,17 +990,9 @@ fn sortMoveScores(entries: []MoveScoreEntry) void {
 // タイムスタンプ取得（WASM用）
 // =============================================================================
 
-/// WASM外部関数: タイムスタンプ（ミリ秒）を取得
-/// WASM環境ではJSから注入
-extern fn getTimestampMsExternal() u32;
-
-/// ネイティブテスト時は0を返す（タイムアウトなし）
+/// 壁時計（ms）。時計の SSoT は `deadline.nowMs`（ネイティブテストでは擬似時計）。
 fn getTimestampMs() u32 {
-    if (@import("builtin").cpu.arch == .wasm32) {
-        return getTimestampMsExternal();
-    }
-    // ネイティブテストでは時間制限なし
-    return 0;
+    return deadline.nowMs();
 }
 
 // === Tests ===

--- a/zig/src/mise_vcf.zig
+++ b/zig/src/mise_vcf.zig
@@ -6,6 +6,7 @@
 /// TS版 miseVcf.ts に対応
 const bitboard = @import("bitboard.zig");
 const board_mod = @import("board.zig");
+const deadline = @import("deadline.zig");
 const evaluate = @import("evaluate.zig");
 const forbidden = @import("forbidden.zig");
 const ft = @import("forced_win_tree.zig");
@@ -645,6 +646,34 @@ test "findMiseVCFMove: 12手目局面でG7がMise-VCF手として検出される
     // G7: row=8, col=6
     try testing.expectEqual(move.?.row, 8);
     try testing.expectEqual(move.?.col, 6);
+}
+
+test "findMiseVCFMove: グローバル絶対デッドライン超過で打ち切られる（#147）" {
+    // ここの VCF limiter は `time_limit = 0`（壁時計無制限・ノード上限のみ）だが、
+    // グローバル絶対デッドラインの網で止まることを確認する（設計メモ C）。
+    // 盤面は「12手目局面でG7がMise-VCF手として検出される」と同じ。
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 7] = .black;
+    cells[6 * BOARD_SIZE + 8] = .white;
+    cells[8 * BOARD_SIZE + 8] = .black;
+    cells[6 * BOARD_SIZE + 6] = .white;
+    cells[7 * BOARD_SIZE + 9] = .black;
+    cells[5 * BOARD_SIZE + 7] = .white;
+    cells[9 * BOARD_SIZE + 7] = .black;
+    cells[6 * BOARD_SIZE + 10] = .white;
+    cells[8 * BOARD_SIZE + 7] = .black;
+    cells[6 * BOARD_SIZE + 7] = .white;
+    cells[6 * BOARD_SIZE + 9] = .black;
+    cells[5 * BOARD_SIZE + 8] = .white;
+
+    try testing.expect(findMiseVCFMove(&cells, .black) != null);
+
+    deadline.test_now_ms = 5000;
+    defer deadline.test_now_ms = 0;
+    deadline.set(1000);
+    defer deadline.clear();
+
+    try testing.expect(findMiseVCFMove(&cells, .black) == null);
 }
 
 test "findMiseVCFMove: 初期局面ではnull" {

--- a/zig/src/quiescence.zig
+++ b/zig/src/quiescence.zig
@@ -6,6 +6,7 @@
 /// TS版 quiescence.ts に対応
 const bitboard = @import("bitboard.zig");
 const board_mod = @import("board.zig");
+const deadline = @import("deadline.zig");
 const evaluate = @import("evaluate.zig");
 const forbidden = @import("forbidden.zig");
 const incremental_eval = @import("incremental_eval.zig");
@@ -58,14 +59,9 @@ pub const QLimits = struct {
     timeout_flag: *bool,
 };
 
-extern fn getTimestampMsExternal() u32;
-
-/// 壁時計（ms）。ネイティブ（テスト）では 0 を返し時間制限なし。
+/// 壁時計（ms）。時計の SSoT は `deadline.nowMs`（ネイティブテストでは擬似時計）。
 fn getTimestampMs() u32 {
-    if (@import("builtin").cpu.arch == .wasm32) {
-        return getTimestampMsExternal();
-    }
-    return 0;
+    return deadline.nowMs();
 }
 
 /// 四を作るかチェック（石配置済み前提、bitboard も同期済み前提）

--- a/zig/src/search.zig
+++ b/zig/src/search.zig
@@ -4,6 +4,7 @@
 /// TS版 iterativeDeepening.ts + preSearch.ts に対応
 const bitboard = @import("bitboard.zig");
 const board_mod = @import("board.zig");
+const deadline_mod = @import("deadline.zig");
 const evaluate = @import("evaluate.zig");
 const forbidden = @import("forbidden.zig");
 const incremental_eval = @import("incremental_eval.zig");
@@ -321,6 +322,28 @@ pub fn findBestMoveIterative(
     const start_time = getTimestampMs();
     aspiration_research_count = 0;
 
+    // =========================================================================
+    // 絶対デッドライン（issue #147）
+    // =========================================================================
+    //
+    // ここが「値の SSoT」。同じ `absolute_deadline` を
+    //   - `ctx.absolute_deadline`（メイン探索 / quiescence が参照）
+    //   - `deadline.g_absolute_deadline_ms`（全 `TimeLimiter` が参照）
+    // の両方へ配る。二重に計算しないので divergence は起きない。
+    //
+    // 事前探索（`findPreSearchMove` → VCF / ミセVCF / VCT）より **前** に立てるのが要点。
+    // 事前探索は独自 limiter で回り、`mise_vcf.zig` には壁時計無制限（`time_limit = 0`）の
+    // limiter も残っているので、ここより後ろで立てると事前探索が天井の外に出てしまう。
+    //
+    // `no_time_limit`（計測モード・解析）の場合は 0＝無効のまま。
+    const no_time_limit = params.time_limit == 0;
+    const absolute_deadline = if (no_time_limit) @as(u32, 0) else start_time + params.absolute_time_limit;
+    deadline_mod.set(absolute_deadline);
+    // 早期 return（即決手・唯一手）を含め、抜けるときは必ず解除する。
+    // 解除し忘れると、以降の振り返り経路（`findVCTSequence` 直接呼び出し）まで
+    // 過去のデッドラインで打ち切られてしまう。
+    defer deadline_mod.clear();
+
     // Aspiration Windowsの幅を選択
     const effective_widths: []const i32 = if (params.aspiration_mode == 1)
         &ASPIRATION_WIDTHS
@@ -436,7 +459,6 @@ pub fn findBestMoveIterative(
     // 時間制限設定
     // =========================================================================
 
-    const no_time_limit = params.time_limit == 0;
     const stone_count = countStones(cells);
     const dynamic_time_limit = if (no_time_limit)
         @as(u32, 0)
@@ -444,7 +466,6 @@ pub fn findBestMoveIterative(
         calculateDynamicTimeLimit(params.time_limit, stone_count, moves.len);
 
     const search_deadline = if (no_time_limit) @as(u32, 0) else start_time + dynamic_time_limit;
-    const absolute_deadline = if (no_time_limit) @as(u32, 0) else start_time + params.absolute_time_limit;
     const loop_deadline = if (no_time_limit) @as(u32, 0) else start_time + dynamic_time_limit * 80 / 100;
 
     ctx.deadline = search_deadline;
@@ -662,13 +683,9 @@ pub fn findBestMoveIterative(
 // タイムスタンプ取得
 // =============================================================================
 
-extern fn getTimestampMsExternal() u32;
-
+/// 壁時計（ms）。時計の SSoT は `deadline.nowMs`（ネイティブテストでは擬似時計）。
 fn getTimestampMs() u32 {
-    if (@import("builtin").cpu.arch == .wasm32) {
-        return getTimestampMsExternal();
-    }
-    return 0;
+    return deadline_mod.nowMs();
 }
 
 // === Tests ===
@@ -719,6 +736,65 @@ test "findBestMoveIterative basic" {
     try testing.expect(result.position.col < BOARD_SIZE);
     try testing.expect(result.completed_depth >= 1);
     try testing.expect(result.stats.nodes > 0);
+}
+
+// --- issue #147: グローバル絶対デッドライン ---
+
+test "findBestMoveIterative: 出口でグローバル絶対デッドラインが 0 に戻る（#147）" {
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 7] = .black;
+    cells[7 * BOARD_SIZE + 8] = .white;
+
+    tt_mod.global_tt.clear();
+    // 前の呼び出しの残骸があっても、抜けたら必ず 0。
+    deadline_mod.set(12345);
+    _ = findBestMoveIterative(&cells, .black, .{
+        .max_depth = 2,
+        .time_limit = 1000,
+        .max_nodes = 10000,
+    });
+    try testing.expectEqual(@as(u32, 0), deadline_mod.g_absolute_deadline_ms);
+}
+
+test "findBestMoveIterative: 事前探索の即決で早期 return してもデッドラインが残らない（#147）" {
+    // 黒の4連 → 事前探索が五連完成手を即決して返す（反復深化に入らない経路）。
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 4] = .black;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+
+    tt_mod.global_tt.clear();
+    deadline_mod.set(12345);
+    const result = findBestMoveIterative(&cells, .black, .{
+        .max_depth = 2,
+        .time_limit = 1000,
+    });
+    try testing.expectEqual(@as(u8, 0), result.completed_depth); // 即決経路
+    try testing.expectEqual(@as(u32, 0), deadline_mod.g_absolute_deadline_ms);
+}
+
+test "findBestMoveIterative: no_time_limit ではデッドラインを立てない（#147）" {
+    // 振り返り・計測モード（time_limit = 0）では絶対デッドラインは無効のまま。
+    // 擬似時計を進めても VCF/VCT が打ち切られないことで確認する。
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 4] = .black;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+
+    deadline_mod.test_now_ms = 5000;
+    defer deadline_mod.test_now_ms = 0;
+
+    tt_mod.global_tt.clear();
+    const result = findBestMoveIterative(&cells, .black, .{
+        .max_depth = 2,
+        .time_limit = 0,
+    });
+    try testing.expectEqual(@as(u32, 0), deadline_mod.g_absolute_deadline_ms);
+    // 五連完成手（(7,3) or (7,8)）が返る＝事前探索が打ち切られていない
+    try testing.expectEqual(@as(u8, 7), result.position.row);
+    try testing.expect(result.position.col == 3 or result.position.col == 8);
 }
 
 test "aspiration_research_count: findBestMoveIterativeの呼び出しごとにリセットされる（累積しない）" {

--- a/zig/src/vcf.zig
+++ b/zig/src/vcf.zig
@@ -6,6 +6,7 @@
 
 const bitboard = @import("bitboard.zig");
 const board_mod = @import("board.zig");
+const deadline = @import("deadline.zig");
 const forbidden = @import("forbidden.zig");
 const jp = @import("jump_patterns.zig");
 const ll = @import("line_lookup.zig");
@@ -52,13 +53,21 @@ pub const TimeLimiter = struct {
     }
 
     /// 予算（ノード数 or 時間）を超えたか
+    ///
+    /// issue #147: 自前の予算に加えて **グローバル絶対デッドライン**
+    /// （`deadline.g_absolute_deadline_ms`）も見る。`time_limit == 0`（壁時計無制限）の
+    /// limiter でも打ち切られるよう、短絡より **前** にデッドラインを評価する。
+    /// 時刻取得は 1 回だけで、従来より頻度が増えないようにしてある。
     pub fn exceeded(self: *const TimeLimiter) bool {
         if (self.max_nodes > 0 and self.nodes >= self.max_nodes) {
             return true;
         }
-        if (self.time_limit == 0) return false;
+        const absolute = deadline.g_absolute_deadline_ms;
+        if (self.time_limit == 0 and absolute == 0) return false;
         const now = getTimestampMs();
-        if (now == 0) return false; // ネイティブテスト
+        if (now == 0) return false; // ネイティブテスト（時計なし）
+        if (absolute != 0 and now >= absolute) return true;
+        if (self.time_limit == 0) return false;
         return (now - self.start_time) >= self.time_limit;
     }
 
@@ -644,13 +653,9 @@ fn findVCFSequenceRecursive(
 // タイムスタンプ取得
 // =============================================================================
 
-extern fn getTimestampMsExternal() u32;
-
+/// 壁時計（ms）。時計の SSoT は `deadline.nowMs`（ネイティブテストでは擬似時計）。
 fn getTimestampMs() u32 {
-    if (@import("builtin").cpu.arch == .wasm32) {
-        return getTimestampMsExternal();
-    }
-    return 0;
+    return deadline.nowMs();
 }
 
 // === Tests ===
@@ -849,4 +854,63 @@ test "findVCFSequence: 五点 0 個の偽四で VCF 成立にしない（issue #
 
     const from_g8 = findVCFSequenceFromFirstMove(&cells, .{ .row = 7, .col = 6 }, .black, VCF_MAX_DEPTH, 0, 0);
     try testing.expect(!from_g8.found);
+}
+
+// --- issue #147: グローバル絶対デッドライン ---
+
+test "TimeLimiter.exceeded: グローバル絶対デッドラインを超えていれば true（#147）" {
+    // 予算無制限（time_limit=0 / max_nodes=0）の limiter でも、
+    // グローバル絶対デッドラインを過ぎていれば打ち切られる。
+    deadline.test_now_ms = 5000;
+    defer deadline.test_now_ms = 0;
+
+    var limiter = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+    try testing.expect(!limiter.exceeded());
+
+    deadline.set(1000);
+    defer deadline.clear();
+    try testing.expect(limiter.exceeded());
+
+    deadline.clear();
+    try testing.expect(!limiter.exceeded());
+}
+
+test "TimeLimiter.exceeded: デッドライン未到達なら従来どおり false（#147）" {
+    deadline.test_now_ms = 500;
+    defer deadline.test_now_ms = 0;
+    deadline.set(1000);
+    defer deadline.clear();
+
+    var limiter = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+    try testing.expect(!limiter.exceeded());
+}
+
+test "TimeLimiter.exceeded: グローバル 0 ならノード予算の判定は不変（#147）" {
+    deadline.clear();
+    var limiter = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 3, .max_nodes = 3 };
+    try testing.expect(limiter.exceeded());
+
+    var loose = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 2, .max_nodes = 3 };
+    try testing.expect(!loose.exceeded());
+}
+
+test "findVCFSequence: グローバル絶対デッドライン超過で即打ち切り（#147）" {
+    // 「two-step VCF」と同じ盤面。通常は found=true になる。
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[4 * BOARD_SIZE + 7] = .black;
+    cells[5 * BOARD_SIZE + 7] = .black;
+    cells[6 * BOARD_SIZE + 7] = .black;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+
+    try testing.expect(findVCFSequence(&cells, .black, VCF_MAX_DEPTH, 0, 0).found);
+
+    deadline.test_now_ms = 5000;
+    defer deadline.test_now_ms = 0;
+    deadline.set(1000);
+    defer deadline.clear();
+
+    const result = findVCFSequence(&cells, .black, VCF_MAX_DEPTH, 0, 0);
+    try testing.expect(!result.found);
 }

--- a/zig/src/vct.zig
+++ b/zig/src/vct.zig
@@ -5,6 +5,7 @@
 /// TS版 vct.ts + vctHelpers.ts + threatMoves.ts + threatPatterns.ts に対応
 const bitboard = @import("bitboard.zig");
 const board_mod = @import("board.zig");
+const deadline = @import("deadline.zig");
 const evaluate = @import("evaluate.zig");
 const forbidden = @import("forbidden.zig");
 const ft = @import("forced_win_tree.zig");
@@ -2542,13 +2543,9 @@ fn cellAt(cells: []const Cell, r: i16, c: i16) Cell {
 // タイムスタンプ取得
 // =============================================================================
 
-extern fn getTimestampMsExternal() u32;
-
+/// 壁時計（ms）。時計の SSoT は `deadline.nowMs`（ネイティブテストでは擬似時計）。
 fn getTimestampMs() u32 {
-    if (@import("builtin").cpu.arch == .wasm32) {
-        return getTimestampMsExternal();
-    }
-    return 0;
+    return deadline.nowMs();
 }
 
 // === Tests ===
@@ -2728,6 +2725,27 @@ test "findVCTSequence: immediate five via VCF" {
     const result = findVCTSequence(&cells, .black, VCT_MAX_DEPTH, 0, 0, false, .lenient);
     try testing.expect(result.found);
     try testing.expect(result.len >= 1);
+}
+
+test "findVCTSequence: グローバル絶対デッドライン超過で即打ち切り（#147）" {
+    // 「immediate five via VCF」と同じ盤面。通常は found=true。
+    // 壁時計無制限（time_limit=0）で呼んでも、グローバル絶対デッドラインで止まる。
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 4] = .black;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+
+    try testing.expect(findVCTSequence(&cells, .black, VCT_MAX_DEPTH, 0, 0, false, .lenient).found);
+
+    deadline.test_now_ms = 5000;
+    defer deadline.test_now_ms = 0;
+    deadline.set(1000);
+    defer deadline.clear();
+
+    const result = findVCTSequence(&cells, .black, VCT_MAX_DEPTH, 0, 0, false, .lenient);
+    try testing.expect(!result.found);
+    try testing.expectEqual(@as(u8, 0), result.len);
 }
 
 test "findVCTSequence: no VCT" {


### PR DESCRIPTION
## 調査要約（先に結論）

- 報告された **29.6s / 31.8s は #136 で解消済み**です。原因は `threatProbe` の VCT 単発呼び出しが攻め手ループ中に一度も時計を見ずに走り切っていたことで、#136（攻め手ごとの `bump()` + 直後の `exceeded()`）で同じ 3 局面が **11.3s/32.7s/31.8s → 10.0s/1.7s/1.1s** になっています。g3 の 11〜46 手目 全 36 局面を走査しても 10s 超過は最大 +170ms でした。
- 本 PR が塞ぐのは**残った構造的な穴**です。`absolute_time_limit` は「見る場所に到達しない区間」があると効かない設計で、
  1. `findVCFSequence` / `findVCTSequence` はエントリで `start_time` をリセットするため入れ子ごとに予算が復活する
  2. `mise_vcf.zig` に production で壁時計無制限（`time_limit = 0`、ノード上限のみ）の limiter が 2 箇所ある
  3. 将来 VCT に新しい再帰が増えても同種の回帰を止める網がない

  という状態でした。**探索の中身を変えずに天井だけを保証する**のが本 PR の目的です（設計メモの案 A + C）。

## 変更

- **`zig/src/deadline.zig`（新規）**: グローバル絶対デッドライン `g_absolute_deadline_ms`（0 = 無効）と時計 `nowMs()`。型は `getTimestampMsExternal()` に合わせて `u32`。
- **`search.zig`**: `findBestMoveIterative` の入口——`start_time` 取得直後、**事前探索 `findPreSearchMove` より前**——でデッドラインを立て、`defer` で必ず 0 に戻す。事前探索は独自 limiter で回り `mise_vcf` の無制限 limiter もそこから呼ばれるので、時間制限を計算していた元の位置より後ろだと天井の外に出てしまうためです。`absolute_deadline` の計算箇所は 1 つに集約し、`ctx.absolute_deadline`（メイン探索 / quiescence 用）と グローバル（全 `TimeLimiter` 用）に同じ値を配ります（値の SSoT）。`no_time_limit`（計測モード・解析）では 0 のまま＝無効。
- **`vcf.zig`**: `TimeLimiter.exceeded()` を「従来条件 OR グローバルデッドライン超過」に。`time_limit == 0` の短絡より **前** に評価し、時刻取得は 1 回だけ（頻度は従来と同じなので NPS 影響なし）。
- **時計の SSoT 化**: `vcf.zig` / `vct.zig` / `search.zig` / `minimax.zig` / `quiescence.zig` に重複していた `extern fn getTimestampMsExternal` + `getTimestampMs()` を `deadline.nowMs()` への委譲に一本化。副産物として**ネイティブテストで擬似時計を注入できる**ようになり、不変条件を `zig build test` で検証できます（wasm 実行不要）。
- **quiescence**: `QLimits` の構築箇所は `minimax.qLimitsFrom` の 1 つだけで、そこが受け取る `ctx.absolute_deadline` はグローバルと同一の値。二重管理にならないので判定ロジックは変更なし。
- **振り返り経路は挙動不変**: グローバルは `findBestMoveIterative` を通る対局探索でのみ立ち、`findVCTSequence` などの直接呼び出し（reviewSnapshot）は 0 のままです。`no_time_limit` でも立ちません。

## テスト（TDD、先に赤を確認）

新規テストはいずれも「デッドライン無しなら成立する」ことを同じテスト内で先に assert してあるので、グローバルが効いていなければ落ちます。

- `deadline.zig`: グローバルの基本挙動 4 件
- `vcf.zig`: `TimeLimiter.exceeded()` のデッドライン OR 3 件 ＋ `findVCFSequence` の即打ち切り
- `vct.zig`: `findVCTSequence` の即打ち切り（壁時計無制限で呼んでも止まる）
- `mise_vcf.zig`: `findMiseVCFMove`（`time_limit = 0` の limiter 2 箇所）が止まる ← 案 C の確認
- `search.zig`: 出口で必ず 0（通常経路 / 事前探索の即決による早期 return）、`no_time_limit` では立てない

結果:

- `pnpm check-fix` 緑
- `pnpm test` 緑（130 files / 1977 tests）
- `cd zig && zig build test` 緑（3543 tests）

## g3 の計測（単一スレッド直接呼び出し、`absolute_time_limit` = 10s、`EVAL_FLAGS=313855`）

| 局面 | ダンプ実測(480f4f4) | development（調査時） | 本 PR |
|---|---|---|---|
| 44 手目(白) | 11,458ms | 10,040ms | **10,000ms** |
| 45 手目(黒) | 29,619ms | 1,700ms | 1,663ms |
| 46 手目(白) | (30s timeout) | 1,100ms | 990ms |

超過は悪化しておらず、10s に張り付く局面はむしろちょうど 10,000ms に収まりました。

## 本 PR でやらないこと（案 B は別 PR）

`findVCFSequence` / `findVCTSequence` のエントリで `start_time` を親から継承する（＝予算復活の解消、threatProbe 予算を `min(50, 残り時間)` に）案は、**探索の中身が変わる**ため本 PR には含めていません。プローブ 50ms → 実測 141ms、pre-search VCT 300ms → 494ms の超過はそちらで解消します。commit-bench が必要なので、#137（threatProbe の予算較正。VCT が思考時間の 50〜90% を占めている件）と合わせて 1 本の別 PR にします。

`mise_vcf.zig` の親 limiter 継承（案 C の「加えて」の部分）も同じ理由で B 側に送り、本 PR ではグローバルの網で止まることをテストで固定するにとどめました。

設計メモ: `docs/plans/issue-147-absolute-deadline-2026-08-23.md`（実装時に確定した差分を追記済み）

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
