### PR TITLE
fix(zig): 入れ子 limiter の壁時計予算を親から継承する (#147 B)

### DIFF
--- a/docs/plans/issue-147b-137-budget-inheritance-2026-08-23.md
+++ b/docs/plans/issue-147b-137-budget-inheritance-2026-08-23.md
@@ -38,3 +38,56 @@
 
 - `docs/plans/issue-147b-137-budget-inheritance-2026-08-23.md` としてこのメモを保存しコミット。
 - PR-B（base development、`Refs #137`、#147 の B 部分である旨）。probe 枝は push のみ（PR なし）。
+
+---
+
+## 実装（2026-08-23、PR-B）
+
+### SSoT: `vcf.TimeLimiter`（`zig/src/vcf.zig`）
+
+設計案 1（`child()`）を採用。案 2（親 limiter を渡すオーバーロード）は
+`findVCFSequenceWithParent` という薄い 1 本だけを追加し、その中身は `child()` を呼ぶ。
+
+| 追加 API                                 | 意味                                                                                                                                                               |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `exhausted: bool = false`                | 生成時点で親の予算が尽きていた。`exceeded()` が最優先で見る。`time_limit == 0` / `max_nodes == 0` がどちらも「無制限」なので「残り 0」を数値で表せず、フラグで表す |
+| `remainingMs() ?u32`                     | 残り壁時計。`null` = 無制限、`0` = 使い切り。擬似時計が 0（ネイティブテスト）なら満額                                                                              |
+| `child(own_budget_ms, own_max_nodes)`    | 子 limiter。壁時計は `min(独自予算, 親の残り)`（独自が 0 なら親の残りを継承）、ノードは独自値、0 なら親の残りノード                                                |
+| `untilDeadline(deadline_ms)`             | limiter を持たない親（メイン探索の `ctx.deadline`）を親 limiter として表現するアダプタ。0 = 無制限                                                                 |
+| `findVCFSequenceWithParent(..., parent)` | `parent.child()` で回して消費ノードを親へ `charge()` する VCF 手順探索                                                                                             |
+
+**ノード予算だけ `min` を取らない**のは設計メモとの差分。ノードは #119 の `charge()` で
+親へ払い戻される設計になっており、`min` を重ねると「この探索専用の小さな上限」
+（`OPPONENT_VCF_PROBE_MAX_NODES` など）まで絞られて挙動が余計に変わる。
+壁時計だけが「復活していた」問題なので、そこだけを直す。
+
+### 置き換えた「子 limiter を作る箇所」
+
+- `vct.zig`
+  - `opponentBlocksThreePursuitWithShallowVCF` の probe → `limiter.child(0, OPPONENT_VCF_PROBE_MAX_NODES)`
+  - `hasBreakingCounterFour` の counter-four probe → `l.child(0, COUNTER_FOUR_VCF_PROBE_MAX_NODES)`
+  - 内部 VCF 6 箇所（`findVCTSequenceInner` / `tryVCFOnly` / `findVCTSequenceRecursive` /
+    `buildBlockDefSubSequence` / `findVCTSequenceFromFirstMove`）→ `findVCFSequenceWithParent`。
+    うち 4 箇所は `time_limit = 0`（壁時計無制限）、2 箇所は `limiter.time_limit` の満額リセットだった。
+  - `findVCTSequenceFromFirstMove` の `sub_limiter` → `limiter.child(0, 0)`
+- `minimax.zig`: `threatProbe` に `search_deadline: u32`（= `ctx.deadline`）を渡し、
+  `TimeLimiter.untilDeadline(...).child(20 or 50, ...)` で実効予算を決める。
+  親の締切を過ぎていれば探索せず `null`。
+- `search.zig`: `findPreSearchMove` に `pre_limiter`（`PRE_SEARCH_TIME_LIMIT = 150*2 + 300 = 600ms`）を
+  導入し、自分の VCF / 相手 VCF / ミセVCF / VCT の 4 段をその子にした。前段が食った分だけ後段が短くなる。
+- `mise_vcf.zig`: `findMiseVCFMoveWithParent` を追加し、壁時計無制限だった limiter 2 箇所
+  （ノリ手 VCF / ミセターゲット VCF）を `parent.child(0, ノード上限)` に。
+  `findMiseVCFMove`（親なしエントリ）は無制限の親を渡して従来どおり。
+
+### 不変にしたもの
+
+- 振り返り経路（`findVCTSequence` / `findVCFSequence` / `findMiseVCFSequence` の直接呼び出し）は
+  親 limiter を持たないので、渡された `time_limit` がそのまま子へ継承される＝従来どおり。
+  `reviewSnapshot` のスナップショットに差分なし（`pnpm test` 1989 件全緑）。
+- ノード予算の計上（#119 の `charge()`）と絶対デッドライン（#151）の挙動。
+
+### テスト
+
+`zig/src/vcf.zig` に `remainingMs` / `child`（親の残り・親無制限・親使い切り・ノード予算）/
+`untilDeadline` / `findVCFSequenceWithParent` の 7 テスト、`zig/src/minimax.zig` に
+`threatProbe` が親の締切を尊重するテストを追加。いずれも `deadline.test_now_ms` の擬似時計を使う。

--- a/docs/plans/issue-147b-137-budget-inheritance-2026-08-23.md
+++ b/docs/plans/issue-147b-137-budget-inheritance-2026-08-23.md
@@ -1,0 +1,40 @@
+# #147-B / #137 設計メモ: 入れ子 limiter の予算継承と threatProbe 予算の較正（2026-08-23、オーケストレータ作成）
+
+## 背景
+
+- #151（A）で絶対デッドライン（1 手 10s の天井）は保証された。
+- 残る「予算復活」: `findVCFSequence` / `findVCTSequence` / `hasVCF` などのエントリが **自前の limiter を `start_time = now` で作る**ため、親（threatProbe の 50ms、pre-search VCT 300ms）の中で子が呼ばれるたびに予算が復活する（実測: probe 50ms → 最大 141ms、pre-search VCT 300ms → 494ms）。`mise_vcf.zig` の 2 箇所は壁時計無制限。
+- threatProbe VCT が hard の思考時間の 50〜90% を占める（g3 の 36 局面で「10s フル使用」が 47%、大半が probe VCT）。`vct_nodes` は #136 で 0（無制限、時間のみ）。これは #137 の較正対象。
+
+## 方針
+
+### B. 予算は継承し、復活させない（本 PR の本体）
+
+- 原則: **子 limiter の壁時計予算は親の残り時間を超えない**。子が独自の小予算（例: probe 50ms）を持つ場合は `min(独自予算, 親の残り)`。
+- 実装案（どれか、実装者が既存 API を見て選ぶ。SSoT を保つこと）:
+  1. `TimeLimiter` に `pub fn child(self, own_budget_ms: u32, own_max_nodes: u32) TimeLimiter` を追加し、`start_time = now`、`time_limit = min(own_budget_ms, self.remainingMs())`（親が無制限なら own のまま）、`max_nodes = own or remainingNodes`。全ての「子 limiter を作る箇所」（vct.zig の内部 VCF 呼び出し、probe、pre-search の VCF/VCT、mise_vcf の 2 箇所）でこれを使う。
+  2. エントリ関数（`findVCFSequence` 等）に親 limiter を渡すオーバーロード（`…WithLimiter`、#136 で `findVCTSequenceWithLimiter` はある）を増やし、自前 limiter を作らない。
+- `mise_vcf.zig` の壁時計無制限 limiter 2 箇所も親の残りを継承。
+- **探索の中身が変わる**（probe が 50ms で本当に止まる、pre-search が 300ms で止まる）→ Elo は commit-bench で確認（下記）。
+
+### #137 プローブ（較正の第 1 手、本 PR には含めない）
+
+- B の上に **1 コミットだけ** `getThreatBudget` の `vct_nodes` を 0 → 50_000 にした枝 `probe/issue-137-vct-nodes-50k` を作る（PR にしない、bench 用）。
+- bench 計画（オーケストレータが実行）: (1) development(#151 後) vs PR-B head、(2) PR-B head vs probe 枝。各 416 局・r0.02・jobs=5。
+- 判断: (2) が中立なら `vct_nodes=0` のまま #137 クローズ（時間のみで十分）、有意に正なら較正を続ける。
+
+## 不変条件・テスト（Zig、先に赤）
+
+1. 親 limiter が残り 30ms のとき、`child(50ms)` の `time_limit` は 30ms（`deadline.test_now_ms` を進めて確認）。親無制限なら 50ms。
+2. probe（`threatProbe` の VCT/VCF）が親の残り時間を超えない（擬似時計で「親の残り 10ms で子が 10ms 後に打ち切る」）。
+3. `findVCTSequence` を直接呼ぶ振り返り経路（親なし）は不変（`reviewSnapshot` 無変化）。
+4. 既存テスト全緑。
+
+## リスク
+
+- probe の実効予算が減る（141ms→50ms）ので対局の VCT 検出が減り弱くなる可能性／逆にメイン探索に時間が戻り強くなる可能性。bench で判断。負なら probe 予算値の方を引き上げる（#137 の較正問題として扱う）。
+
+## 成果物
+
+- `docs/plans/issue-147b-137-budget-inheritance-2026-08-23.md` としてこのメモを保存しコミット。
+- PR-B（base development、`Refs #137`、#147 の B 部分である旨）。probe 枝は push のみ（PR なし）。

--- a/zig/src/minimax.zig
+++ b/zig/src/minimax.zig
@@ -340,38 +340,49 @@ fn threatProbe(
     // 防御ノード（相手の被詰み判定）では strict 耐性検証で偽の追い詰め
     // （幻の被詰み）を棄却する。攻めノードは lenient で真正VCTを取りこぼさない。
     defensive: bool,
+    /// メイン探索の締切（絶対時刻 ms、0 = 無制限）。プローブはこの残り時間を超えない
+    /// （issue #147 B）。
+    search_deadline: u32,
 ) ?Position {
     const budget = getThreatBudget(minimax_depth);
 
+    // プローブの親＝メイン探索の残り時間。プローブ独自の 20ms / 50ms は
+    // 親の残りとの min を取る（`TimeLimiter.child` が SSoT）。
+    const parent = vcf_mod.TimeLimiter.untilDeadline(if (no_time_limit) 0 else search_deadline);
+
     // VCF探索（軽量・常にチェック）。VCFは受け一意で偽陽性が出にくいため常に lenient。
     const vcf_time: u32 = if (no_time_limit) 0 else 20;
+    var vcf_budget = parent.child(vcf_time, budget.vcf_nodes);
+    if (vcf_budget.exceeded()) return null;
     const vcf_move = vcf_mod.findVCFMoveWithBudget(
         cells,
         color,
         budget.vcf_depth,
-        vcf_time,
-        budget.vcf_nodes,
+        vcf_budget.time_limit,
+        vcf_budget.max_nodes,
     );
     if (vcf_move) |m| return m;
 
     // VCT探索（予算が許す場合のみ）
     if (budget.vct_depth > 0) {
         const vct_time: u32 = if (no_time_limit) 0 else 50;
+        var vct_budget = parent.child(vct_time, budget.vct_nodes);
+        if (vct_budget.exceeded()) return null;
         const vct_move = if (defensive)
             vct_mod.findVCTMoveWithBudgetStrict(
                 cells,
                 color,
                 budget.vct_depth,
-                vct_time,
-                budget.vct_nodes,
+                vct_budget.time_limit,
+                vct_budget.max_nodes,
             )
         else
             vct_mod.findVCTMoveWithBudget(
                 cells,
                 color,
                 budget.vct_depth,
-                vct_time,
-                budget.vct_nodes,
+                vct_budget.time_limit,
+                vct_budget.max_nodes,
             );
         if (vct_move) |m| return m;
     }
@@ -521,6 +532,7 @@ pub fn minimaxWithTT(
             depth,
             ctx.no_time_limit,
             !is_maximizing,
+            ctx.deadline,
         );
         if (threat_result) |threat_move| {
             ctx.stats.threat_probe_cutoffs += 1;
@@ -1020,6 +1032,29 @@ fn getTimestampMs() u32 {
 // === Tests ===
 
 const testing = std.testing;
+
+test "threatProbe: メイン探索の残り時間を超えない（issue #147 B）" {
+    // 黒の四連（VCF 即検出）。プローブ独自の 20ms 予算があっても、
+    // 親（メイン探索）の締切を過ぎていれば探索せず null を返す。
+    var cells = [_]Cell{.empty} ** board_mod.CELL_COUNT;
+    cells[7 * BOARD_SIZE + 4] = .black;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+
+    deadline.clear();
+    deadline.test_now_ms = 1000;
+    defer deadline.test_now_ms = 0;
+
+    // 親に余裕がある（締切 1200ms、現在 1000ms）→ 従来どおり検出する
+    try testing.expect(threatProbe(&cells, .black, 4, false, false, 1200) != null);
+
+    // 親の締切を過ぎている（締切 900ms、現在 1000ms）→ プローブは走らない
+    try testing.expect(threatProbe(&cells, .black, 4, false, false, 900) == null);
+
+    // 締切 0（無制限）は従来どおり
+    try testing.expect(threatProbe(&cells, .black, 4, false, false, 0) != null);
+}
 
 test "threat_probe_enabled=false: threatProbeによるcutoffが発生しない（深さ3以上、VCFがある局面）" {
     defer threat_probe_enabled = true;

--- a/zig/src/mise_vcf.zig
+++ b/zig/src/mise_vcf.zig
@@ -192,6 +192,7 @@ fn isInvalidatedByNoriTe(
     cells: []Cell,
     color: Cell,
     three_defenses: *const threats.PositionList,
+    parent: *vcf.TimeLimiter,
 ) NoriTeResult {
     const opponent = color.opposite();
 
@@ -202,13 +203,10 @@ fn isInvalidatedByNoriTe(
         cells[def_idx] = opponent;
         bitboard.placeStone(defense.row, defense.col, opponent);
 
-        var limiter = vcf.TimeLimiter{
-            .start_time = 0,
-            .time_limit = 0,
-            .nodes = 0,
-            .max_nodes = NORI_TE_VCF_NODES,
-        };
+        // 親の残り壁時計予算を継承（issue #147 B。従来は time_limit=0＝壁時計無制限）
+        var limiter = parent.child(0, NORI_TE_VCF_NODES);
         const vcf_ok = vcf.hasVCF(cells, color, 0, &limiter, MISE_VCF_DEPTH);
+        parent.charge(limiter.nodes);
 
         cells[def_idx] = .empty;
         bitboard.removeStone(defense.row, defense.col);
@@ -241,7 +239,19 @@ fn isInvalidatedByNoriTe(
 ///    h. hasVCFでVCF判定
 ///    i. VCF成立 → MがMise-VCF勝ち手
 ///    j. 全てundo
+///
+/// 親 limiter を持たない呼び出し（テスト・解析）用のエントリ。壁時計は無制限で、
+/// 内部 VCF はノード数上限のみで縛られる（従来どおり）。
 pub fn findMiseVCFMove(cells: []Cell, color: Cell) ?Position {
+    var unlimited = vcf.TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+    return findMiseVCFMoveWithParent(cells, color, &unlimited);
+}
+
+/// `findMiseVCFMove` の親 limiter 付き版（issue #147 B）
+///
+/// 内部の VCF 判定はすべて `parent.child(...)` で作った limiter で回るので、
+/// 親（pre-search）の残り壁時計予算を超えて走らない。
+pub fn findMiseVCFMoveWithParent(cells: []Cell, color: Cell, parent: *vcf.TimeLimiter) ?Position {
     // トップレベルエントリ: bitboard を cells と同期
     bitboard.initFromCells(cells);
     ll.init();
@@ -308,7 +318,7 @@ pub fn findMiseVCFMove(cells: []Cell, color: Cell) ?Position {
             }
 
             // ノリ手チェック
-            const nori_result = isInvalidatedByNoriTe(cells, color, &three_defenses);
+            const nori_result = isInvalidatedByNoriTe(cells, color, &three_defenses, parent);
             if (nori_result == .invalidated) {
                 cells[idx] = .empty;
                 bitboard.removeStone(r, c);
@@ -326,13 +336,10 @@ pub fn findMiseVCFMove(cells: []Cell, color: Cell) ?Position {
                 bitboard.placeStone(target.row, target.col, opponent);
 
                 // VCF探索
-                var limiter = vcf.TimeLimiter{
-                    .start_time = 0,
-                    .time_limit = 0,
-                    .nodes = 0,
-                    .max_nodes = MISE_VCF_NODES,
-                };
+                // 親の残り壁時計予算を継承（issue #147 B。従来は time_limit=0＝壁時計無制限）
+                var limiter = parent.child(0, MISE_VCF_NODES);
                 const vcf_ok = vcf.hasVCF(cells, color, 0, &limiter, MISE_VCF_DEPTH);
+                parent.charge(limiter.nodes);
 
                 cells[target_idx] = .empty;
                 bitboard.removeStone(target.row, target.col);
@@ -410,6 +417,10 @@ pub fn findMiseVCFSequence(
     bitboard.initFromCells(cells);
     ll.init();
 
+    // 振り返り経路（親 limiter なし）。ノリ手チェックの予算は従来どおり
+    // ノード数上限のみ（issue #147 B で挙動を変えない）。
+    var review_limiter = vcf.TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+
     var result = MiseVCFSequenceResult{
         .sequence = undefined,
         .len = 0,
@@ -479,7 +490,7 @@ pub fn findMiseVCFSequence(
             }
 
             // ノリ手チェック
-            const nori_result = isInvalidatedByNoriTe(cells, color, &three_defenses);
+            const nori_result = isInvalidatedByNoriTe(cells, color, &three_defenses, &review_limiter);
             if (nori_result == .invalidated) {
                 cells[idx] = .empty;
                 bitboard.removeStone(r, c);

--- a/zig/src/search.zig
+++ b/zig/src/search.zig
@@ -90,11 +90,27 @@ fn findWinningMove(cells: []Cell, color: Cell) ?Position {
     return null;
 }
 
+/// pre-search 全体の壁時計上限（ms）
+///
+/// 内訳は自分の VCF 150 + 相手 VCF 150 + VCT 300。issue #147 B 以前は各段が
+/// 独立した予算を持ち、しかも内部の VCF/VCT が予算を復活させていたため
+/// 名目 300ms の VCT が実測 494ms まで伸びていた。ここを親 limiter にして
+/// 各段を `child()` で作ることで「前段が食った分だけ後段が短くなる」ようにする。
+pub const PRE_SEARCH_TIME_LIMIT: u32 = vcf_mod.VCF_TIME_LIMIT * 2 + vct.VCT_TIME_LIMIT;
+
 /// 必須手の事前チェック
 pub fn findPreSearchMove(
     cells: []Cell,
     color: Cell,
 ) PreSearchResult {
+    // pre-search 全体の予算（issue #147 B）。各段はこの残りを継承した子で回る。
+    var pre_limiter = vcf_mod.TimeLimiter{
+        .start_time = getTimestampMs(),
+        .time_limit = PRE_SEARCH_TIME_LIMIT,
+        .nodes = 0,
+        .max_nodes = 0,
+    };
+
     // 即勝ち手
     const win_move = findWinningMove(cells, color);
     if (win_move) |wm| {
@@ -141,7 +157,8 @@ pub fn findPreSearchMove(
     }
 
     // VCF勝ち手を探す
-    const vcf_move = vcf_mod.findVCFMove(cells, color, vcf_mod.VCF_MAX_DEPTH, vcf_mod.VCF_TIME_LIMIT);
+    const vcf_budget = pre_limiter.child(vcf_mod.VCF_TIME_LIMIT, 0);
+    const vcf_move = vcf_mod.findVCFMove(cells, color, vcf_mod.VCF_MAX_DEPTH, vcf_budget.time_limit);
     if (vcf_move) |vm| {
         return .{
             .immediate_move = vm,
@@ -151,19 +168,14 @@ pub fn findPreSearchMove(
 
     // 相手VCFチェック（Mise-VCFスキップ判定用）
     const opponent_has_vcf = blk: {
-        var opp_limiter = vcf_mod.TimeLimiter{
-            .start_time = getTimestampMs(),
-            .time_limit = vcf_mod.VCF_TIME_LIMIT,
-            .nodes = 0,
-            .max_nodes = 3000,
-        };
+        var opp_limiter = pre_limiter.child(vcf_mod.VCF_TIME_LIMIT, 3000);
         break :blk vcf_mod.hasVCF(cells, opponent_color, 0, &opp_limiter, vcf_mod.VCF_MAX_DEPTH);
     };
 
     // Mise-VCF（ミセ→強制応手→VCF勝ち）
     // 相手VCFがある場合は間に合わないのでスキップ
     if (!opponent_has_vcf) {
-        const mise_move = mise_vcf.findMiseVCFMove(cells, color);
+        const mise_move = mise_vcf.findMiseVCFMoveWithParent(cells, color, &pre_limiter);
         if (mise_move) |mm| {
             // 黒番の禁手チェック
             if (color == .black) {
@@ -184,7 +196,8 @@ pub fn findPreSearchMove(
     }
 
     // VCT勝ち手を探す
-    const vct_move = vct.findVCTMove(cells, color, vct.VCT_MAX_DEPTH, vct.VCT_TIME_LIMIT);
+    const vct_budget = pre_limiter.child(vct.VCT_TIME_LIMIT, 0);
+    const vct_move = vct.findVCTMove(cells, color, vct.VCT_MAX_DEPTH, vct_budget.time_limit);
     if (vct_move) |vm| {
         return .{
             .immediate_move = vm,

--- a/zig/src/vcf.zig
+++ b/zig/src/vcf.zig
@@ -42,6 +42,13 @@ pub const TimeLimiter = struct {
     nodes: u32,
     max_nodes: u32, // 0 = 無制限
 
+    /// 生成時点で親の予算が尽きていたことを表すフラグ（issue #147 B）
+    ///
+    /// `time_limit == 0` / `max_nodes == 0` はどちらも「無制限」を意味するため、
+    /// 「残り 0」を数値で表現できない。`child()` が親の使い切りを検出したときに
+    /// これを立て、`exceeded()` が最優先で見る。
+    exhausted: bool = false,
+
     /// 探索ノードを 1 つ計上する
     pub fn bump(self: *TimeLimiter) void {
         self.nodes +|= 1;
@@ -59,6 +66,7 @@ pub const TimeLimiter = struct {
     /// limiter でも打ち切られるよう、短絡より **前** にデッドラインを評価する。
     /// 時刻取得は 1 回だけで、従来より頻度が増えないようにしてある。
     pub fn exceeded(self: *const TimeLimiter) bool {
+        if (self.exhausted) return true;
         if (self.max_nodes > 0 and self.nodes >= self.max_nodes) {
             return true;
         }
@@ -78,6 +86,65 @@ pub const TimeLimiter = struct {
     pub fn remainingNodes(self: *const TimeLimiter) u32 {
         if (self.max_nodes == 0) return 0;
         return self.max_nodes -| self.nodes;
+    }
+
+    /// 残りの壁時計予算（ms）。`null` = 無制限、`0` = 使い切り（issue #147 B）
+    ///
+    /// ネイティブテスト（擬似時計が 0 = 時計なし）では満額を返す。
+    pub fn remainingMs(self: *const TimeLimiter) ?u32 {
+        if (self.exhausted) return 0;
+        if (self.time_limit == 0) return null;
+        const now = getTimestampMs();
+        if (now == 0) return self.time_limit; // 時計なし＝満額
+        const elapsed = now -| self.start_time;
+        if (elapsed >= self.time_limit) return 0;
+        return self.time_limit - elapsed;
+    }
+
+    /// 子探索用の limiter を作る（issue #147 B の SSoT）
+    ///
+    /// 原則: **子の壁時計予算は親の残りを超えない。予算は復活しない。**
+    /// エントリ関数（`findVCFSequence` / `findVCTSequence` など）は `start_time` を
+    /// 現在時刻にリセットするため、親の中で呼ぶたびに予算が満額に戻っていた
+    /// （プローブ 50ms → 実測 141ms、pre-search VCT 300ms → 494ms）。
+    ///
+    /// - 壁時計: 親が無制限なら `own_budget_ms` のまま、そうでなければ
+    ///   `min(own_budget_ms, 親の残り)`（`own_budget_ms == 0`＝子は無制限を望む
+    ///   場合は親の残りをそのまま継承）。
+    /// - ノード: `own_max_nodes != 0` ならその値、`0` なら親の残りノード。
+    ///   壁時計と違い `min` を取らないのは、ノード予算は #119 の `charge()` で
+    ///   親へ払い戻される設計になっており、二重に絞ると既存の探索が変わるため。
+    pub fn child(self: *const TimeLimiter, own_budget_ms: u32, own_max_nodes: u32) TimeLimiter {
+        const parent_rem = self.remainingMs();
+        const nodes_left = self.remainingNodes();
+        const time_budget: u32 = if (parent_rem) |rem|
+            (if (own_budget_ms == 0) rem else @min(own_budget_ms, rem))
+        else
+            own_budget_ms;
+        return .{
+            .start_time = getTimestampMs(),
+            .time_limit = time_budget,
+            .nodes = 0,
+            .max_nodes = if (own_max_nodes != 0) own_max_nodes else nodes_left,
+            .exhausted = self.exhausted or
+                (parent_rem != null and parent_rem.? == 0) or
+                (self.max_nodes != 0 and nodes_left == 0),
+        };
+    }
+
+    /// 絶対時刻のデッドラインを「親 limiter」として表現する（issue #147 B）
+    ///
+    /// `SearchContext.deadline` のように limiter を持たない親（メイン探索）の
+    /// 残り時間を `child()` に渡すためのアダプタ。`deadline_ms == 0` は無制限。
+    pub fn untilDeadline(deadline_ms: u32) TimeLimiter {
+        const unlimited = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+        if (deadline_ms == 0) return unlimited;
+        const now = getTimestampMs();
+        if (now == 0) return unlimited; // ネイティブテスト（時計なし）
+        if (now >= deadline_ms) {
+            return .{ .start_time = now, .time_limit = 1, .nodes = 0, .max_nodes = 0, .exhausted = true };
+        }
+        return .{ .start_time = now, .time_limit = deadline_ms - now, .nodes = 0, .max_nodes = 0 };
     }
 };
 
@@ -380,16 +447,43 @@ pub fn findVCFSequence(
     time_limit: u32,
     max_nodes: u32,
 ) VCFSequenceResult {
-    // トップレベルエントリ: bitboard を cells と同期
-    bitboard.initFromCells(cells);
-    ll.init();
-
     var limiter = TimeLimiter{
         .start_time = getTimestampMs(),
         .time_limit = time_limit,
         .nodes = 0,
         .max_nodes = max_nodes,
     };
+    return findVCFSequenceWithLimiter(cells, color, max_depth, &limiter);
+}
+
+/// 親 limiter の残り予算を継承した子 limiter で VCF 手順を探す（issue #147 B）
+///
+/// 子の消費ノードは呼び出し後に親へ計上する（#119 の部分払い）ので、
+/// 呼び出し側で `charge()` を重ねて呼んではいけない。
+pub fn findVCFSequenceWithParent(
+    cells: []Cell,
+    color: Cell,
+    max_depth: u8,
+    own_time_limit: u32,
+    own_max_nodes: u32,
+    parent: *TimeLimiter,
+) VCFSequenceResult {
+    var limiter = parent.child(own_time_limit, own_max_nodes);
+    const result = findVCFSequenceWithLimiter(cells, color, max_depth, &limiter);
+    parent.charge(limiter.nodes);
+    return result;
+}
+
+/// `findVCFSequence` の本体（limiter を受け取る版）
+fn findVCFSequenceWithLimiter(
+    cells: []Cell,
+    color: Cell,
+    max_depth: u8,
+    limiter: *TimeLimiter,
+) VCFSequenceResult {
+    // トップレベルエントリ: bitboard を cells と同期
+    bitboard.initFromCells(cells);
+    ll.init();
 
     var result = VCFSequenceResult{
         .sequence = undefined,
@@ -405,7 +499,7 @@ pub fn findVCFSequence(
 
         var seq_len: u8 = 0;
         var is_forbidden_trap = false;
-        const found = findVCFSequenceRecursive(cells, color, 0, &limiter, depth, &result.sequence, &seq_len, &is_forbidden_trap);
+        const found = findVCFSequenceRecursive(cells, color, 0, limiter, depth, &result.sequence, &seq_len, &is_forbidden_trap);
         if (found) {
             result.len = seq_len;
             result.is_forbidden_trap = is_forbidden_trap;
@@ -892,6 +986,132 @@ test "TimeLimiter.exceeded: グローバル 0 ならノード予算の判定は�
 
     var loose = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 2, .max_nodes = 3 };
     try testing.expect(!loose.exceeded());
+}
+
+// --- issue #147 B: 入れ子 limiter の予算継承 ---
+
+test "TimeLimiter.remainingMs: 親の残り時間を返す（#147 B）" {
+    deadline.clear();
+    deadline.test_now_ms = 1020;
+    defer deadline.test_now_ms = 0;
+
+    // 予算 50ms・開始 1000ms・現在 1020ms → 残り 30ms
+    const limited = TimeLimiter{ .start_time = 1000, .time_limit = 50, .nodes = 0, .max_nodes = 0 };
+    try testing.expectEqual(@as(?u32, 30), limited.remainingMs());
+
+    // 使い切り
+    const spent = TimeLimiter{ .start_time = 900, .time_limit = 50, .nodes = 0, .max_nodes = 0 };
+    try testing.expectEqual(@as(?u32, 0), spent.remainingMs());
+
+    // 壁時計無制限は null（＝無制限）
+    const unlimited = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+    try testing.expectEqual(@as(?u32, null), unlimited.remainingMs());
+}
+
+test "TimeLimiter.child: 子の予算は min(独自予算, 親の残り)（#147 B）" {
+    deadline.clear();
+    deadline.test_now_ms = 1020;
+    defer deadline.test_now_ms = 0;
+
+    // 親の残り 30ms < 子の独自予算 50ms → 30ms
+    const parent = TimeLimiter{ .start_time = 1000, .time_limit = 50, .nodes = 0, .max_nodes = 0 };
+    const c = parent.child(50, 0);
+    try testing.expectEqual(@as(u32, 30), c.time_limit);
+    try testing.expectEqual(@as(u32, 1020), c.start_time);
+    try testing.expect(!c.exhausted);
+
+    // 子の独自予算 10ms < 親の残り 30ms → 10ms
+    const tight = parent.child(10, 0);
+    try testing.expectEqual(@as(u32, 10), tight.time_limit);
+
+    // 子が壁時計無制限（0）を望んでも親の残りを継承する
+    const inherit = parent.child(0, 0);
+    try testing.expectEqual(@as(u32, 30), inherit.time_limit);
+}
+
+test "TimeLimiter.child: 親が無制限なら独自予算のまま（#147 B）" {
+    deadline.clear();
+    deadline.test_now_ms = 1020;
+    defer deadline.test_now_ms = 0;
+
+    const parent = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+    const c = parent.child(50, 0);
+    try testing.expectEqual(@as(u32, 50), c.time_limit);
+    try testing.expect(!c.exhausted);
+
+    // 独自予算も 0 なら無制限のまま
+    const u = parent.child(0, 0);
+    try testing.expectEqual(@as(u32, 0), u.time_limit);
+}
+
+test "TimeLimiter.child: 親が予算を使い切っていれば子は即打ち切り（#147 B）" {
+    deadline.clear();
+    deadline.test_now_ms = 1020;
+    defer deadline.test_now_ms = 0;
+
+    // 壁時計を使い切った親
+    const spent = TimeLimiter{ .start_time = 900, .time_limit = 50, .nodes = 0, .max_nodes = 0 };
+    var c = spent.child(50, 0);
+    try testing.expect(c.exhausted);
+    try testing.expect(c.exceeded());
+
+    // ノード予算を使い切った親
+    const spent_nodes = TimeLimiter{ .start_time = 1020, .time_limit = 0, .nodes = 100, .max_nodes = 100 };
+    var cn = spent_nodes.child(50, 0);
+    try testing.expect(cn.exceeded());
+}
+
+test "TimeLimiter.child: ノード予算は独自値、無指定なら親の残り（#147 B）" {
+    deadline.clear();
+    const parent = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 40, .max_nodes = 100 };
+    try testing.expectEqual(@as(u32, 10), parent.child(0, 10).max_nodes);
+    try testing.expectEqual(@as(u32, 60), parent.child(0, 0).max_nodes);
+
+    const unlimited = TimeLimiter{ .start_time = 0, .time_limit = 0, .nodes = 0, .max_nodes = 0 };
+    try testing.expectEqual(@as(u32, 0), unlimited.child(0, 0).max_nodes);
+}
+
+test "TimeLimiter.untilDeadline: デッドラインまでの残りを親として表現する（#147 B）" {
+    deadline.clear();
+    deadline.test_now_ms = 1000;
+    defer deadline.test_now_ms = 0;
+
+    // 残り 200ms の親 → 子の 500ms 要求は 200ms に切り詰められる
+    const parent = TimeLimiter.untilDeadline(1200);
+    try testing.expectEqual(@as(?u32, 200), parent.remainingMs());
+    try testing.expectEqual(@as(u32, 200), parent.child(500, 0).time_limit);
+
+    // デッドライン超過 → 子は即打ち切り
+    var past = TimeLimiter.untilDeadline(900).child(50, 0);
+    try testing.expect(past.exceeded());
+
+    // 0 は無制限
+    const none = TimeLimiter.untilDeadline(0);
+    try testing.expectEqual(@as(?u32, null), none.remainingMs());
+}
+
+test "findVCFSequenceWithParent: 親の残り時間を継承する（#147 B）" {
+    deadline.clear();
+    deadline.test_now_ms = 1020;
+    defer deadline.test_now_ms = 0;
+
+    var cells = [_]Cell{.empty} ** CELL_COUNT;
+    cells[7 * BOARD_SIZE + 4] = .black;
+    cells[7 * BOARD_SIZE + 5] = .black;
+    cells[7 * BOARD_SIZE + 6] = .black;
+    cells[7 * BOARD_SIZE + 7] = .black;
+
+    // 親は壁時計を使い切っている → 子は探索せず不成立を返す
+    var spent = TimeLimiter{ .start_time = 900, .time_limit = 50, .nodes = 0, .max_nodes = 0 };
+    const blocked = findVCFSequenceWithParent(&cells, .black, VCF_MAX_DEPTH, 0, 0, &spent);
+    try testing.expect(!blocked.found);
+
+    // 親に余裕があれば従来どおり見つかる
+    var fresh = TimeLimiter{ .start_time = 1000, .time_limit = 50, .nodes = 0, .max_nodes = 0 };
+    const ok = findVCFSequenceWithParent(&cells, .black, VCF_MAX_DEPTH, 0, 0, &fresh);
+    try testing.expect(ok.found);
+    // 消費ノードは親へ計上される
+    try testing.expect(fresh.nodes > 0);
 }
 
 test "findVCFSequence: グローバル絶対デッドライン超過で即打ち切り（#147）" {

--- a/zig/src/vct.zig
+++ b/zig/src/vct.zig
@@ -227,8 +227,8 @@ const OPPONENT_VCF_PROBE_MAX_NODES: u32 = 1000;
 /// - 三の攻め手に入る直前の遅延評価（呼び出し側）
 /// の3重の制限をかける。安い述語を先に評価して短絡する。
 ///
-/// プローブは呼び出し元 `limiter` の開始時刻・時間制限を引き継ぎ（時間切れなら
-/// hasVCF 側が即座に打ち切る）、消費ノードは呼び出し元へ加算する（#119 の部分払い）。
+/// プローブは呼び出し元 `limiter` の残り時間を継承し（`TimeLimiter.child` が SSoT。
+/// issue #147 B）、消費ノードは呼び出し元へ加算する（#119 の部分払い）。
 fn opponentBlocksThreePursuitWithShallowVCF(
     cells: []Cell,
     opponent: Cell,
@@ -238,14 +238,9 @@ fn opponentBlocksThreePursuitWithShallowVCF(
     if (opponentBlocksThreePursuit(cells, opponent)) return true;
     if (node_depth > OPPONENT_VCF_PROBE_MAX_NODE_DEPTH) return false;
 
-    var probe_limiter = TimeLimiter{
-        .start_time = limiter.start_time,
-        .time_limit = limiter.time_limit,
-        .nodes = 0,
-        .max_nodes = OPPONENT_VCF_PROBE_MAX_NODES,
-    };
+    var probe_limiter = limiter.child(0, OPPONENT_VCF_PROBE_MAX_NODES);
     const found = vcf_mod.hasVCF(cells, opponent, 0, &probe_limiter, OPPONENT_VCF_PROBE_DEPTH);
-    limiter.nodes +|= probe_limiter.nodes;
+    limiter.charge(probe_limiter.nodes);
     return found;
 }
 
@@ -824,12 +819,16 @@ fn hasBreakingCounterFour(
             if (hasFourThreeAvailable(cells, opponent)) break :blk true;
             // 白相手の場合、三三・四四も即勝ち
             if (opponent == .white and hasDoubleThreeForWhite(cells)) break :blk true;
-            var probe_limiter = TimeLimiter{
-                .start_time = if (limiter) |l| l.start_time else 0,
-                .time_limit = if (limiter) |l| l.time_limit else 0,
-                .nodes = 0,
-                .max_nodes = COUNTER_FOUR_VCF_PROBE_MAX_NODES,
-            };
+            // 親の残り予算を継承した子 limiter（issue #147 B）
+            var probe_limiter = if (limiter) |l|
+                l.child(0, COUNTER_FOUR_VCF_PROBE_MAX_NODES)
+            else
+                TimeLimiter{
+                    .start_time = 0,
+                    .time_limit = 0,
+                    .nodes = 0,
+                    .max_nodes = COUNTER_FOUR_VCF_PROBE_MAX_NODES,
+                };
             const found = vcf_mod.hasVCF(cells, opponent, 0, &probe_limiter, vcf_mod.VCF_MAX_DEPTH);
             // プローブの消費ノードも親の予算に計上する（issue #119）
             if (limiter) |l| l.charge(probe_limiter.nodes);
@@ -1359,9 +1358,8 @@ fn findVCTSequenceInner(
         return tryVCFOnly(cells, color, limiter, &result, collect_branches);
     }
 
-    // VCFが先に成立する場合はVCF手順を返す（予算は残額。満額だと親の予算を超える）
-    const vcf_seq = vcf_mod.findVCFSequence(cells, color, vcf_mod.VCF_MAX_DEPTH, limiter.time_limit, limiter.remainingNodes());
-    limiter.charge(vcf_seq.nodes);
+    // VCFが先に成立する場合はVCF手順を返す（予算は親の残額。issue #147 B）
+    const vcf_seq = vcf_mod.findVCFSequenceWithParent(cells, color, vcf_mod.VCF_MAX_DEPTH, 0, 0, limiter);
     if (vcf_seq.found) {
         var i: u8 = 0;
         while (i < vcf_seq.len) : (i += 1) {
@@ -1422,8 +1420,7 @@ fn findVCTSequenceInner(
 
 /// VCF-onlyフォールバック: 相手にVCT阻害要因があるとき
 fn tryVCFOnly(cells: []Cell, color: Cell, limiter: *TimeLimiter, result: *VCTSequenceResult, collect_branches: bool) VCTSequenceResult {
-    const vcf_seq = vcf_mod.findVCFSequence(cells, color, vcf_mod.VCF_MAX_DEPTH, limiter.time_limit, limiter.remainingNodes());
-    limiter.charge(vcf_seq.nodes);
+    const vcf_seq = vcf_mod.findVCFSequenceWithParent(cells, color, vcf_mod.VCF_MAX_DEPTH, 0, 0, limiter);
     if (vcf_seq.found) {
         var i: u8 = 0;
         while (i < vcf_seq.len) : (i += 1) {
@@ -1469,8 +1466,7 @@ fn findVCTSequenceRecursive(
     // 深さを絞ると「VCF は在るが長すぎる」と「VCF が無い」を区別できなくなり、
     // 前者のとき脅威手探索に落ちて**より短い別解**を返してしまう（＝結果が変わる）。
     // 長すぎる VCF はここで false にして親に捨てさせるのが α カットの健全な形。
-    const vcf_seq = vcf_mod.findVCFSequence(cells, color, vcf_mod.VCF_MAX_DEPTH, 0, 0);
-    limiter.charge(vcf_seq.nodes);
+    const vcf_seq = vcf_mod.findVCFSequenceWithParent(cells, color, vcf_mod.VCF_MAX_DEPTH, 0, 0, limiter);
     if (vcf_seq.found and vcf_seq.len >= max_len) return false;
     if (vcf_seq.found) {
         var i: u8 = 0;
@@ -1674,8 +1670,7 @@ fn findVCTSequenceRecursive(
                 // ct=three: VCFのみで勝てるか
                 const vcf_depth = @min(CT_THREE_VCF_MAX_DEPTH, vcf_mod.VCF_MAX_DEPTH);
                 if (context.collect_branches or !has_first_defense) {
-                    const vcf_result = vcf_mod.findVCFSequence(cells, color, vcf_depth, 0, 0);
-                    limiter.charge(vcf_result.nodes);
+                    const vcf_result = vcf_mod.findVCFSequenceWithParent(cells, color, vcf_depth, 0, 0, limiter);
                     if (!vcf_result.found) {
                         cells[def_idx] = .empty;
                         bitboard.removeStone(dp.row, dp.col);
@@ -2014,8 +2009,7 @@ fn buildBlockDefSubSequence(
         .win => return result,
         .three => {
             const vcf_depth = @min(CT_THREE_VCF_MAX_DEPTH, vcf_mod.VCF_MAX_DEPTH);
-            const vcf_result = vcf_mod.findVCFSequence(cells, color, vcf_depth, 0, 0);
-            limiter.charge(vcf_result.nodes);
+            const vcf_result = vcf_mod.findVCFSequenceWithParent(cells, color, vcf_depth, 0, 0, limiter);
             if (!vcf_result.found) return result;
             var i: u8 = 0;
             while (i < vcf_result.len) : (i += 1) {
@@ -2332,8 +2326,7 @@ pub fn findVCTSequenceFromFirstMove(
             }
         } else if (ct == .three) {
             const vcf_depth = @min(CT_THREE_VCF_MAX_DEPTH, vcf_mod.VCF_MAX_DEPTH);
-            const vcf_result = vcf_mod.findVCFSequence(cells, color, vcf_depth, 0, 0);
-            limiter.charge(vcf_result.nodes);
+            const vcf_result = vcf_mod.findVCFSequenceWithParent(cells, color, vcf_depth, 0, 0, &limiter);
             if (vcf_result.found) {
                 var si: u8 = 0;
                 while (si < vcf_result.len) : (si += 1) {
@@ -2352,14 +2345,9 @@ pub fn findVCTSequenceFromFirstMove(
             // まるごとリセットされていた（＝予算が受けの数だけ倍加していた）。
             // アリーナを reset しない内部版を使うのは、collect 時に
             // ここまで積んだ詰み木ノードを壊さないため（#122 レバー1）。
-            var sub_limiter = TimeLimiter{
-                .start_time = limiter.start_time,
-                .time_limit = limiter.time_limit,
-                .nodes = 0,
-                .max_nodes = limiter.remainingNodes(),
-            };
+            var sub_limiter = limiter.child(0, 0);
             const sub = findVCTSequenceWithLimiter(cells, color, max_depth, &sub_limiter, use_collect, .lenient);
-            limiter.nodes +|= sub_limiter.nodes;
+            limiter.charge(sub_limiter.nodes);
             if (sub.found) {
                 var si: u8 = 0;
                 while (si < sub.len) : (si += 1) {


### PR DESCRIPTION
#147 の調査コメントで挙がった修正方針のうち **案 B（予算を「残り時間」に連動させる）** を実装します。#151（案 A: グローバル絶対デッドライン）は探索の中身を変えずに天井だけを保証するものでしたが、本 PR は**予算が入れ子ごとに復活する**構造そのものを直します。

設計メモ: `docs/plans/issue-147b-137-budget-inheritance-2026-08-23.md`（実装差分も追記済み）

## 何が問題だったか

`findVCFSequence` / `findVCTSequence` などのエントリは毎回 `start_time = getTimestampMs()` で時計をリセットするため、親（threatProbe の 50ms、pre-search VCT の 300ms）の中で子が呼ばれるたびに予算が満額に戻っていました。実測で probe 50ms → 最大 141ms、pre-search VCT 300ms → 494ms。さらに `vct.zig` の内部 VCF 4 箇所と `mise_vcf.zig` の 2 箇所は `time_limit = 0`＝**壁時計無制限**でした。

## 変更

原則を **「子 limiter の壁時計予算は親の残りを超えない（`min(独自予算, 親の残り)`）。予算は復活しない」** とし、`vcf.TimeLimiter` に 1 箇所 SSoT を置きました。

| 追加 API | 意味 |
| --- | --- |
| `remainingMs() ?u32` | 残り壁時計。`null` = 無制限、`0` = 使い切り |
| `child(own_budget_ms, own_max_nodes)` | 子 limiter。壁時計 `min(独自, 親の残り)`、独自が 0 なら親の残りを継承 |
| `exhausted: bool` | 親の予算が尽きた状態で作られた子。`exceeded()` が最優先で見る（`0` は「無制限」の意味なので数値で表せない） |
| `untilDeadline(deadline_ms)` | limiter を持たない親（メイン探索の `ctx.deadline`）を親として表現するアダプタ |
| `findVCFSequenceWithParent(...)` | `child()` で回して消費ノードを親へ `charge()` する VCF 手順探索 |

子 limiter を作る全箇所を `child()` 経由に置き換えました。

- `vct.zig`: probe 2 箇所、内部 VCF 6 箇所（うち 4 箇所は壁時計無制限、2 箇所は満額リセット）、`sub_limiter`
- `minimax.zig`: `threatProbe` に `ctx.deadline` を渡し、20ms / 50ms は親の残りとの `min`。親の締切を過ぎていれば探索せず `null`
- `search.zig`: `findPreSearchMove` に `pre_limiter`（`PRE_SEARCH_TIME_LIMIT = 150*2 + 300 = 600ms`）を導入し、自分の VCF / 相手 VCF / ミセVCF / VCT の 4 段をその子に。前段が食った分だけ後段が短くなる
- `mise_vcf.zig`: `findMiseVCFMoveWithParent` を追加し、壁時計無制限だった 2 箇所を親の残り継承に

## 不変条件

- **振り返り経路は挙動不変**。`findVCTSequence` / `findVCFSequence` / `findMiseVCFSequence` の直接呼び出しは親 limiter を持たないので、渡された `time_limit` がそのまま子へ渡ります。`reviewSnapshot` のスナップショットに差分なし。
- ノード予算の計上（#119 の `charge()`）は不変。**ノードだけは `min` を取らない**（設計メモとの差分）— ノードは `charge()` で親へ払い戻される設計なので、`min` を重ねると `OPPONENT_VCF_PROBE_MAX_NODES` のような「その探索専用の小さな上限」まで絞られて挙動が余計に変わるため。壁時計だけが復活していた問題なので、そこだけを直しています。
- 絶対デッドライン（#151）の挙動は不変。

## テスト

TDD（先に赤）。`deadline.test_now_ms` の擬似時計を使用。

- `zig/src/vcf.zig`: `remainingMs` / `child`（親の残り・親無制限・親使い切り・ノード予算）/ `untilDeadline` / `findVCFSequenceWithParent` の 7 テスト
- `zig/src/minimax.zig`: `threatProbe` が親（メイン探索）の締切を超えないテスト

`pnpm check-fix` / `pnpm test`（131 ファイル 1989 件）/ `zig build test` すべて緑。

## bench 必須

**探索の中身が変わります**（probe が本当に 50ms で止まる、pre-search VCT が 300ms で止まる、ミセVCF が壁時計で縛られる）。probe の実効予算が減ることで対局の VCT 検出が減り弱くなる可能性と、逆にメイン探索へ時間が戻り強くなる可能性の両方があるため、**マージ前に commit-bench が必要**です（オーケストレータが実施）。

- (1) `development`(#151 後) vs 本 PR head
- (2) 本 PR head vs `probe/issue-137-vct-nodes-50k`（`getThreatBudget` の `vct_nodes` を 0 → 50,000 にしただけの bench 用ブランチ、PR にしない）

負なら probe の予算値の方を引き上げる方向で #137 の較正問題として扱います。

Refs #147 #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
